### PR TITLE
Better check to see if ERR_ABORTED should be ignored.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.5.0-beta.5",
+  "version": "0.5.0-beta.6",
   "main": "browsertrix-crawler",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",
   "author": "Ilya Kreymer <ikreymer@gmail.com>, Webrecorder Software",


### PR DESCRIPTION
Fix possible regression with `req.failure()` returning null, also move to separate function.
bump to 0.5.0-beta.6