### PR TITLE
BlockRules Fixes (0.4.3)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## CHANGES
 
+v0.4.3
+- BlockRules Fixes: When considering the 'inFrameUrl' for a navigation request for an iframe, look at the parent frame's URL
+- Logging: Improved debug logging for block rules (log blocked requests and conditional iframe requests)
+
 v0.4.2
 - Compose/docs: Build latest image by default, update README to refer to latest image
 - Fix typo in `crawler.capturePrefix` that resulted in `directFetchCapture()` always failing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 ## CHANGES
 
 v0.4.3
-- BlockRules Fixes: When considering the 'inFrameUrl' for a navigation request for an iframe, look at the parent frame's URL
-- Logging: Improved debug logging for block rules (log blocked requests and conditional iframe requests)
+- BlockRules Fixes: When considering the 'inFrameUrl' for a navigation request for an iframe, use URL of parent frame.
+- BlockRules Fixes: Always allow pywb proxy scripts.
+- Logging: Improved debug logging for block rules (log blocked requests and conditional iframe requests) when 'debug' set in 'logging'
 
 v0.4.2
 - Compose/docs: Build latest image by default, update README to refer to latest image

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Support
 
 Initial support for development of Browsertrix Crawler, was provided by [Kiwix](https://kiwix.org/). The initial functionality for Browsertrix Crawler was developed to support the [zimit](https://github.com/openzim/zimit) project in a collaboration between. Webrecorder and Kiwix, and this project has been split off from Zimit into a core component of Webrecorder.
 
-Additional support for Browsertrix Crawler, including the development of the  0.4.x version has been provided by [Portico](https://www.portico.org/).
+Additional support for Browsertrix Crawler, including for the development of the 0.4.x version has been provided by [Portico](https://www.portico.org/).
 
 
 License

--- a/README.md
+++ b/README.md
@@ -484,10 +484,9 @@ Then, loading the `http://localhost:8080/wr-net/https://webrecorder.net/` should
 Support
 -------
 
-Initial support for development of Browsertrix Crawler, was provided by [Kiwix](https://kiwix.org/)
+Initial support for development of Browsertrix Crawler, was provided by [Kiwix](https://kiwix.org/). The initial functionality for Browsertrix Crawler was developed to support the [zimit](https://github.com/openzim/zimit) project in a collaboration between. Webrecorder and Kiwix, and this project has been split off from Zimit into a core component of Webrecorder.
 
-Initial functionality for Browsertrix Crawler was developed to support the [zimit](https://github.com/openzim/zimit) project in a collaboration between
-Webrecorder and Kiwix, and this project has been split off from Zimit into a core component of Webrecorder.
+Additional support for Browsertrix Crawler, including the development of the including 0.4.x version has been provided by Portico.
 
 
 License

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Support
 
 Initial support for development of Browsertrix Crawler, was provided by [Kiwix](https://kiwix.org/). The initial functionality for Browsertrix Crawler was developed to support the [zimit](https://github.com/openzim/zimit) project in a collaboration between. Webrecorder and Kiwix, and this project has been split off from Zimit into a core component of Webrecorder.
 
-Additional support for Browsertrix Crawler, including the development of the including 0.4.x version has been provided by Portico.
+Additional support for Browsertrix Crawler, including the development of features in the including 0.4.x version has been provided by [Portico](https://www.portico.org/).
 
 
 License

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Support
 
 Initial support for development of Browsertrix Crawler, was provided by [Kiwix](https://kiwix.org/). The initial functionality for Browsertrix Crawler was developed to support the [zimit](https://github.com/openzim/zimit) project in a collaboration between. Webrecorder and Kiwix, and this project has been split off from Zimit into a core component of Webrecorder.
 
-Additional support for Browsertrix Crawler, including the development of features in the including 0.4.x version has been provided by [Portico](https://www.portico.org/).
+Additional support for Browsertrix Crawler, including the development of the  0.4.x version has been provided by [Portico](https://www.portico.org/).
 
 
 License

--- a/crawler.js
+++ b/crawler.js
@@ -329,7 +329,7 @@ class Crawler {
     await this.initPages();
 
     if (this.params.blockRules && this.params.blockRules.length) {
-      this.blockRules = new BlockRules(this.params.blockRules, this.captureBasePrefix, this.params.blockMessage);
+      this.blockRules = new BlockRules(this.params.blockRules, this.captureBasePrefix, this.params.blockMessage, (text) => this.debugLog(text));
     }
 
     if (this.params.screencastPort) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "browsertrix-crawler",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",
   "author": "Ilya Kreymer <ikreymer@gmail.com>, Webrecorder Software",

--- a/tests/blockrules.test.js
+++ b/tests/blockrules.test.js
@@ -130,23 +130,24 @@ test("test block url in frame url", () => {
 });
 
 
-test("test block rules complex example, block other iframes, but not youtube", () => {
+test("test block rules complex example, block external urls on main frame, but not on youtube", () => {
   const config = {
     "seeds": [
-      "https://hdsr.mitpress.mit.edu/pub/xcq8a1v1",
-      "https://hdsr.mitpress.mit.edu/pub/3csmghzj/release/1"
+      "https://archiveweb.page/guide/troubleshooting/errors.html",
     ],
     "depth": "0",
     "blockRules": [{
-      "url": "(pubpub.org|polyfill.io|typekit.net|hdsr.mitpress.mit.edu|www.youtube.com)",
+      "url": "(archiveweb.page|www.youtube.com)",
       "type": "allowOnly",
-      "inFrameUrl": "hdsr.mitpress.mit.edu"
+      "inFrameUrl": "archiveweb.page"
+    }, {
+      "url": "https://archiveweb.page/assets/js/vendor/lunr.min.js",
+      "inFrameUrl": "archiveweb.page"
     }, {
       "url": "https://www.youtube.com/embed/",
       "type": "allowOnly",
-      "frameTextMatch": "(\\\\\"channelId\\\\\":\\\\\"UCl0IFA3-VcWOadMbNiUH2aw\\\\\")"
+      "frameTextMatch": "(\\\\\"channelId\\\\\":\\\\\"UCOHO8gYUWpDYFWHXmIwE02g\\\\\")"
     }],
-    "include": "(hdsr.mitpress.mit.edu|assets.pubpub.org)",
 
     "combineWARC": true,
 
@@ -156,7 +157,7 @@ test("test block rules complex example, block other iframes, but not youtube", (
 
   runCrawl("block-7", config);
 
-  expect(doesCDXContain("block-7", "\"https://mit-harvard.netlify.com/\"")).toBe(false);  
+  expect(doesCDXContain("block-7", "\"https://archiveweb.page/assets/js/vendor/lunr.min.js\"")).toBe(false);  
   expect(doesCDXContain("block-7", "\"video/mp4\"")).toBe(true);
 });
 

--- a/tests/blockrules.test.js
+++ b/tests/blockrules.test.js
@@ -130,4 +130,35 @@ test("test block url in frame url", () => {
 });
 
 
+test("test block rules complex example, block other iframes, but not youtube", () => {
+  const config = {
+    "seeds": [
+      "https://hdsr.mitpress.mit.edu/pub/xcq8a1v1",
+      "https://hdsr.mitpress.mit.edu/pub/3csmghzj/release/1"
+    ],
+    "depth": "0",
+    "blockRules": [{
+      "url": "(pubpub.org|polyfill.io|typekit.net|hdsr.mitpress.mit.edu|www.youtube.com)",
+      "type": "allowOnly",
+      "inFrameUrl": "hdsr.mitpress.mit.edu"
+    }, {
+      "url": "https://www.youtube.com/embed/",
+      "type": "allowOnly",
+      "frameTextMatch": "(\\\\\"channelId\\\\\":\\\\\"UCl0IFA3-VcWOadMbNiUH2aw\\\\\")"
+    }],
+    "include": "(hdsr.mitpress.mit.edu|assets.pubpub.org)",
+
+    "combineWARC": true,
+
+    "logging": 'stats,debug'
+  };
+
+
+  runCrawl("block-7", config);
+
+  expect(doesCDXContain("block-7", "\"https://mit-harvard.netlify.com/\"")).toBe(false);  
+  expect(doesCDXContain("block-7", "\"video/mp4\"")).toBe(true);
+});
+
+
 

--- a/tests/blockrules.test.js
+++ b/tests/blockrules.test.js
@@ -150,7 +150,7 @@ test("test block rules complex example, block other iframes, but not youtube", (
 
     "combineWARC": true,
 
-    "logging": 'stats,debug'
+    "logging": "stats,debug"
   };
 
 

--- a/util/blockrules.js
+++ b/util/blockrules.js
@@ -37,10 +37,11 @@ ${this.frameTextMatch ? "Frame Text Regex: " + this.frameTextMatch : ""}
 // ===========================================================================
 class BlockRules
 {
-  constructor(blockRules, blockPutUrl, blockErrMsg) {
+  constructor(blockRules, blockPutUrl, blockErrMsg, debugLog) {
     this.rules = [];
     this.blockPutUrl = blockPutUrl;
     this.blockErrMsg = blockErrMsg;
+    this.debugLog = debugLog;
     this.putUrlSet = new Set();
 
     for (const ruleData of blockRules) {
@@ -48,9 +49,9 @@ class BlockRules
     }
 
     if (this.rules.length) {
-      console.log("URL Block Rules:\n");
+      this.debugLog("URL Block Rules:\n");
       for (const rule of this.rules) {
-        console.log(rule.toString());
+        this.debugLog(rule.toString());
       }
     }
   }
@@ -80,14 +81,11 @@ class BlockRules
     }
 
     for (const rule of this.rules) {
-      const {done, block} = await this.shouldBlock(rule, request);
+      const {done, block, frameUrl} = await this.shouldBlock(rule, request);
 
       if (block) {
-        //const frameUrl = request.frame().url();
-        //console.log("Blocking/Aborting Request for: " + request.url());
-        // not allowed, abort loading this response
         request.abort();
-        await this.recordBlockMsg(request.url());
+        await this.recordBlockMsg(request.url(), frameUrl);
         return;
       }
       if (done) {
@@ -106,16 +104,31 @@ class BlockRules
     const type = rule.type || "block";
     const allowOnly = (type === "allowOnly");
 
-    const frameUrl = request.frame().url();
+    const isNavReq = request.isNavigationRequest();
+
+    const frame = request.frame();
+
+    let frameUrl = null;
+
+    if (isNavReq) {
+      const parentFrame = frame.parentFrame();
+      if (parentFrame) {
+        frameUrl = parentFrame.url();
+      } else {
+        frameUrl = frame.url();
+      }
+    } else {
+      frameUrl = frame.url();
+    }
 
     // ignore initial page
     if (frameUrl === "about:blank") {
-      return {block: false, done: true};
+      return {block: false, done: true, frameUrl};
     }
 
     // not a frame match, skip rule
     if (inFrameUrl && !frameUrl.match(inFrameUrl)) {
-      return {block: false, done: false};
+      return {block: false, done: false, frameUrl};
     }
 
     const urlMatched = (url && reqUrl.match(url));
@@ -123,17 +136,18 @@ class BlockRules
     // if frame text-based rule: if url matched and a frame request
     // frame text-based match: only applies to nav requests, never block otherwise
     if (frameTextMatch) {
-      if (!urlMatched || !request.isNavigationRequest()) {
-        return {block: false, done: false};
+      if (!urlMatched || !isNavReq) {
+        return {block: false, done: false, frameUrl};
       }
 
       const block = await this.isTextMatch(request, reqUrl, frameTextMatch) ? !allowOnly : allowOnly;
-      return {block, done: true};
+      this.debugLog(`iframe ${url} conditionally ${block ? "BLOCKED" : "ALLOWED"}, parent frame ${frameUrl}`);
+      return {block, done: true, frameUrl};
     }
 
     // for non frame text rule, simply match by URL
     const block = urlMatched ? !allowOnly : allowOnly;
-    return {block, done: false};
+    return {block, done: false, frameUrl};
   }
 
   async isTextMatch(request, reqUrl, frameTextMatch) {
@@ -144,11 +158,13 @@ class BlockRules
       return !!text.match(frameTextMatch);
 
     } catch (e) {
-      console.log(e);
+      this.debugLog(e);
     }
   }
 
-  async recordBlockMsg(url) {
+  async recordBlockMsg(url, frameUrl) {
+    this.debugLog(`URL Blocked/Aborted: ${url} in frame ${frameUrl}`);
+
     if (!this.blockErrMsg || !this.blockPutUrl) {
       return;
     }
@@ -162,7 +178,6 @@ class BlockRules
     const body = this.blockErrMsg;
     const putUrl = new URL(this.blockPutUrl);
     putUrl.searchParams.set("url", url);
-    //console.log("put url", putUrl.href);
     await fetch(putUrl.href, {method: "PUT", headers: {"Content-Type": "text/html"}, body});
   }
 }


### PR DESCRIPTION
- Fix block rules to ensure 'inFrameUrl' check for iframe navigation requests checks the parent frame
- Logging: When 'debug' is set in 'logging', log blocked requests and conditional iframe requests
- Always allow pywb proxy resources in block rules
- bump to 0.4.3