### PR TITLE
Support Screenshot Creation, resolves #11

### DIFF
--- a/screenshots.js
+++ b/screenshots.js
@@ -1,0 +1,56 @@
+const fs = require("fs");
+const path = require("path");
+const warcio = require("warcio");
+
+class Screenshots {
+
+  constructor({page, id, url, date, directory}) {
+    this.page = page;
+    this.id = id;
+    this.url = url;
+    this.directory = directory;
+    this.date = date ? date : new Date();
+  }
+
+  async take() {
+    const warcName = path.join(this.directory, "screenshot-" + this.id + ".warc.gz");
+    try {
+      let screenshotBuffer = await this.page.screenshot({omitBackground: true, fullPage: false});
+      let warcRecord = await this.wrap(screenshotBuffer);
+      let warcRecordBuffer = await warcio.WARCSerializer.serialize(warcRecord, {gzip: true});
+      fs.appendFileSync(warcName, warcRecordBuffer);
+      let digest = warcRecord.warcPayloadDigest;
+      console.log(`Screenshot for ${this.url} written to ${warcName}`);
+      // take full page screenshot
+      screenshotBuffer = await this.page.screenshot({omitBackground: true, fullPage: true});
+      warcRecord = await this.wrap(screenshotBuffer);
+      warcRecordBuffer = await warcio.WARCSerializer.serialize(warcRecord, {gzip: true});
+      if (digest === warcRecord.warcPayloadDigest) {
+        console.log("Skipping full page screenshot (identical to simple screenshot)");
+      } else {
+        fs.appendFileSync(warcName, warcRecordBuffer);
+        console.log(`Full page screenshot for ${this.url} written to ${warcName}`);
+      }
+    } catch (e) {
+      console.log(`Taking screenshots failed for ${this.url}`, e);
+    }
+  }
+
+  async wrap(buffer) {
+    const warcVersion = "WARC/1.1";
+    const warcRecordType = "resource";
+    const warcHeaders = {"Content-Type": "image/png"};
+    async function* content() {
+      yield buffer;
+    }
+    let screenshotUrl = "urn:screenshot:" + this.url;
+    return warcio.WARCRecord.create({
+      url: screenshotUrl,
+      date: this.date.toISOString(),
+      type: warcRecordType,
+      warcVersion,
+      warcHeaders}, content());
+  }
+}
+
+module.exports = Screenshots;


### PR DESCRIPTION
- add command-line option `--screenshot` to enable screenshot creation
- save screenshots as resource records in WARC files
- per page two screenshots are taken:
    1. one showing the visible screen area
    2. full page screenshot
        (not saved in WARC if identical to first screenshot)

Open questions / to be discussed:
- put screenshots into the combined WARCs?
- screenshot location? First version: in a collection subdirectory `screenshots/`. By placing them in `archive/`, they'd be automatically wrapped into the combined WARCs.
- screen resolution (`viewport`) if not set implicitly by `--mobileDevice`
- screenshot file names: So far, one WARC file per page (WARC file name includes the page UUID)
