### PR TITLE
0.6.0 Wait State + Screencasting Fixes

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -561,7 +561,9 @@ class Crawler {
 
   async redisStatusIncFailCount(count) {
     const key = `${this.crawlId}:status:failcount:${os.hostname()}`;
-    return (await this.crawlState.redis.incr(key)) > count;
+    const res = await this.crawlState.redis.incr(key);
+    await this.crawlState.redis.expire(key, 60);
+    return (res >= count);
   }
 
   async generateWACZ() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
   
 services:
     crawler:
-        image: webrecorder/browsertrix-crawler:latest
+        image: ${REGISTRY}webrecorder/browsertrix-crawler:latest
         build:
           context: ./
 

--- a/main.js
+++ b/main.js
@@ -33,7 +33,9 @@ process.on("SIGINT", async () => {
 });
 
 process.on("SIGUSR1", () => {
-  crawler.finalExit = true;
+  if (crawler) {
+    crawler.finalExit = true;
+  }
 });
 
 process.on("SIGTERM", async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0",
   "main": "browsertrix-crawler",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",
   "author": "Ilya Kreymer <ikreymer@gmail.com>, Webrecorder Software",

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -281,6 +281,12 @@ class ArgParser {
         type: "boolean",
         default: false
       },
+
+      "waitOnDone": {
+        describe: "if set, wait for interrupt signal when finished instead of exiting",
+        type: "boolean",
+        default: false
+      },
     };
   }
 

--- a/util/screencaster.js
+++ b/util/screencaster.js
@@ -190,12 +190,15 @@ class ScreenCaster
       const sessionId = resp.sessionId;
       const url = target.url();
 
-      this.caches.set(id, data);
-      this.urls.set(id, url);
+      // only send if already in map, otherwise probably already closed
+      if (this.urls.has(id)) {
+        this.caches.set(id, data);
+        this.urls.set(id, url);
 
-      //if (url !== "about:blank") {
-      await this.transport.sendAll({msg, id, data, url});
-      //}
+        //if (url !== "about:blank") {
+        await this.transport.sendAll({msg, id, data, url});
+        //}
+      }
 
       try {
         await cdp.send("Page.screencastFrameAck", {sessionId});

--- a/util/state.js
+++ b/util/state.js
@@ -51,6 +51,20 @@ class MemoryCrawlState extends BaseState
     this.queue = [];
     this.pending = new Map();
     this.done = [];
+    this.status = null;
+  }
+
+  setStatus(status) {
+    this.status = status;
+  }
+
+  getStatus() {
+    return this.status;
+  }
+
+  incFailCount() {
+    // memory-only state, no retries
+    return true;
   }
 
   push(job) {
@@ -165,12 +179,13 @@ class MemoryCrawlState extends BaseState
 // ============================================================================
 class RedisCrawlState extends BaseState
 {
-  constructor(redis, key, pageTimeout) {
+  constructor(redis, key, pageTimeout, uid) {
     super();
     this.redis = redis;
 
     this._lastSize = 0;
 
+    this.uid = uid;
     this.key = key;
     this.pageTimeout = pageTimeout / 1000;
 
@@ -270,6 +285,23 @@ return 0;
 
   async _fail(url) {
     return await this.redis.movedone(this.pkey, this.dkey, url, "1", "failed");
+  }
+
+  async setStatus(status_) {
+    await this.redis.hset(`${this.key}:status`, this.uid, status_);
+  }
+
+  async getStatus() {
+    return await this.redis.hget(`${this.key}:status`, this.uid);
+  }
+
+  async incFailCount() {
+    const key = `${this.key}:status:failcount:${this.uid}`;
+    const res = await this.redis.incr(key);
+
+    // consider failed if 3 failed retries in 60 secs
+    await this.redis.expire(key, 60);
+    return (res >= 3);
   }
 
   async push(job) {

--- a/util/state.js
+++ b/util/state.js
@@ -18,8 +18,8 @@ class BaseState
     return this.drainMax ? 0 : await this.realSize();
   }
 
-  async finished() {
-    return await this.realSize() == 0;
+  async isFinished() {
+    return (await this.realSize() == 0) && (await this.numDone() > 0);
   }
 
   async numSeen() {


### PR DESCRIPTION
Improvements to support parallel crawls:
- Add a `waitOnDone` option, which has browsertrix crawler wait when finished (for use with Browsertrix Cloud)
- When running with redis shared state, set the `<crawl id>:status` field to `running`, `failing`/`failed` or `done` to let job controller know crawl is finished.
- Set redis state to `failing` in case of exception, set to failed in case of >3 or more failed exits within 60 seconds (todo: make customizable)
- When receiving a SIGUSR1, don't wait on down (assume final exit due to scale down).

Screencasting Fixes:
- Don't end screencasting when page ends, only when target is destroyed
- Keep same screencasting connection from one page to next, as the target are reused in 'window' concurrency mode