### PR TITLE
Added limit info to statsFilename

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -32,6 +32,9 @@ class Crawler {
     // links crawled counter
     this.numLinks = 0;
 
+    // was the limit hit?
+    this.limitHit = false;
+
     this.monitor = true;
 
     this.userAgent = "";
@@ -410,8 +413,8 @@ class Crawler {
       const total = this.cluster.allTargetCount;
       const workersRunning = this.cluster.workersBusy.length;
       const numCrawled = total - this.cluster.jobQueue.size() - workersRunning;
-
-      const stats = {numCrawled, workersRunning, total};
+      const limit = {max: this.params.limit || 0, hit: this.limitHit};
+      const stats = {numCrawled, workersRunning, total, limit};
 
       try {
         fs.writeFileSync(this.params.statsFilename, JSON.stringify(stats, null, 2))
@@ -456,6 +459,7 @@ class Crawler {
   queueUrl(url) {
     this.seenList.add(url);
     if (this.numLinks >= this.params.limit && this.params.limit > 0) {
+      this.limitHit = true;
       return false;
     }
     this.numLinks++;


### PR DESCRIPTION
- added new `limit` dict to statsFilename
- `limit` dict composed of:
  - `max`: the limit requested (or `0`)
  - `hit`: boolean whether limit was reached or not
- limit now limiting to `n` pages for `--limit n` instead of `n - 1`