### PR TITLE
Improve to URL direct check and fetch

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -718,7 +718,7 @@ class Crawler {
         headers: this.headers,
         agent: this.resolveAgent
       });
-      if (resp.status >= 300) {
+      if (resp.status !== 200) {
         this.debugLog(`Skipping HEAD check ${url}, invalid status ${resp.status}`);
         return true;
       }

--- a/util/state.js
+++ b/util/state.js
@@ -77,7 +77,7 @@ class MemoryCrawlState extends BaseState
       },
 
       reject(e) {
-        console.warn(`URL Load Failed: ${url}, Reason: ${e}`);
+        console.warn(`Page Load Failed: ${url}, Reason: ${e}`);
 
         state.pending.delete(url);
 
@@ -284,7 +284,7 @@ return 0;
       },
 
       async reject(e) {
-        console.warn(`URL Load Failed: ${url}, Reason: ${e}`);
+        console.warn(`Page Load Failed: ${url}, Reason: ${e}`);
         await state._fail(url);
       }
     };


### PR DESCRIPTION
Only direct fetch URLs that have 200 responses, and don't set cookies, load all others in browser.
Improved error logging: don't log ERR_ABORTED if caused by loading of PDF/downloadable resource that is not a page.