### PR TITLE
Profile download support

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -63,8 +63,6 @@ class Crawler {
 
     this.debugLogging = this.params.logging.includes("debug");
 
-    this.profileDir = loadProfile(this.params.profile);
-
     if (this.params.profile) {
       this.statusLog("With Browser Profile: " + this.params.profile);
     }
@@ -372,6 +370,7 @@ class Crawler {
   }
 
   async crawl() {
+    this.profileDir = await loadProfile(this.params.profile);
 
     try {
       this.driver = require(this.params.driver);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "node-fetch": "^2.6.1",
     "puppeteer-cluster": "github:ikreymer/puppeteer-cluster#async-job-queue",
     "puppeteer-core": "^13.3.2",
+    "request": "^2.88.2",
     "sitemapper": "^3.1.2",
     "uuid": "8.3.2",
     "warcio": "^1.5.0",

--- a/util/browser.js
+++ b/util/browser.js
@@ -6,6 +6,16 @@ const os = require("os");
 const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "profile-"));
 
 module.exports.loadProfile = function(profileFilename) {
+  if (profileFilename &&
+      (profileFilename.startsWith("http:") || profileFilename.startsWith("https:"))) {
+    request.get(profileFilename).on("error", (err) => {
+      console.error(err);
+      throw Error("Unable to load profile: " + profileFilename);
+    }).pipe(fs.createWriteStream("/tmp/profile.tar.gz"));
+
+    profileFilename = "/tmp/profile.tar.gz";
+  }
+
   if (profileFilename) {
     child_process.execSync("tar xvfz " + profileFilename, {cwd: profileDir});
   }

--- a/util/browser.js
+++ b/util/browser.js
@@ -2,6 +2,7 @@ const child_process = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const request = require("request");
 
 const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "profile-"));
 


### PR DESCRIPTION
If `--profile` is an http/https URL, eg. `--profile https://example.com/path/to/profile.tar.gz`, support downloading the profile to a local directory first.