### PR TITLE
New Docker Image, Customizable Browser Source + Binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: validate existing wacz
       run: docker-compose run crawler wacz validate --file collections/wr-net/wr-net.wacz
     - name: unzip wacz
-      run: unzip crawls/collections/wr-net/wr-net.wacz -d crawls/collections/wr-net/wacz
+      run: sudo unzip crawls/collections/wr-net/wr-net.wacz -d crawls/collections/wr-net/wacz
     - name: run jest
       run: sudo yarn jest
         

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: validate existing wacz
       run: docker-compose run crawler wacz validate --file collections/wr-net/wr-net.wacz
     - name: unzip wacz
-      run: docker-compose run crawler unzip collections/wr-net/wr-net.wacz -d collections/wr-net/wacz
+      run: unzip collections/wr-net/wr-net.wacz -d collections/wr-net/wacz
     - name: run jest
       run: sudo yarn jest
         

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: validate existing wacz
       run: docker-compose run crawler wacz validate --file collections/wr-net/wr-net.wacz
     - name: unzip wacz
-      run: unzip collections/wr-net/wr-net.wacz -d collections/wr-net/wacz
+      run: unzip crawls/collections/wr-net/wr-net.wacz -d crawls/collections/wr-net/wacz
     - name: run jest
       run: sudo yarn jest
         

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,26 @@
 ARG BROWSER_VERSION=90
 
-FROM oldwebtoday/chrome:${BROWSER_VERSION} as chrome
+ARG BROWSER_IMAGE_BASE=oldwebtoday/chrome
 
-FROM nikolaik/python-nodejs:python3.8-nodejs14
+FROM ${BROWSER_IMAGE_BASE}:${BROWSER_VERSION} as chrome
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+#FROM nikolaik/python-nodejs:python3.9-nodejs16
+FROM ubuntu:bionic
 
+#RUN apt-get update -y && apt-get install --no-install-recommends -qqy software-properties-common \
+#&& add-apt-repository -y ppa:deadsnakes \
 RUN apt-get update -y \
-    && apt-get install --no-install-recommends -qqy fonts-stix locales-all redis-server xvfb \
+    && apt-get install --no-install-recommends -qqy build-essential fonts-stix locales-all redis-server xvfb gpg-agent curl git \
+		python3 python3-distutils python3-dev gpg ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && curl -sL https://deb.nodesource.com/setup_16.x -o /tmp/nodesource_setup.sh && bash /tmp/nodesource_setup.sh \
+		&& apt-get update -y && apt-get install -qqy nodejs yarn \
+    && curl https://bootstrap.pypa.io/get-pip.py | python3 \
+    && pip3 install -U setuptools
 
 ARG BROWSER_VERSION
 
@@ -29,7 +40,7 @@ RUN dpkg -i /deb/*.deb; apt-get update; apt-get install -fqqy && \
 WORKDIR /app
 
 ADD requirements.txt /app/
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 ADD package.json /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && curl https://bootstrap.pypa.io/get-pip.py | python3.8 \
     && pip install -U setuptools
 
+# needed to add args to main build stage
+ARG BROWSER_VERSION
+ARG BROWSER_BIN
+
 ENV PROXY_HOST=localhost \
     PROXY_PORT=8080 \
     PROXY_CA_URL=http://wsgiprox/download/pem \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,26 @@ ARG BROWSER_VERSION=90
 
 ARG BROWSER_IMAGE_BASE=oldwebtoday/chrome
 
+ARG BROWSER_BIN=google-chrome
+
 FROM ${BROWSER_IMAGE_BASE}:${BROWSER_VERSION} as chrome
 
-#FROM nikolaik/python-nodejs:python3.9-nodejs16
 FROM ubuntu:bionic
 
-#RUN apt-get update -y && apt-get install --no-install-recommends -qqy software-properties-common \
-#&& add-apt-repository -y ppa:deadsnakes \
-RUN apt-get update -y \
+RUN apt-get update -y && apt-get install --no-install-recommends -qqy software-properties-common \
+    && add-apt-repository -y ppa:deadsnakes \
+    && apt-get update -y \
     && apt-get install --no-install-recommends -qqy build-essential fonts-stix locales-all redis-server xvfb gpg-agent curl git \
-		python3 python3-distutils python3-dev gpg ca-certificates \
+	   python3.8 python3.8-distutils python3.8-dev gpg ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && curl -sL https://deb.nodesource.com/setup_16.x -o /tmp/nodesource_setup.sh && bash /tmp/nodesource_setup.sh \
-		&& apt-get update -y && apt-get install -qqy nodejs yarn \
-    && curl https://bootstrap.pypa.io/get-pip.py | python3 \
-    && pip3 install -U setuptools
-
-ARG BROWSER_VERSION
+	&& apt-get update -y && apt-get install -qqy nodejs yarn \
+    && curl https://bootstrap.pypa.io/get-pip.py | python3.8 \
+    && pip install -U setuptools
 
 ENV PROXY_HOST=localhost \
     PROXY_PORT=8080 \
@@ -30,7 +29,8 @@ ENV PROXY_HOST=localhost \
     PROXY_CA_FILE=/tmp/proxy-ca.pem \
     DISPLAY=:99 \
     GEOMETRY=1360x1020x16 \
-    BROWSER_VERSION=${BROWSER_VERSION}
+    BROWSER_VERSION=${BROWSER_VERSION} \
+    BROWSER_BIN=${BROWSER_BIN}
 
 COPY --from=chrome /tmp/*.deb /deb/
 COPY --from=chrome /app/libpepflashplayer.so /app/libpepflashplayer.so
@@ -40,7 +40,7 @@ RUN dpkg -i /deb/*.deb; apt-get update; apt-get install -fqqy && \
 WORKDIR /app
 
 ADD requirements.txt /app/
-RUN pip3 install -r requirements.txt
+RUN pip install -r requirements.txt
 
 ADD package.json /app/
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ Here's how you can use some of the command-line options to configure the crawl:
 - To run more than one browser worker and crawl in parallel, and `--workers N` where N is number of browsers to run in parallel. More browsers will require more CPU and network bandwidth, and does not guarantee faster crawling.
 
 - To crawl into a new directory, specify a different name for the `--collection` param, or, if omitted, a new collection directory based on current time will be created.
--
 
 Browsertrix Crawler includes a number of additional command-line options, explained below.
 
 ## Crawling Configuration Options
 
-The Browsertrix Crawler docker image currently accepts the following parameters:
+
+<details>
+      <summary><b>The Browsertrix Crawler docker image currently accepts the following parameters:</b></summary>
 
 ```
 crawler [options]
@@ -136,6 +137,8 @@ Options:
                                            command line will take precedence.              
                                            [string]
 ```
+</details>
+
 
 For the `--waitUntil` flag,  see [page.goto waitUntil options](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagegotourl-options).
 
@@ -238,7 +241,7 @@ The current profile creation script is still experimental and the script attempt
 The Docker container provided here packages up several components used in Browsertrix.
 
 The system uses:
- - `oldwebtoday/chrome` - to install a recent version of Chrome (currently chrome:84)
+ - `oldwebtoday/chrome` or `oldwebtoday/chromium` - to install a recent version of Chrome (currently chrome:90) or Chromium (see below).
  - `puppeteer-cluster` - for running Chrome browsers in parallel
  - `pywb` - in recording mode for capturing the content
 
@@ -247,6 +250,19 @@ The crawl produces a single pywb collection, at `/crawls/collections/<collection
 
 To access the contents of the crawl, the `/crawls` directory in the container should be mounted to a volume (default in the Docker Compose setup).
 
+### Building with Custom Browser Image / Building on Apple M1
+
+Browsertrix Crawler can be built on the new ARM M1 chip (for development). However, since there is no Linux build of Chrome for ARM, Chromium can be used instead. Currently, Webrecorder provides the `oldwebtoday/chromium:91-arm` for running Browsertrix Crawler on ARM-based systems.
+
+For example, to build with this Chromium image on an Apple M1 machine, run:
+
+```
+docker-compose build --build-arg BROWSER_IMAGE_BASE=oldwebtoday/chromium --build-arg "BROWSER_VERSION=91-arm" --build-arg BROWSER_BIN=chromium-browser
+```
+
+You should then be able to run Browsertrix Crawler natively on M1. 
+
+The build arguments specify the base image, version and browser binary. This approach can also be used to install a different browser in general from any Debian-based Docker image.
 
 
 ### Example Usage

--- a/crawler.js
+++ b/crawler.js
@@ -255,9 +255,8 @@ class Crawler {
     const warcVersion = "WARC/1.1";
     const type = "warcinfo";
     const packageFileJSON = JSON.parse(await fsp.readFile("../app/package.json"));
-    const version = await fsp.readFile("/usr/local/lib/python3.8/dist-packages/pywb/version.py", "utf8");
-    const pywbVersion = version.split("\n")[0].split("=")[1].trim().replace(/['"]+/g, "");
     const warcioPackageJson = JSON.parse(await fsp.readFile("/app/node_modules/warcio/package.json"));
+    const pywbVersion = child_process.execSync("pywb -V", {encoding: "utf8"}).trim().split(" ")[1];
 
     const info = {
       "software": `Browsertrix-Crawler ${packageFileJSON["version"]} (with warcio.js ${warcioPackageJson} pywb ${pywbVersion})`,

--- a/crawler.js
+++ b/crawler.js
@@ -26,7 +26,7 @@ const  TextExtract  = require("./util/textextract");
 const { ScreenCaster } = require("./util/screencaster");
 const { parseArgs } = require("./util/argParser");
 
-const { CHROME_PATH, BEHAVIOR_LOG_FUNC, HTML_TYPES } = require("./util/constants");
+const { BROWSER_BIN, BEHAVIOR_LOG_FUNC, HTML_TYPES } = require("./util/constants");
 
 // ============================================================================
 class Crawler {
@@ -91,7 +91,7 @@ class Crawler {
       let version = process.env.BROWSER_VERSION;
 
       try {
-        version = child_process.execFileSync(CHROME_PATH, ["--product-version"], {encoding: "utf8"}).trim();
+        version = child_process.execFileSync(BROWSER_BIN, ["--product-version"], {encoding: "utf8"}).trim();
       } catch(e) {
         console.log(e);
       }
@@ -171,7 +171,7 @@ class Crawler {
     // Puppeter Options
     return {
       headless: this.params.headless,
-      executablePath: CHROME_PATH,
+      executablePath: BROWSER_BIN,
       ignoreHTTPSErrors: true,
       args: this.chromeArgs,
       userDataDir: this.profileDir,

--- a/crawler.js
+++ b/crawler.js
@@ -255,7 +255,7 @@ class Crawler {
     const warcVersion = "WARC/1.1";
     const type = "warcinfo";
     const packageFileJSON = JSON.parse(await fsp.readFile("../app/package.json"));
-    const version = await fsp.readFile("/usr/local/lib/python3.8/site-packages/pywb/version.py", "utf8");
+    const version = await fsp.readFile("/usr/local/lib/python3.8/dist-packages/pywb/version.py", "utf8");
     const pywbVersion = version.split("\n")[0].split("=")[1].trim().replace(/['"]+/g, "");
     const warcioPackageJson = JSON.parse(await fsp.readFile("/app/node_modules/warcio/package.json"));
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
   
 services:
     crawler:
-        image: webrecorder/browsertrix-crawler:0.4.0-beta.1
+        image: webrecorder/browsertrix-crawler:0.4.0-beta.2
         build:
           context: ./
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "main": "browsertrix-crawler",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",
   "author": "Ilya Kreymer <ikreymer@gmail.com>, Webrecorder Software",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pywb>=2.6.0b2
+pywb>=2.6.0b3
 #git+https://github.com/webrecorder/pywb@main
 uwsgi
 wacz>=0.3.0

--- a/util/constants.js
+++ b/util/constants.js
@@ -2,5 +2,5 @@
 module.exports.HTML_TYPES = ["text/html", "application/xhtml", "application/xhtml+xml"];
 module.exports.WAIT_UNTIL_OPTS = ["load", "domcontentloaded", "networkidle0", "networkidle2"];
 module.exports.BEHAVIOR_LOG_FUNC = "__bx_log";
-module.exports.CHROME_PATH = "chromium-browser";
+module.exports.BROWSER_BIN = process.env.BROWSER_BIN || "google-chrome";
 

--- a/util/constants.js
+++ b/util/constants.js
@@ -2,5 +2,5 @@
 module.exports.HTML_TYPES = ["text/html", "application/xhtml", "application/xhtml+xml"];
 module.exports.WAIT_UNTIL_OPTS = ["load", "domcontentloaded", "networkidle0", "networkidle2"];
 module.exports.BEHAVIOR_LOG_FUNC = "__bx_log";
-module.exports.CHROME_PATH = "google-chrome";
+module.exports.CHROME_PATH = "chromium-browser";
 


### PR DESCRIPTION
This change removes dependency on python-nodejs image, and instead installs python + node directly on ubuntu bionic image.
This allows for building browsertrix crawler natively on Apple M1 / ARM architectures.

The change also allows specifying a different browser instead of google-chrome and a different source image.

Since a Chrome binary is not available for ARM, but Chromium is, this works well with the `oldwebtoday/chromium:91-arm` image, which can be used to build browsertrix-crawler on Apple M1 machines.

This also allows building the crawler with other custom browser images.

Also, using latest version of pywb which prints out the version with -V flag, to have a cleaner way of getting version.
