### PR TITLE
add 'scopeType: domain' to include all subdomains

### DIFF
--- a/tests/scopes.test.js
+++ b/tests/scopes.test.js
@@ -26,7 +26,7 @@ seeds:
 
   expect(seeds.length).toEqual(1);
   expect(seeds[0].scopeType).toEqual("prefix");
-  expect(seeds[0].include).toEqual([/^https:\/\/example\.com\//]);
+  expect(seeds[0].include).toEqual([/^https?:\/\/example\.com\//]);
   expect(seeds[0].exclude).toEqual([]);
 
 });
@@ -43,7 +43,7 @@ exclude: https://example.com/pathexclude
 
   expect(seeds.length).toEqual(1);
   expect(seeds[0].scopeType).toEqual("prefix");
-  expect(seeds[0].include).toEqual([/^https:\/\/example\.com\//]);
+  expect(seeds[0].include).toEqual([/^https?:\/\/example\.com\//]);
   expect(seeds[0].exclude).toEqual([/https:\/\/example.com\/pathexclude/]);
 
 });
@@ -62,7 +62,7 @@ exclude: https://example.com/pathexclude
 
   expect(seeds.length).toEqual(1);
   expect(seeds[0].scopeType).toEqual("prefix");
-  expect(seeds[0].include).toEqual([/^https:\/\/example\.com\//]);
+  expect(seeds[0].include).toEqual([/^https?:\/\/example\.com\//]);
   expect(seeds[0].exclude).toEqual([/https:\/\/example.com\/pathexclude/]);
 
 });
@@ -81,25 +81,54 @@ exclude: https://example.com/pathexclude
 
   expect(seeds.length).toEqual(1);
   expect(seeds[0].scopeType).toEqual("prefix");
-  expect(seeds[0].include).toEqual([/^https:\/\/example\.com\//]);
+  expect(seeds[0].include).toEqual([/^https?:\/\/example\.com\//]);
   expect(seeds[0].exclude).toEqual([/https:\/\/example.com\/pathexclude/]);
 
 });
+
+
+test("host scope and domain scope", async () => {
+  const seeds = getSeeds(`
+
+seeds:
+   - url: https://example.com/
+     scopeType: domain
+
+   - url: https://example.org/
+     scopeType: host
+`);
+
+  expect(seeds.length).toEqual(2);
+  expect(seeds[0].scopeType).toEqual("domain");
+  expect(seeds[0].include).toEqual([/^https?:\/\/([^/]+\.)*example\.com\//]);
+  expect(!!seeds[0].include[0].exec("https://example.com/")).toEqual(true);
+  expect(!!seeds[0].include[0].exec("https://example.com/path")).toEqual(true);
+  expect(!!seeds[0].include[0].exec("https://sub.example.com/path")).toEqual(true);
+  expect(!!seeds[0].include[0].exec("https://sub.domain.example.com/path")).toEqual(true);
+  expect(!!seeds[0].include[0].exec("https://notsub.domainexample.com/path")).toEqual(false);
+
+  expect(seeds[1].scopeType).toEqual("host");
+  expect(seeds[1].include).toEqual([/^https?:\/\/example\.org\//]);
+  expect(!!seeds[1].include[0].exec("https://example.org/")).toEqual(true);
+  expect(!!seeds[1].include[0].exec("https://example.org/path")).toEqual(true);
+  expect(!!seeds[1].include[0].exec("https://sub.example.com/path")).toEqual(false);
+});
+
 
 
 test("custom scope", async () => {
   const seeds = getSeeds(`
 seeds:
    - url: https://example.com/
-     include: https://example.com/(path|other)
-     exclude: https://example.com/pathexclude
+     include: https?://example.com/(path|other)
+     exclude: https?://example.com/pathexclude
 `);
 
 
   expect(seeds.length).toEqual(1);
   expect(seeds[0].scopeType).toEqual("custom");
-  expect(seeds[0].include).toEqual([/https:\/\/example.com\/(path|other)/]);
-  expect(seeds[0].exclude).toEqual([/https:\/\/example.com\/pathexclude/]);
+  expect(seeds[0].include).toEqual([/https?:\/\/example.com\/(path|other)/]);
+  expect(seeds[0].exclude).toEqual([/https?:\/\/example.com\/pathexclude/]);
 });
 
 
@@ -110,7 +139,7 @@ seeds:
    - url: https://example.com/1
    - url: https://example.com/2
 
-include: https://example.com/(path|other)
+include: https?://example.com/(path|other)
 exclude: https://example.com/pathexclude
 `);
 
@@ -119,12 +148,12 @@ exclude: https://example.com/pathexclude
 
   expect(seeds[0].scopeType).toEqual("custom");
   expect(seeds[0].url).toEqual("https://example.com/1");
-  expect(seeds[0].include).toEqual([/https:\/\/example.com\/(path|other)/]);
+  expect(seeds[0].include).toEqual([/https?:\/\/example.com\/(path|other)/]);
   expect(seeds[0].exclude).toEqual([/https:\/\/example.com\/pathexclude/]);
 
   expect(seeds[1].scopeType).toEqual("custom");
   expect(seeds[1].url).toEqual("https://example.com/2");
-  expect(seeds[1].include).toEqual([/https:\/\/example.com\/(path|other)/]);
+  expect(seeds[1].include).toEqual([/https?:\/\/example.com\/(path|other)/]);
   expect(seeds[1].exclude).toEqual([/https:\/\/example.com\/pathexclude/]);
 
 });
@@ -159,7 +188,7 @@ include: https://example.com/onlythispath
 
   expect(seeds[2].scopeType).toEqual("prefix");
   expect(seeds[2].url).toEqual("https://example.com/subpath/file.html");
-  expect(seeds[2].include).toEqual([/^https:\/\/example\.com\/subpath\//]);
+  expect(seeds[2].include).toEqual([/^https?:\/\/example\.com\/subpath\//]);
   expect(seeds[2].exclude).toEqual([]);
 
 });
@@ -201,7 +230,7 @@ exclude:
 
   expect(seeds[1].scopeType).toEqual("prefix");
   expect(seeds[1].url).toEqual("https://example.com/subpath/file.html");
-  expect(seeds[1].include).toEqual([/^https:\/\/example\.com\/subpath\//]);
+  expect(seeds[1].include).toEqual([/^https?:\/\/example\.com\/subpath\//]);
   expect(seeds[1].exclude).toEqual(excludeRxs);
 
   expect(seeds[2].scopeType).toEqual("any");

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -82,7 +82,7 @@ class ArgParser {
       "scopeType": {
         describe: "A predfined scope of the crawl. For more customization, use 'custom' and set scopeIncludeRx regexes",
         type: "string",
-        choices: ["page", "page-spa", "prefix", "host", "any", "custom"]
+        choices: ["page", "page-spa", "prefix", "host", "domain", "any", "custom"]
       },
 
       "scopeIncludeRx": {

--- a/util/seeds.js
+++ b/util/seeds.js
@@ -158,7 +158,7 @@ function rxEscape(string) {
 }
 
 function urlRxEscape(url, parsedUrl) {
-  return rxEscape(url).replace(parsedUrl.protocol, "https?:")
+  return rxEscape(url).replace(parsedUrl.protocol, "https?:");
 }
 
 

--- a/util/seeds.js
+++ b/util/seeds.js
@@ -67,16 +67,20 @@ class ScopedSeed
 
     case "page-spa":
       // allow scheme-agnostic URLS as likely redirects
-      include = [new RegExp("^" + rxEscape(parsedUrl.href).replace(parsedUrl.protocol, "https?:") + "#.+")];
+      include = [new RegExp("^" + urlRxEscape(parsedUrl.href, parsedUrl) + "#.+")];
       allowHash = true;
       break;
 
     case "prefix":
-      include = [new RegExp("^" + rxEscape(parsedUrl.origin + parsedUrl.pathname.slice(0, parsedUrl.pathname.lastIndexOf("/") + 1)))];
+      include = [new RegExp("^" + urlRxEscape(parsedUrl.origin + parsedUrl.pathname.slice(0, parsedUrl.pathname.lastIndexOf("/") + 1), parsedUrl))];
       break;
 
     case "host":
-      include = [new RegExp("^" + rxEscape(parsedUrl.origin + "/"))];
+      include = [new RegExp("^" + urlRxEscape(parsedUrl.origin + "/", parsedUrl))];
+      break;
+
+    case "domain":
+      include = [new RegExp("^" + urlRxEscape(parsedUrl.origin + "/", parsedUrl).replace("\\/\\/", "\\/\\/([^/]+\\.)*"))];
       break;
 
     case "any":
@@ -84,7 +88,7 @@ class ScopedSeed
       break;
 
     default:
-      throw new Error(`Invalid scope type "${scopeType}" specified, valid types are: page, page-spa, prefix, host, any`);
+      throw new Error(`Invalid scope type "${scopeType}" specified, valid types are: page, page-spa, prefix, host, domain, any`);
     }
 
     return [include, allowHash];
@@ -151,6 +155,10 @@ class ScopedSeed
 
 function rxEscape(string) {
   return string.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+}
+
+function urlRxEscape(url, parsedUrl) {
+  return rxEscape(url).replace(parsedUrl.protocol, "https?:")
 }
 
 


### PR DESCRIPTION
include both http/https in all the default scopes except single page (page-spa, prefix, host, domain)
fixes #116