### PR TITLE
Fix typo in regex yaml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ but skip URLs that end with 'skip-me'. For example, `https://example.com/crawl-t
 ```
 seeds:
   - url: https://example.com/startpage.html
-    include: example.com/crawl-this|crawl-that
+    include: example.com/(crawl-this|crawl-that)
     exclude:
       - skip$
 ```


### PR DESCRIPTION
crawl-this|crawl-that didn't have () around it in the yaml example