### PR TITLE
Health Check + Size Limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Browsertrix Crawler includes a number of additional command-line options, explai
       --crawlId, --id                       A user provided ID for this crawl or
                                             crawl configuration (can also be set
                                             via CRAWL_ID env var)
-                                              [string] [default: "4dd1535f7800"]
+                                              [string] [default: <hostname> or CRAWL_ID env variable]
       --newContext                          The context for each new capture,
                                             can be a new: page, window, session
                                             or browser.
@@ -75,6 +75,9 @@ Browsertrix Crawler includes a number of additional command-line options, explai
                                                   [default: "load,networkidle2"]
       --depth                               The depth of the crawl for all seeds
                                                           [number] [default: -1]
+      --extraHops                           Number of extra 'hops' to follow,
+                                            beyond the current scope
+                                                           [number] [default: 0]
       --limit                               Limit crawl to this number of pages
                                                            [number] [default: 0]
       --timeout                             Timeout for each page to load (in
@@ -82,7 +85,8 @@ Browsertrix Crawler includes a number of additional command-line options, explai
       --scopeType                           A predfined scope of the crawl. For
                                             more customization, use 'custom' and
                                             set scopeIncludeRx regexes
-       [string] [choices: "page", "page-spa", "prefix", "host", "domain", "any", "custom"]
+       [string] [choices: "page", "page-spa", "prefix", "host", "domain", "any",
+                                                                       "custom"]
       --scopeIncludeRx, --include           Regex of page URLs that should be
                                             included in the crawl (defaults to
                                             the immediate directory of URL)
@@ -103,7 +107,7 @@ Browsertrix Crawler includes a number of additional command-line options, explai
   -c, --collection                          Collection name to crawl to (replay
                                             will be accessible under this name
                                             in pywb preview)
-                               [string] [default: "capture-YYYY-MM-DDThh:mm:ss"]
+                                                 [string] [default: "crawl-@ts"]
       --headless                            Run in headless mode, otherwise
                                             start xvfb[boolean] [default: false]
       --driver                              JS driver for the crawler
@@ -157,6 +161,10 @@ Browsertrix Crawler includes a number of additional command-line options, explai
                                             an HTTP server with screencast
                                             accessible on this port
                                                            [number] [default: 0]
+      --screencastRedis                     If set, will use the state store
+                                            redis pubsub for screencasting.
+                                            Requires --redisStoreUrl to be set
+                                                      [boolean] [default: false]
       --warcInfo, --warcinfo                Optional fields added to the
                                             warcinfo record in combined WARCs
       --redisStoreUrl                       If set, url for remote redis server
@@ -167,6 +175,25 @@ Browsertrix Crawler includes a number of additional command-line options, explai
                                             Defaults to 'partial', only saved
                                             when crawl is interrupted
            [string] [choices: "never", "partial", "always"] [default: "partial"]
+      --saveStateInterval                   If save state is set to 'always',
+                                            also save state during the crawl at
+                                            this interval (in seconds)
+                                                         [number] [default: 300]
+      --saveStateHistory                    Number of save states to keep during
+                                            the duration of a crawl
+                                                           [number] [default: 5]
+      --sizeLimit                           If set, save state and exit if size
+                                            limit exceeds this value
+                                                           [number] [default: 0]
+      --timeLimit                           If set, save state and exit after
+                                            time limit, in seconds
+                                                           [number] [default: 0]
+      --healthCheckPort                     port to run healthcheck on
+                                                           [number] [default: 0]
+      --overwrite                           overwrite current crawl data: if
+                                            set, existing collection directory
+                                            will be deleted before crawl is
+                                            started   [boolean] [default: false]
       --config                              Path to YAML config file
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -39,9 +39,13 @@ Here's how you can use some of the command-line options to configure the crawl:
 
 - To limit the crawl to a maximum number of pages, add `--limit P` where P is the number of pages that will be crawled.
 
+- To limit the crawl to a maximum size, set `--sizeLimit` (size in bytes)
+
+- To limit the crawl time, set `--timeLimit` (in seconds)
+
 - To run more than one browser worker and crawl in parallel, and `--workers N` where N is number of browsers to run in parallel. More browsers will require more CPU and network bandwidth, and does not guarantee faster crawling.
 
-- To crawl into a new directory, specify a different name for the `--collection` param, or, if omitted, a new collection directory based on current time will be created.
+- To crawl into a new directory, specify a different name for the `--collection` param, or, if omitted, a new collection directory based on current time will be created. Adding the `--overwrite` flag will delete the collection directory at the start of the crawl, if it exists.
 
 Browsertrix Crawler includes a number of additional command-line options, explained below.
 

--- a/crawler.js
+++ b/crawler.js
@@ -376,15 +376,15 @@ class Crawler {
     const pathname = url.parse(req.url).pathname;
     switch (pathname) {
     case "/healthz":
-      if (this.errorCount <= threshold) {
-        console.log("health check succeeds", this.errorCount);
+      if (this.errorCount < threshold) {
+        console.log(`health check ok, num errors ${this.errorCount} < ${threshold}`);
         res.writeHead(200);
         res.end();
       }
       return;
     }
 
-    console.log("health check failed", this.errorCount);
+    console.log(`health check failed: ${this.errorCount} >= ${threshold}`);
     res.writeHead(503);
     res.end();
   }
@@ -397,8 +397,8 @@ class Crawler {
 
       const size = await getDirSize(dir);
 
-      if (size >= this.params.sizeLimit) {
-        console.log(`Size threshold reached ${size} >= ${this.params.sizeLimit}, interrupting`);
+      if (size >= this.params.interruptSize) {
+        console.log(`Size threshold reached ${size} >= ${this.params.interruptSize}, interrupting`);
         interrupt = true;
       }
     }
@@ -406,7 +406,7 @@ class Crawler {
     if (this.params.interruptTime) {
       const elapsed = (Date.now() - this.startTime) / 1000;
       if (elapsed > this.params.interruptTime) {
-        console.log(`Time threadshold reached ${elapsed} > ${this.params.interruptTime}, interrupting`);
+        console.log(`Time threshold reached ${elapsed} > ${this.params.interruptTime}, interrupting`);
         interrupt = true;
       }
     }

--- a/crawler.js
+++ b/crawler.js
@@ -51,7 +51,6 @@ class Crawler {
     this.pagesFH = null;
 
     this.crawlId = process.env.CRAWL_ID || os.hostname();
-    this.uploadDir = "data/@id/";
 
     this.startTime = Date.now();
 
@@ -566,7 +565,7 @@ class Crawler {
     if (this.storage) {
       const finished = await this.crawlState.finished();
       const filename = process.env.STORE_FILENAME || "@ts-@id.wacz";
-      const targetFilename = interpolateFilename(this.uploadDir + filename, this.crawlId);
+      const targetFilename = interpolateFilename(filename, this.crawlId);
 
       await this.storage.uploadCollWACZ(waczPath, targetFilename, finished);
     }
@@ -1037,8 +1036,8 @@ class Crawler {
       }
     }
 
-    if (this.storage && done) {
-      const targetFilename = interpolateFilename(this.uploadDir + filenameOnly, this.crawlId);
+    if (this.storage && done && this.params.saveState === "always") {
+      const targetFilename = interpolateFilename(filenameOnly, this.crawlId);
 
       await this.storage.uploadFile(filename, targetFilename);
     }

--- a/create-login-profile.js
+++ b/create-login-profile.js
@@ -213,7 +213,7 @@ async function createProfile(params, browser, page, targetFilename = "") {
   const storage = initStorage();
   if (storage) {
     console.log("Uploading to remote storage...");
-    resource = await storage.uploadFile(profileFilename, "profiles/" + targetFilename);
+    resource = await storage.uploadFile(profileFilename, targetFilename);
   }
 
   console.log("done");

--- a/create-login-profile.js
+++ b/create-login-profile.js
@@ -210,10 +210,10 @@ async function createProfile(params, browser, page, targetFilename = "") {
 
   let resource = {};
 
-  const storage = initStorage("profiles/");
+  const storage = initStorage();
   if (storage) {
     console.log("Uploading to remote storage...");
-    resource = await storage.uploadFile(profileFilename, targetFilename);
+    resource = await storage.uploadFile(profileFilename, "profiles/" + targetFilename);
   }
 
   console.log("done");
@@ -296,6 +296,7 @@ class InteractiveBrowser {
     const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
     const pathname = parsedUrl.pathname;
     let targetUrl;
+    let origins;
 
     switch (pathname) {
     case "/":
@@ -310,8 +311,11 @@ class InteractiveBrowser {
         this.shutdownTimer = setTimeout(() => process.exit(0), this.shutdownWait);
         console.log(`Ping received, delaying shutdown for ${this.shutdownWait}ms`);
       }
+
+      origins = Array.from(this.originSet.values());
+
       res.writeHead(200, {"Content-Type": "application/json"});
-      res.end(JSON.stringify({"pong": true}));
+      res.end(JSON.stringify({"pong": true, origins}));
       return;
 
     case "/target":
@@ -325,7 +329,6 @@ class InteractiveBrowser {
       }
 
       try {
-
         const buffers = [];
 
         for await (const chunk of req) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.6.0-beta.0",
+  "version": "0.6.0-beta.1",
   "main": "browsertrix-crawler",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",
   "author": "Ilya Kreymer <ikreymer@gmail.com>, Webrecorder Software",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "browsertrix-behaviors": "^0.3.0",
+    "get-folder-size": "2",
     "ioredis": "^4.27.1",
     "js-yaml": "^4.1.0",
     "minio": "7.0.26",

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -257,6 +257,12 @@ class ArgParser {
         default: 5,
       },
 
+      "sizeLimit": {
+        describe: "If set, save state and exit if size limit exceeds this value",
+        type: "number",
+        default: 0,
+      },
+
       "healthCheckPort": {
         describe: "port to run healthcheck on",
         type: "number",

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -255,6 +255,12 @@ class ArgParser {
         describe: "Number of save states to keep during the duration of a crawl",
         type: "number",
         default: 5,
+      },
+
+      "healthCheckPort": {
+        describe: "port to run healthcheck on",
+        type: "number",
+        default: 0,
       }
     };
   }

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -11,6 +11,7 @@ const { hideBin } = require("yargs/helpers");
 const { NewWindowPage} = require("./screencaster");
 const { BEHAVIOR_LOG_FUNC, WAIT_UNTIL_OPTS } = require("./constants");
 const { ScopedSeed } = require("./seeds");
+const { interpolateFilename } = require("./storage");
 
 
 // ============================================================================
@@ -114,7 +115,7 @@ class ArgParser {
         alias: "c",
         describe: "Collection name to crawl to (replay will be accessible under this name in pywb preview)",
         type: "string",
-        default: `capture-${new Date().toISOString().slice(0,19)}`.replace(/:/g, "-")
+        default: "crawl-@ts"
       },
 
       "headless": {
@@ -257,8 +258,14 @@ class ArgParser {
         default: 5,
       },
 
-      "sizeLimit": {
+      "interruptSize": {
         describe: "If set, save state and exit if size limit exceeds this value",
+        type: "number",
+        default: 0,
+      },
+
+      "interruptTime": {
+        describe: "If set, save state and exit after time limit, in seconds",
         type: "number",
         default: 0,
       },
@@ -298,6 +305,8 @@ class ArgParser {
 
 
   validateArgs(argv) {
+    argv.collection = interpolateFilename(argv.collection, argv.crawlId);
+
     // Check that the collection name is valid.
     if (argv.collection.search(/^[\w][\w-]*$/) === -1){
       throw new Error(`\n${argv.collection} is an invalid collection name. Please supply a collection name only using alphanumeric characters and the following characters [_ - ]\n`);

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -258,13 +258,13 @@ class ArgParser {
         default: 5,
       },
 
-      "interruptSize": {
+      "sizeLimit": {
         describe: "If set, save state and exit if size limit exceeds this value",
         type: "number",
         default: 0,
       },
 
-      "interruptTime": {
+      "timeLimit": {
         describe: "If set, save state and exit after time limit, in seconds",
         type: "number",
         default: 0,
@@ -274,7 +274,13 @@ class ArgParser {
         describe: "port to run healthcheck on",
         type: "number",
         default: 0,
-      }
+      },
+
+      "overwrite": {
+        describe: "overwrite current crawl data: if set, existing collection directory will be deleted before crawl is started",
+        type: "boolean",
+        default: false
+      },
     };
   }
 

--- a/util/browser.js
+++ b/util/browser.js
@@ -91,8 +91,9 @@ module.exports.chromeArgs = (proxy, userAgent=null, extraArgs=[]) => {
     "--no-xshm", // needed for Chrome >80 (check if puppeteer adds automatically)
     "--no-sandbox",
     "--disable-background-media-suspend",
+    "--enable-features=NetworkService,NetworkServiceInProcess",
     "--autoplay-policy=no-user-gesture-required",
-    "--disable-features=Translate,LazyFrameLoading,IsolateOrigins,site-per-process",
+    "--disable-features=IsolateOrigins,site-per-process,ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,AcceptCHFrame,AutoExpandDetailsElement",
     "--disable-popup-blocking",
     "--disable-backgrounding-occluded-windows",
     `--user-agent=${userAgent || getDefaultUA()}`,

--- a/util/state.js
+++ b/util/state.js
@@ -274,7 +274,11 @@ return 0;
       data = JSON.parse(json);
     } catch(e) {
       console.error("Invalid queued json: ", json);
-      return;
+      return null;
+    }
+
+    if (!data) {
+      return null;
     }
 
     const url = data.url;

--- a/util/storage.js
+++ b/util/storage.js
@@ -9,6 +9,9 @@ const Minio = require("minio");
 
 const { initRedis } = require("./redis");
 
+const util = require("util");
+const getFolderSize = util.promisify(require("get-folder-size"));
+
 
 // ===========================================================================
 class S3StorageSync
@@ -146,6 +149,10 @@ async function getFileSize(filename) {
   return stats.size;
 }
 
+async function getDirSize(dir) {
+  return await getFolderSize(dir);
+}
+
 function checksumFile(hashName, path) {
   return new Promise((resolve, reject) => {
     const hash = createHash(hashName);
@@ -158,5 +165,6 @@ function checksumFile(hashName, path) {
 
 module.exports.S3StorageSync = S3StorageSync;
 module.exports.getFileSize = getFileSize;
+module.exports.getDirSize = getDirSize;
 module.exports.initStorage = initStorage;
 

--- a/util/storage.js
+++ b/util/storage.js
@@ -16,7 +16,7 @@ const getFolderSize = util.promisify(require("get-folder-size"));
 // ===========================================================================
 class S3StorageSync
 {
-  constructor(urlOrData, {filename, webhookUrl, userId, crawlId, prefix = ""} = {}) {
+  constructor(urlOrData, {webhookUrl, userId, crawlId} = {}) {
     let url;
     let accessKey;
     let secretKey;
@@ -56,23 +56,14 @@ class S3StorageSync
     this.userId = userId;
     this.crawlId = crawlId;
     this.webhookUrl = webhookUrl;
-
-    this.filenamePrefix = prefix;
-
-    filename = filename.replace("@ts", new Date().toISOString().replace(/[:TZz.]/g, ""));
-    filename = filename.replace("@hostname", os.hostname());
-    filename = filename.replace("@id", this.crawlId);
-
-    this.targetFilename = this.filenamePrefix + filename;
   }
 
   async uploadFile(srcFilename, targetFilename) {
-    // allow overriding targetFilename
-    if (targetFilename) {
-      targetFilename = this.filenamePrefix + targetFilename;
-    } else {
-      targetFilename = this.targetFilename;
-    }
+    console.log(`Bucket: ${this.bucketName}`);
+    console.log(`Crawl Id: ${this.crawlId}`);
+    console.log(`Prefix: ${this.objectPrefix}`);
+    console.log(`Target Filename: ${targetFilename}`);
+
     await this.client.fPutObject(this.bucketName, this.objectPrefix + targetFilename, srcFilename);
 
     const finalHash = await checksumFile("sha256", srcFilename);
@@ -85,8 +76,8 @@ class S3StorageSync
     await this.client.fGetObject(this.bucketName, this.objectPrefix + srcFilename, destFilename);
   }
 
-  async uploadCollWACZ(srcFilename, completed = true) {
-    const resource = await this.uploadFile(srcFilename, this.targetFilename);
+  async uploadCollWACZ(srcFilename, targetFilename, completed = true) {
+    const resource = await this.uploadFile(srcFilename, targetFilename);
     console.log(resource);
 
     if (this.webhookUrl) {
@@ -95,7 +86,7 @@ class S3StorageSync
         user: this.userId,
 
         //filename: `s3://${this.bucketName}/${this.objectPrefix}${this.waczFilename}`,
-        filename: this.fullPrefix + this.targetFilename,
+        filename: this.fullPrefix + targetFilename,
 
         hash: resource.hash,
         size: resource.bytes,
@@ -119,7 +110,7 @@ class S3StorageSync
   }
 }
 
-function initStorage(prefix = "") {
+function initStorage() {
   if (!process.env.STORE_ENDPOINT_URL) {
     return null;
   }
@@ -135,8 +126,6 @@ function initStorage(prefix = "") {
     crawlId: process.env.CRAWL_ID || os.hostname(),
     webhookUrl: process.env.WEBHOOK_URL,
     userId: process.env.STORE_USER,
-    prefix,
-    filename: process.env.STORE_FILENAME || "@ts-@id.wacz",
   };
 
   console.log("Initing Storage...");
@@ -163,8 +152,16 @@ function checksumFile(hashName, path) {
   });
 }
 
+function interpolateFilename(filename, crawlId) {
+  filename = filename.replace("@ts", new Date().toISOString().replace(/[:TZz.-]/g, ""));
+  filename = filename.replace("@hostname", os.hostname());
+  filename = filename.replace("@hostsuffix", os.hostname().slice(-14));
+  filename = filename.replace("@id", crawlId);
+  return filename;
+}
+
 module.exports.S3StorageSync = S3StorageSync;
 module.exports.getFileSize = getFileSize;
 module.exports.getDirSize = getDirSize;
 module.exports.initStorage = initStorage;
-
+module.exports.interpolateFilename = interpolateFilename;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,6 +2247,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+gar@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gar/-/gar-1.0.4.tgz#f777bc7db425c0572fdeb52676172ca1ae9888b8"
+  integrity sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -2256,6 +2261,14 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-folder-size@2:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-folder-size/-/get-folder-size-2.0.1.tgz#3fe0524dd3bad05257ef1311331417bcd020a497"
+  integrity sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==
+  dependencies:
+    gar "^1.0.4"
+    tiny-each-async "2.0.3"
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
@@ -5001,6 +5014,11 @@ through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tiny-each-async@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-each-async/-/tiny-each-async-2.0.3.tgz#8ebbbfd6d6295f1370003fbb37162afe5a0a51d1"
+  integrity sha1-jru/1tYpXxNwAD+7NxYq/loKUdE=
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
- Add optional health check via `--healthCheckPort`. If set, runs a server on designated port that returns 200 if healthcheck succeeds (num of consecutive failed page loads < 2*num workers), or 503 if fails. Useful for k8s health check

- Add crawl size limit (in bytes), via `--sizeLimit`. Crawl exits (and state optionally saved) when size limit is exceeded.

- Add crawl total time limit (in seconds), via `--timeLimit`. Crawl exists (and state optionally saved) when total running time is exceeded.
- Add option to overwrite existing collection. If `--overwrite` is included, any existing data for specified collection is deleted.

- S3 Storage refactor, simplify, don't add additional paths by default.
- Add interpolateFilename as generic utility, supported in filename and STORE_PATH env value.

- Profiles: support /navigate endpoint, return origins from /ping, prevent opening new tabs.

bump to 0.6.0-beta.1