### PR TITLE
Set a `UTF-8` locale in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ FROM ${BROWSER_IMAGE_BASE}:${BROWSER_VERSION} AS browser
 
 FROM ubuntu:bionic
 
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
 RUN apt-get update -y && apt-get install --no-install-recommends -qqy software-properties-common \
     && add-apt-repository -y ppa:deadsnakes \
     && apt-get update -y \


### PR DESCRIPTION
There have been several reports of `UnicodeDecodeError`s relating to `pages.jsonl` when creating WACZ files.  I think they may have to do with the locale in the docker container.  This commit ensures a `UTF-8` locale is used, which I think might fix many of the problems.

See here [1] for a very old issue on the repo for the official python docker images.

Apparently from python 3.7 on the `C` locale is automatically coerced to `C.UTF-8` ([2], [3]), but note that the official python docker images still ship with this line [4].  Compare also:

```sh
% docker run python:3.8 python -c "import sys; print(sys.getfilesystemencoding())"
utf-8

% docker run python:3.8 python -c "print(chr(0x423))"                     
У
```

```sh
% docker run webrecorder/browsertrix-crawler python3 -c "import sys; print(sys.getfilesystemencoding())"
ascii

% docker run webrecorder/browsertrix-crawler python3 -c "print(chr(0x423))" 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character '\u0423' in position 0: ordinal not in range(128)  
```

It's possible there's something else going on (instead? as well?) with the problems reported in the SUCHO slack (I've not been able to reproduce anything), but this seems like a safe, worthwhile, and important change in any event.  I've confirmed that building the image with this change produces behaviour that matches the `python:3.8` image.

[1] https://github.com/docker-library/python/issues/13
[2] https://bugs.python.org/issue19846
[3] https://bugs.python.org/issue28180
[4] e.g. https://github.com/docker-library/python/blob/master/3.10/bullseye/Dockerfile#L12-L14