### PR TITLE
Per-Seed Scoping Rules + Crawl Depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ docker run -v $PWD/crawl-config.yaml:/app/crawl-config.yaml -v $PWD/crawls:/craw
 
 The config can also be passed via stdin, which can simplify the command. Note that this require running `docker run` with the `-i` flag. To read config from stdin, pass `--config stdin`
 
-
 ```
 cat ./crawl-config.yaml | docker run -i -v $PWD/crawls:/crawls/ webrecorder/browsertrix-crawler:[VERSION] crawl —-config stdin
 ```
@@ -180,6 +179,38 @@ combineWARCs: true
 
 The list of seeds can be loaded via an external file by specifying the filename via the `seedFile` config or command-line option.
 
+#### Per Seed Settings
+
+Certain settings such scope type, scope includes and excludes, and depth can be configured per seed, for example:
+
+```
+seeds:
+  - url: https://webrecorder.net/
+    depth: 1
+    type: "prefix"
+```
+
+### Scope Types
+
+The crawl scope can be configured globally for all seeds, or customized per seed, by specifying the `--scopeType` command-line option or setting the `type` property for each seed.
+
+The scope controls which linked pages are also included in the crawl.
+
+The available types are:
+
+- `page` - crawl only this page, but load any links that include different hashtags. Useful for single-page apps that may load different content based on hashtag.
+
+- `prefix` - crawl any pages in the same directory, eg. starting from `https://example.com/path/page.html`, crawl anything under `https://example.com/path/` (default)
+
+- `host` - crawl pages that share the same host.
+
+- `any` - crawl any and all pages.
+
+- `none` - don't crawl any additional pages besides the seed.
+
+
+The `depth` setting also limits how many pages will be crawled for that seed, while the `limit` option sets the total
+number of pages crawled from any seed.
 
 
 ### Behaviors

--- a/crawler.js
+++ b/crawler.js
@@ -1,19 +1,8 @@
-const puppeteer = require("puppeteer-core");
-const { Cluster } = require("puppeteer-cluster");
 const child_process = require("child_process");
-const fetch = require("node-fetch");
-const AbortController = require("abort-controller");
 const path = require("path");
 const fs = require("fs");
 const fsp = require("fs/promises");
 const os = require("os");
-const Sitemapper = require("sitemapper");
-const { v4: uuidv4 } = require("uuid");
-const warcio = require("warcio");
-
-const Redis = require("ioredis");
-
-const behaviors = fs.readFileSync("/app/node_modules/browsertrix-behaviors/dist/behaviors.js", "utf-8");
 
 // to ignore HTTPS error for HEAD check
 const HTTPS_AGENT = require("https").Agent({
@@ -21,6 +10,18 @@ const HTTPS_AGENT = require("https").Agent({
 });
 
 const HTTP_AGENT = require("http").Agent();
+
+const fetch = require("node-fetch");
+const puppeteer = require("puppeteer-core");
+const { Cluster } = require("puppeteer-cluster");
+const AbortController = require("abort-controller");
+const Sitemapper = require("sitemapper");
+const { v4: uuidv4 } = require("uuid");
+const Redis = require("ioredis");
+
+const warcio = require("warcio");
+
+const behaviors = fs.readFileSync("/app/node_modules/browsertrix-behaviors/dist/behaviors.js", "utf-8");
 
 const  TextExtract  = require("./util/textextract");
 const { ScreenCaster } = require("./util/screencaster");
@@ -51,9 +52,7 @@ class Crawler {
 
     this.params = parseArgs();
 
-    console.log("Exclusions Regexes: ", this.params.exclude);
-    console.log("Scope Regexes: ", this.params.scope);
-
+    console.log("Seeds", this.params.scopedSeeds);
 
     this.capturePrefix = `http://${process.env.PROXY_HOST}:${process.env.PROXY_PORT}/${this.params.collection}/record/id_/`;
 
@@ -301,26 +300,13 @@ class Crawler {
       this.screencaster = new ScreenCaster(this.cluster, this.params.screencastPort);
     }
 
-    // first, check external seeds file
-    if (this.params.urlFile) {
-      const urlSeedFile =  await fsp.readFile(this.params.urlFile, "utf8");
-      const urlSeedFileList = urlSeedFile.split("\n");
-      this.queueUrls(urlSeedFileList, true);
-      this.params.allowHashUrls = true;
+    for (let i = 0; i < this.params.scopedSeeds.length; i++) {
+      const seed = this.params.scopedSeeds[i];
+      this.queueUrl(i, seed.url, 0);
 
-    // check inline seeds
-    } else if (this.params.seeds) {
-      this.queueUrls(this.params.seeds, true);
-      this.params.allowHashUrls = true;
-
-    // check single URL
-    }
-    if (this.params.url) {
-      this.queueUrl(this.params.url);
-    }
-
-    if (this.params.useSitemap) {
-      await this.parseSitemap(this.params.useSitemap);
+      if (seed.sitemap) {
+        await this.parseSitemap(seed.sitemap, i);
+      }
     }
 
     await this.cluster.idle();
@@ -382,7 +368,9 @@ class Crawler {
     }
   }
 
-  async loadPage(page, url, selector = "a[href]") {
+  async loadPage(page, urlData, selector = "a[href]") {
+    const {url, seedId, depth} = urlData;
+
     if (!await this.isHTML(url)) {
       await this.directFetchCapture(url);
       return;
@@ -395,11 +383,11 @@ class Crawler {
     }
 
     if (selector) {
-      await this.extractLinks(page, selector);
+      await this.extractLinks(page, seedId, depth, selector);
     }
   }
 
-  async extractLinks(page, selector = "a[href]") {
+  async extractLinks(page, seedId, depth, selector = "a[href]") {
     let results = [];
 
     try {
@@ -412,17 +400,19 @@ class Crawler {
       console.warn("Link Extraction failed", e);
       return;
     }
-    this.queueUrls(results);
+    this.queueUrls(seedId, results, depth);
   }
 
-  queueUrls(urls, ignoreScope=false) {
+  queueUrls(seedId, urls, depth) {
     try {
+      depth += 1;
+      const seed = this.params.scopedSeeds[seedId];
+
       for (const url of urls) {
-        const captureUrl = this.shouldCrawl(url, ignoreScope);
+        const captureUrl = seed.isIncluded(url, depth);
+
         if (captureUrl) {
-          if (!this.queueUrl(captureUrl)) {
-            break;
-          }
+          this.queueUrl(seedId, captureUrl, depth);
         }
       }
     } catch (e) {
@@ -430,14 +420,18 @@ class Crawler {
     }
   }
 
-  queueUrl(url) {
+  queueUrl(seedId, url, depth) {
+    if (this.seenList.has(url)) {
+      return false;
+    }
+
     this.seenList.add(url);
     if (this.numLinks >= this.params.limit && this.params.limit > 0) {
       this.limitHit = true;
       return false;
     }
     this.numLinks++;
-    this.cluster.queue({url});
+    this.cluster.queue({url, seedId, depth});
     return true;
   }
 
@@ -487,61 +481,6 @@ class Crawler {
     catch (err) {
       console.warn("pages/pages.jsonl append failed", err);
     }
-  }
-
-  shouldCrawl(url, ignoreScope) {
-    try {
-      url = new URL(url);
-    } catch(e) {
-      return false;
-    }
-
-    if (!this.params.allowHashUrls) {
-      // remove hashtag
-      url.hash = "";
-    }
-
-    // only queue http/https URLs
-    if (url.protocol != "http:" && url.protocol != "https:") {
-      return false;
-    }
-
-    url = url.href;
-
-    // skip already crawled
-    if (this.seenList.has(url)) {
-      return false;
-    }
-    let inScope = false;
-
-    if (ignoreScope) {
-      inScope = true;
-    }
-
-    // check scopes
-    if (!ignoreScope){
-      for (const s of this.params.scope) {
-        if (s.exec(url)) {
-          inScope = true;
-          break;
-        }
-      }
-    }
-
-    if (!inScope) {
-      //console.log(`Not in scope ${url} ${scope}`);
-      return false;
-    }
-
-    // check exclusions
-    for (const e of this.params.exclude) {
-      if (e.exec(url)) {
-        //console.log(`Skipping ${url} excluded by ${e}`);
-        return false;
-      }
-    }
-
-    return url;
   }
 
   resolveAgent(urlParsed) {
@@ -609,7 +548,7 @@ class Crawler {
     return new Promise(resolve => setTimeout(resolve, time));
   }
 
-  async parseSitemap(url) {
+  async parseSitemap(url, seedId) {
     const sitemapper = new Sitemapper({
       url,
       timeout: 15000,
@@ -618,7 +557,7 @@ class Crawler {
 
     try {
       const { sites } = await sitemapper.fetch();
-      this.queueUrls(sites);
+      this.queueUrls(seedId, sites, 0);
     } catch(e) {
       console.log(e);
     }

--- a/crawler.js
+++ b/crawler.js
@@ -47,10 +47,11 @@ class Crawler {
     this.limitHit = false;
 
     this.userAgent = "";
-    this.behaviorsLogDebug = false;
     this.profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "profile-"));
 
-    this.params = parseArgs();
+    this.params = parseArgs(this.profileDir);
+
+    this.emulateDevice = this.params.emulateDevice;
 
     console.log("Seeds", this.params.scopedSeeds);
 
@@ -199,7 +200,7 @@ class Crawler {
 
     case "debug":
     default:
-      if (this.behaviorsLogDebug) {
+      if (this.params.behaviorsLogDebug) {
         console.log("behavior debug: " + JSON.stringify(data));
       }
     }
@@ -215,9 +216,9 @@ class Crawler {
         await page.emulate(this.emulateDevice);
       }
 
-      if (this.behaviorOpts && !page.__bx_inited) {
+      if (this.params.behaviorOpts && !page.__bx_inited) {
         await page.exposeFunction(BEHAVIOR_LOG_FUNC, (logdata) => this._behaviorLog(logdata));
-        await page.evaluateOnNewDocument(behaviors + `;\nself.__bx_behaviors.init(${this.behaviorOpts});`);
+        await page.evaluateOnNewDocument(behaviors + `;\nself.__bx_behaviors.init(${this.params.behaviorOpts});`);
         page.__bx_inited = true;
       }
 
@@ -235,7 +236,7 @@ class Crawler {
 
       await this.writePage(data.url, title, this.params.text, text);
 
-      if (this.behaviorOpts) {
+      if (this.params.behaviorOpts) {
         await Promise.allSettled(page.frames().map(frame => frame.evaluate("self.__bx_behaviors.run();")));
       }
 

--- a/defaultDriver.js
+++ b/defaultDriver.js
@@ -1,5 +1,4 @@
 
 module.exports = async ({data, page, crawler}) => {
-  const {url} = data;
-  await crawler.loadPage(page, url);
+  await crawler.loadPage(page, data);
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
-    "browsertrix-behaviors": "^0.2.1",
+    "browsertrix-behaviors": "^0.2.2",
     "ioredis": "^4.27.1",
     "js-yaml": "^4.1.0",
     "node-fetch": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "abort-controller": "^3.0.0",
     "browsertrix-behaviors": "^0.2.1",
     "ioredis": "^4.27.1",
+    "js-yaml": "^4.1.0",
     "node-fetch": "^2.6.1",
     "puppeteer-cluster": "^0.22.0",
     "puppeteer-core": "^8.0.0",

--- a/tests/config_file.test.js
+++ b/tests/config_file.test.js
@@ -8,7 +8,7 @@ test("check yaml config file with seed list is used", async () => {
 
   try{
 
-    await exec("docker-compose run -v $PWD/tests/fixtures:/tests/fixtures crawler crawl --collection configtest --yamlConfig /tests/fixtures/crawl-1.yaml --depth 0");
+    await exec("docker-compose run -v $PWD/tests/fixtures:/tests/fixtures crawler crawl --collection configtest --config /tests/fixtures/crawl-1.yaml --depth 0");
   }
   catch (error) {
     console.log(error);
@@ -45,7 +45,7 @@ test("check yaml config file will be overwritten by command line", async () => {
 
   try{
 
-    await exec("docker-compose run -v $PWD/crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures crawler crawl --collection configtest --yamlConfig /tests/fixtures/crawl-1.yaml --url https://www.example.com --timeout 20000");
+    await exec("docker-compose run -v $PWD/crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures crawler crawl --collection configtest --config /tests/fixtures/crawl-1.yaml --url https://www.example.com --timeout 20000");
   }
   catch (error) {
     console.log(error);

--- a/tests/config_file.test.js
+++ b/tests/config_file.test.js
@@ -8,7 +8,7 @@ test("check yaml config file with seed list is used", async () => {
 
   try{
 
-    await exec("docker-compose run -v $PWD/crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures crawler crawl --collection configtest --yamlConfig /tests/fixtures/crawl-1.yaml --limit 3 --timeout 20000");
+    await exec("docker-compose run -v $PWD/crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures crawler crawl --collection configtest --yamlConfig /tests/fixtures/crawl-1.yaml --depth 0");
   }
   catch (error) {
     console.log(error);

--- a/tests/config_file.test.js
+++ b/tests/config_file.test.js
@@ -21,7 +21,7 @@ test("check yaml config file with seed list is used", async () => {
     pages.add(JSON.parse(line).url);
   }
 
-  const config = yaml.safeLoad(fs.readFileSync("tests/fixtures/crawl-1.yaml", "utf8"));
+  const config = yaml.load(fs.readFileSync("tests/fixtures/crawl-1.yaml", "utf8"));
 
   let foundAllSeeds = true; 
 

--- a/tests/config_file.test.js
+++ b/tests/config_file.test.js
@@ -8,7 +8,7 @@ test("check yaml config file with seed list is used", async () => {
 
   try{
 
-    await exec("docker-compose run -v $PWD/crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures crawler crawl --collection configtest --yamlConfig /tests/fixtures/crawl-1.yaml --depth 0");
+    await exec("docker-compose run -v $PWD/tests/fixtures:/tests/fixtures crawler crawl --collection configtest --yamlConfig /tests/fixtures/crawl-1.yaml --depth 0");
   }
   catch (error) {
     console.log(error);
@@ -18,7 +18,10 @@ test("check yaml config file with seed list is used", async () => {
   const pages = new Set();
 
   for (const line of crawledPages.trim().split("\n")) {
-    pages.add(JSON.parse(line).url);
+    const url = JSON.parse(line).url;
+    if (url) {
+      pages.add(url);
+    }
   }
 
   const config = yaml.load(fs.readFileSync("tests/fixtures/crawl-1.yaml", "utf8"));

--- a/tests/config_stdin.test.js
+++ b/tests/config_stdin.test.js
@@ -1,5 +1,4 @@
 const yaml = require("js-yaml");
-const util = require("util");
 const child_process = require("child_process");
 const fs = require("fs");
 
@@ -12,6 +11,8 @@ test("pass config file via stdin", async () => {
   try {
     const version = require("../package.json").version;
     const proc = child_process.execSync(`docker run -i -v $PWD/crawls:/crawls webrecorder/browsertrix-crawler:${version} crawl --yamlConfig stdin --exclude webrecorder.net/202`, {input: configYaml, stdin: "inherit", encoding: "utf8"});
+
+    console.log(proc);
   }
   catch (error) {
     console.log(error);

--- a/tests/config_stdin.test.js
+++ b/tests/config_stdin.test.js
@@ -10,7 +10,7 @@ test("pass config file via stdin", async () => {
 
   try {
     const version = require("../package.json").version;
-    const proc = child_process.execSync(`docker run -i -v $PWD/crawls:/crawls webrecorder/browsertrix-crawler:${version} crawl --yamlConfig stdin --exclude webrecorder.net/202`, {input: configYaml, stdin: "inherit", encoding: "utf8"});
+    const proc = child_process.execSync(`docker run -i -v $PWD/crawls:/crawls webrecorder/browsertrix-crawler:${version} crawl --config stdin --exclude webrecorder.net/202`, {input: configYaml, stdin: "inherit", encoding: "utf8"});
 
     console.log(proc);
   }

--- a/tests/config_stdin.test.js
+++ b/tests/config_stdin.test.js
@@ -1,0 +1,46 @@
+const yaml = require("js-yaml");
+const util = require("util");
+const child_process = require("child_process");
+const fs = require("fs");
+
+test("pass config file via stdin", async () => {
+  jest.setTimeout(30000);
+
+  const configYaml = fs.readFileSync("tests/fixtures/crawl-2.yaml", "utf8");
+  const config = yaml.load(configYaml);
+
+  try {
+    const version = require("../package.json").version;
+    const proc = child_process.execSync(`docker run -i -v $PWD/crawls:/crawls webrecorder/browsertrix-crawler:${version} crawl --yamlConfig stdin --exclude webrecorder.net/202`, {input: configYaml, stdin: "inherit", encoding: "utf8"});
+  }
+  catch (error) {
+    console.log(error);
+  }
+
+  const crawledPages = fs.readFileSync("crawls/collections/config-stdin/pages/pages.jsonl", "utf8");
+  const pages = new Set();
+
+  for (const line of crawledPages.trim().split("\n")) {
+    const url = JSON.parse(line).url;
+    if (!url) {
+      continue;
+    }
+    pages.add(url);
+    expect(url.indexOf("webrecorder.net/202")).toEqual(-1);
+  }
+
+  let foundAllSeeds = true; 
+
+  for (const seed of config.seeds) {
+    const url = new URL(seed).href;
+    if (!pages.has(url)) {
+      foundAllSeeds = false;
+    }
+  }
+  expect(foundAllSeeds).toBe(true);
+
+  expect(fs.existsSync("crawls/collections/config-stdin/config-stdin.wacz")).toBe(true);
+
+});
+
+

--- a/tests/fixtures/crawl-2.yaml
+++ b/tests/fixtures/crawl-2.yaml
@@ -1,0 +1,10 @@
+name: crawl-test-2
+
+seeds:
+  - https://webrecorder.net/
+
+collection: config-stdin
+depth: 1
+behaviors: ""
+
+generateWACZ: true

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -16,6 +16,10 @@ const { ScopedSeed } = require("./seeds");
 
 // ============================================================================
 class ArgParser {
+  constructor(profileDir) {
+    this.profileDir = profileDir;
+  }
+
   get cliOpts() {
     return {
       "seeds": {
@@ -198,7 +202,7 @@ class ArgParser {
       .usage("crawler [options]")
       .option(this.cliOpts)
       .config("yamlConfig", (configPath) => {
-        return yaml.safeLoad(fs.readFileSync(configPath, "utf-8"));
+        return yaml.load(fs.readFileSync(configPath, "utf-8"));
       })
       .check((argv) => this.validateArgs(argv))
       .argv;
@@ -239,9 +243,9 @@ class ArgParser {
       behaviorOpts.log = BEHAVIOR_LOG_FUNC;
     } else if (argv.logging.includes("behaviors-debug")) {
       behaviorOpts.log = BEHAVIOR_LOG_FUNC;
-      this.behaviorsLogDebug = true;
+      argv.behaviorsLogDebug = true;
     }
-    this.behaviorOpts = JSON.stringify(behaviorOpts);
+    argv.behaviorOpts = JSON.stringify(behaviorOpts);
 
     if (!argv.newContext) {
       argv.newContext = "page";
@@ -272,8 +276,8 @@ class ArgParser {
     }
 
     if (argv.mobileDevice) {
-      this.emulateDevice = puppeteer.devices[argv.mobileDevice];
-      if (!this.emulateDevice) {
+      argv.emulateDevice = puppeteer.devices[argv.mobileDevice];
+      if (!argv.emulateDevice) {
         throw new Error("Unknown device: " + argv.mobileDevice);
       }
     }
@@ -328,6 +332,6 @@ class ArgParser {
 }
 
   
-module.exports.parseArgs = function(argv) {
-  return new ArgParser().parseArgs(argv);
+module.exports.parseArgs = function(profileDir, argv) {
+  return new ArgParser(profileDir).parseArgs(argv);
 };

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -29,6 +29,12 @@ class ArgParser {
         default: [],
       },
 
+      "seedFile": {
+        alias: ["urlFile"],
+        describe: "If set, read a list of seed urls, one per line, from the specified",
+        type: "string",
+      },
+ 
       "workers": {
         alias: "w",
         describe: "The number of workers to run in parallel",
@@ -134,13 +140,7 @@ class ArgParser {
         type: "string",
         default: "stats",
       },
-      
-      "urlFile": {
-        alias: ["urlfile", "url-file", "url-list"],
-        describe: "If set, read a list of urls from the passed file INSTEAD of the url from the --url flag.",
-        type: "string",
-      },
-      
+  
       "text": {
         describe: "If set, extract text to the pages.jsonl file",
         type: "boolean",
@@ -201,7 +201,7 @@ class ArgParser {
     return yargs(hideBin(argv))
       .usage("crawler [options]")
       .option(this.cliOpts)
-      .config("yamlConfig", "Path to YAML config file", (configPath) => {
+      .config("config", "Path to YAML config file", (configPath) => {
         if (configPath === "/crawls/stdin") {
           configPath = process.stdin.fd;
         }
@@ -285,8 +285,8 @@ class ArgParser {
       }
     }
 
-    if (argv.urlFile) {
-      const urlSeedFile = fs.readFileSync(argv.urlFile, "utf8");
+    if (argv.seedFile) {
+      const urlSeedFile = fs.readFileSync(argv.seedFile, "utf8");
       const urlSeedFileList = urlSeedFile.split("\n");
 
       if (typeof(argv.seeds) === "string") {

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -43,7 +43,7 @@ class ArgParser {
         default: "load,networkidle0",
       },
 
-      "maxDepth": {
+      "depth": {
         describe: "The depth of the crawl for all seeds",
         default: -1,
         type: "number",
@@ -298,7 +298,7 @@ class ArgParser {
       sitemap: argv.useSitemap,
       include: argv.scope,
       exclude: argv.exclude,
-      depth: argv.maxDepth,
+      depth: argv.depth,
     };
 
     if (argv.scope && argv.scopeType) {

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -279,7 +279,7 @@ class ArgParser {
     }
 
     if (argv.urlFile) {
-      const urlSeedFile = fs.readFileFile(argv.urlFile, "utf8");
+      const urlSeedFile = fs.readFileSync(argv.urlFile, "utf8");
       const urlSeedFileList = urlSeedFile.split("\n");
 
       if (typeof(argv.seeds) === "string") {

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -201,8 +201,11 @@ class ArgParser {
     return yargs(hideBin(argv))
       .usage("crawler [options]")
       .option(this.cliOpts)
-      .config("yamlConfig", (configPath) => {
-        return yaml.load(fs.readFileSync(configPath, "utf-8"));
+      .config("yamlConfig", "Path to YAML config file", (configPath) => {
+        if (configPath === "/crawls/stdin") {
+          configPath = process.stdin.fd;
+        }
+        return yaml.load(fs.readFileSync(configPath, "utf8"));
       })
       .check((argv) => this.validateArgs(argv))
       .argv;

--- a/util/seeds.js
+++ b/util/seeds.js
@@ -1,15 +1,16 @@
 class ScopedSeed
 {
   constructor({url, type, include, exclude = [], allowHash = false, depth = -1, sitemap = false} = {}) {
-    this.url = url;
+    const parsedUrl = this.parseUrl(url);
+    this.url = parsedUrl.href;
     this.type = type;
     if (type) {
-      [include, allowHash] = this.scopeFromType(type, url);
+      [include, allowHash] = this.scopeFromType(type, parsedUrl);
     }
     this.include = this.parseRx(include);
     this.exclude = this.parseRx(exclude);
-    this.allowHash = allowHash;
     this.sitemap = this.resolveSiteMap(sitemap);
+    this.allowHash = allowHash;
     this.maxDepth = depth < 0 ? 99999 : depth;
   }
 
@@ -43,16 +44,9 @@ class ScopedSeed
     return sitemap;
   }
 
-  scopeFromType(type, url) {
+  scopeFromType(type, parsedUrl) {
     let include;
     let allowHash = false;
-    let parsedUrl = null;
-
-    if (url) {
-      parsedUrl = this.parseUrl(url);
-    } else {
-      type = "any";
-    }
 
     switch (type) {
     case "page":

--- a/util/seeds.js
+++ b/util/seeds.js
@@ -56,7 +56,7 @@ class ScopedSeed
       break;
 
     case "prefix":
-      include = [new RegExp("^" + rxEscape(parsedUrl.origin + parsedUrl.pathname.slice(parsedUrl.pathname.lastIndexOf("/") + 1)))];
+      include = [new RegExp("^" + rxEscape(parsedUrl.origin + parsedUrl.pathname.slice(0, parsedUrl.pathname.lastIndexOf("/") + 1)))];
       break;
 
     case "host":

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,6 +811,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -2966,6 +2971,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,10 +1053,10 @@ browserslist@^4.14.5:
     escalade "^3.1.1"
     node-releases "^1.1.71"
 
-browsertrix-behaviors@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.2.1.tgz#5a3b7d2f1ed5dad5054312738c69748b8ec638b8"
-  integrity sha512-NkReAj+PMS91oewA0tpsyvQVFspsy8mhKLXT8sg33pSDGYCDVlezqPt2agKmsmG1Y2m39yOzt31L8A3v4WcJDw==
+browsertrix-behaviors@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.2.2.tgz#50b52fcab80ecb4793827b6affaf20a50a8b6c21"
+  integrity sha512-6yuanZtGBm90gSUNAYxkbTt52ikKzs84kDH9eLVTl6Q1H2PMQJHLd4SY47fF/WU5PR0A2yRSQyuU3GAbPefLPQ==
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This refactors the scope (include and exclude) settings to be set per-seed, as well as the scope type, allowing hashtags to be in scope, as well as sitemap fetching.

This should allow for more flexible crawling.

Also fixes some settings that were broken by the previous refactor that were not configured via args.

Still needs: additional testing!