### PR TITLE
Integrate Mozilla's Readibility.js

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -822,7 +822,7 @@ class Crawler {
       if (createNew) {
         const header = {"format": "json-pages-1.0", "id": "pages", "title": "All Pages"};
         header["hasText"] = this.params.text;
-        header["hasReaderView"] = this.params.readerView;
+        header["textSource"] = (this.params.readerView ? "readability" : "browser-dom");
         let msg = "creating pages ";
         if (this.params.text) {
           msg += "with full text";

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "sitemapper": "^3.1.2",
     "uuid": "8.3.2",
     "ws": "^7.4.4",
-    "yargs": "^16.0.3"
+    "yargs": "^16.0.3",
+    "@mozilla/readability": "^0.4.1"
   },
   "devDependencies": {
     "eslint": "^7.20.0",

--- a/tests/mozilla_readability_test.js
+++ b/tests/mozilla_readability_test.js
@@ -1,0 +1,23 @@
+const util = require("util");
+const exec = util.promisify(require("child_process").exec);
+const fs = require("fs");
+
+test("verify that Mozilla's Readibility.js extracts a boilerplate-free text", async () => {
+  jest.setTimeout(30000);
+
+  try {
+    await exec("docker-compose run crawler crawl --collection readibilitytest --url https://www.iana.org/about --timeout 10000 --text --readerView --limit 1");
+  }
+  catch (error) {
+    console.log(error);
+  }
+
+  const page = JSON.parse(fs.readFileSync("crawls/collections/readibilitytest/pages/pages.jsonl",
+    "utf8").split("\n")[1]);
+  console.log("title:", page.article.title, "\nexcerpt:", page.article.excerpt);
+
+  // test whether excerpt is present
+  expect(page.article.excerpt.length > 0).toBe(true);
+  // test whether boilerplate-free text is shorter than DOM-constructed text
+  expect(page.article.textContent.length < page.text.length).toBe(true);
+});


### PR DESCRIPTION
- see https://github.com/mozilla/readability
- enabled by command-line flag `--readerView`
- strip the boilerplate from text and HTML (done of a clone of the DOM)
- extract article metadata (author, etc. - if available)
- add readable 'article' object to records in pages.jsonl

The readability library is useful to get a clean text for news articles or blog posts, see the example below. Of course, the results are not always perfect.

```json
{
  "id": "...",
  "url": "https://www.theguardian.com/government-computing-network/2011/jul/25/national-archives-web-archiving-project",
  "title": "National Archives pilots council web archiving project | Guardian Government Computing | The Guardian",
  "text": "Advertisement\nNews\nOpinion\nSport\nCulture\nLifestyle\nShow\nMore\nShow More\nNews\nCoronavirus\nWorld news\nUK news\nEnvironment\nScience\nGlobal development\nFootball\nTech\nBusiness\nObituaries\nOpinion\nThe Guardian view\nColumnists\nCartoons\nOpinion videos\nLetters\nSport\nFootball\nCricket\nRugby union\nTennis\nCycling\nF1\nGolf\nUS sports\nCulture\nBooks\nMusic\nTV & radio\nArt & design\nFilm\nGames\nClassical\nStage\nLifestyle\nFashion\nFood\nRecipes\nLove & sex\nHealth & fitness\nHome & garden\nWomen\nMen\nFamily\nTravel\nMoney\nMake a contribution\nSubscribe\nSearch jobs\nHolidays\nDigital Archive\nGuardian Puzzles app\nThe Guardian app\nVideo\nPodcasts\nPictures\nNewsletters\nToday's paper\nInside the Guardian\nThe Observer\nGuardian Weekly\nCrosswords\nSearch jobs\nHolidays\nDigital Archive\nGuardian Puzzles app\nGuardian Government Computing\nThis article is more than\n9 years old\nNational Archives pilots council web archiving project\nThis article is more than 9 years old\nNew project will allow councils to preserve online information\nG\nu\na\nr\nd\ni\na\nn\nG\no\nv\ne\nr\nn\nm\ne\nn\nt\nC\no\nm\np\nu\nt\ni\nn\ng\nMon 25 Jul 2011 12.04 BST\n1\n1\nA web archiving model that allows local authorities to preserve important online information is to be piloted by the National Archives.\nIt will run the pilots ...",
  "article": {
    "title": "National Archives pilots council web archiving project",
    "byline": null,
    "dir": null,
    "content": "<div id=\"readability-page-1\" class=\"page\"><div><p>A web archiving model that allows local authorities to preserve important online information is to be piloted by the National Archives.</p><p>It will run the pilots ...",
    "textContent": "A web archiving model that allows local authorities to preserve important online information is to be piloted by the National Archives.It will run the pilots ...",
    "length": 3414,
    "excerpt": "New project will allow councils to preserve online information",
    "siteName": "the Guardian"
  }
}
```