### PR TITLE
Page-reuse concurrency + Browser Repair + Screencaster Cleanup Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "main": "browsertrix-crawler",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",
   "author": "Ilya Kreymer <ikreymer@gmail.com>, Webrecorder Software",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "minio": "7.0.26",
     "node-fetch": "^2.6.1",
     "puppeteer-cluster": "github:ikreymer/puppeteer-cluster#async-job-queue",
-    "puppeteer-core": "16.1.0",
+    "puppeteer-core": "^16.1.1",
     "request": "^2.88.2",
     "sitemapper": "^3.1.2",
     "uuid": "8.3.2",

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -8,7 +8,7 @@ const { Cluster } = require("puppeteer-cluster");
 const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
 
-const { NewWindowPage} = require("./screencaster");
+const { ReuseWindowConcurrency } = require("./windowconcur");
 const { BEHAVIOR_LOG_FUNC, WAIT_UNTIL_OPTS } = require("./constants");
 const { ScopedSeed } = require("./seeds");
 const { interpolateFilename } = require("./storage");
@@ -374,7 +374,7 @@ class ArgParser {
       argv.newContext = Cluster.CONCURRENCY_PAGE;
       if (argv.screencastPort && argv.workers > 1) {
         console.log("Note: to support screencasting with >1 workers, newContext set to 'window' instead of 'page'");
-        argv.newContext = NewWindowPage;
+        argv.newContext = ReuseWindowConcurrency;
       }
       break;
 
@@ -387,7 +387,7 @@ class ArgParser {
       break;
 
     case "window":
-      argv.newContext = NewWindowPage;
+      argv.newContext = ReuseWindowConcurrency;
       break;
 
     default:

--- a/util/screencaster.js
+++ b/util/screencaster.js
@@ -305,53 +305,56 @@ class NewWindowPage extends SingleBrowserImplementation {
     await super.init();
 
     this.pendingTargets = new Map();
-
-    this.mainPage = await this.browser.newPage();
+    this.startPage = "about:blank?_browsertrix" + Math.random().toString(36).slice(2);
 
     this.pages = [];
-    this.reuse = true;
+    this.reuseCount = 25;
 
-    this.storeTarget = 0;
-
-    //await this.mainPage.goto("about:blank");
-
-    this.mainTarget = this.mainPage.target();
-    this.cdp = await this.mainTarget.createCDPSession();
+    const mainTarget = this.browser.target();
+    this.cdp = await mainTarget.createCDPSession();
 
     this.browser.on("targetcreated", (target) => {
-      if (this.storeTarget && target.url() === "about:blank") {
-        console.log("target created", target._targetId, target);
+      if (target.url() === this.startPage) {
         this.pendingTargets.set(target._targetId, target);
       }
     });
   }
 
   async getNewPage() {
-    try {
-      this.storeTarget++;
-      const {targetId} = await this.cdp.send("Target.createTarget", {url: "about:blank", newWindow: true});
-      this.storeTarget--;
+    while (true) {
+      let targetId;
+      try {
+        const res = await this.cdp.send("Target.createTarget", {url: this.startPage, newWindow: true});
+        targetId = res.targetId;
+      } catch (e) {
+        console.warn(e);
+        return null;
+      }
 
       const target = this.pendingTargets.get(targetId);
+      // this shouldn't really happen, but just in case somehow ended up w/o a target, try again
+      if (!target) {
+        continue;
+      }
+
       this.pendingTargets.delete(targetId);
 
-      return {page: await target.page() };
-    } catch (e) {
-      console.log(e);
+      return {page: await target.page(), count: 0};
     }
   }
 
   async createResources() {
     if (this.pages.length) {
-      return {page: this.pages.shift()};
+      return this.pages.shift();
     }
     return await this.getNewPage();
   }
 
   async freeResources(resources) {
-    if (this.reuse) {
-      this.pages.push(resources.page);
+    if (++resources.count <= this.reuseCount) {
+      this.pages.push(resources);
     } else {
+      //console.log(`page not reused, ${this.reuseCount} reached`);
       await resources.page.close();
     }
   }

--- a/util/screencaster.js
+++ b/util/screencaster.js
@@ -6,9 +6,6 @@ const path = require("path");
 
 const { initRedis } = require("./redis");
 
-
-const SingleBrowserImplementation = require("puppeteer-cluster/dist/concurrency/SingleBrowserImplementation").default;
-
 const indexHTML = fs.readFileSync(path.join(__dirname, "..", "html", "screencast.html"), {encoding: "utf8"});
 
 
@@ -298,68 +295,4 @@ class ScreenCaster
   }
 }
 
-
-// ===========================================================================
-class NewWindowPage extends SingleBrowserImplementation {
-  async init() {
-    await super.init();
-
-    this.pendingTargets = new Map();
-    this.startPage = "about:blank?_browsertrix" + Math.random().toString(36).slice(2);
-
-    this.pages = [];
-    this.reuseCount = 25;
-
-    const mainTarget = this.browser.target();
-    this.cdp = await mainTarget.createCDPSession();
-
-    this.browser.on("targetcreated", (target) => {
-      if (target.url() === this.startPage) {
-        this.pendingTargets.set(target._targetId, target);
-      }
-    });
-  }
-
-  async getNewPage() {
-    while (true) {
-      let targetId;
-      try {
-        const res = await this.cdp.send("Target.createTarget", {url: this.startPage, newWindow: true});
-        targetId = res.targetId;
-      } catch (e) {
-        console.warn(e);
-        return null;
-      }
-
-      const target = this.pendingTargets.get(targetId);
-      // this shouldn't really happen, but just in case somehow ended up w/o a target, try again
-      if (!target) {
-        continue;
-      }
-
-      this.pendingTargets.delete(targetId);
-
-      return {page: await target.page(), count: 0};
-    }
-  }
-
-  async createResources() {
-    if (this.pages.length) {
-      return this.pages.shift();
-    }
-    return await this.getNewPage();
-  }
-
-  async freeResources(resources) {
-    if (++resources.count <= this.reuseCount) {
-      this.pages.push(resources);
-    } else {
-      //console.log(`page not reused, ${this.reuseCount} reached`);
-      await resources.page.close();
-    }
-  }
-}
-
-
-
-module.exports = { ScreenCaster, NewWindowPage, WSTransport, RedisPubSubTransport };
+module.exports = { ScreenCaster, WSTransport, RedisPubSubTransport };

--- a/util/windowconcur.js
+++ b/util/windowconcur.js
@@ -1,0 +1,67 @@
+const SingleBrowserImplementation = require("puppeteer-cluster/dist/concurrency/SingleBrowserImplementation").default;
+
+
+// ===========================================================================
+class ReuseWindowConcurrency extends SingleBrowserImplementation {
+  async init() {
+    await super.init();
+
+    this.pendingTargets = new Map();
+    this.startPage = "about:blank?_browsertrix" + Math.random().toString(36).slice(2);
+
+    this.pages = [];
+    this.reuseCount = 25;
+
+    const mainTarget = this.browser.target();
+    this.cdp = await mainTarget.createCDPSession();
+
+    this.browser.on("targetcreated", (target) => {
+      if (target.url() === this.startPage) {
+        this.pendingTargets.set(target._targetId, target);
+      }
+    });
+  }
+
+  async getNewPage() {
+    while (true) {
+      let targetId;
+      try {
+        const res = await this.cdp.send("Target.createTarget", {url: this.startPage, newWindow: true});
+        targetId = res.targetId;
+      } catch (e) {
+        console.warn(e);
+        return null;
+      }
+
+      const target = this.pendingTargets.get(targetId);
+      // this shouldn't really happen, but just in case somehow ended up w/o a target, try again
+      if (!target) {
+        continue;
+      }
+
+      this.pendingTargets.delete(targetId);
+
+      return {page: await target.page(), count: 0};
+    }
+  }
+
+  async createResources() {
+    if (this.pages.length) {
+      return this.pages.shift();
+    }
+    return await this.getNewPage();
+  }
+
+  async freeResources(resources) {
+    if (++resources.count <= this.reuseCount) {
+      this.pages.push(resources);
+    } else {
+      //console.log(`page not reused, ${this.reuseCount} reached`);
+      await resources.page.close();
+    }
+  }
+}
+
+module.exports = { ReuseWindowConcurrency };
+
+

--- a/util/windowconcur.js
+++ b/util/windowconcur.js
@@ -12,14 +12,54 @@ class ReuseWindowConcurrency extends SingleBrowserImplementation {
     this.pages = [];
     this.reuseCount = 25;
 
+    this.screencaster = null;
+
     const mainTarget = this.browser.target();
+
     this.cdp = await mainTarget.createCDPSession();
+    this.sessionId = this.cdp.id();
 
     this.browser.on("targetcreated", (target) => {
       if (target.url() === this.startPage) {
         this.pendingTargets.set(target._targetId, target);
       }
     });
+  }
+
+  setScreencaster(screencaster) {
+    this.screencaster = screencaster;
+  }
+
+  async repair() {
+    if (this.openInstances !== 0 || this.repairing) {
+      // already repairing or there are still pages open? wait for start/finish
+      await new Promise(resolve => this.waitingForRepairResolvers.push(resolve));
+      return;
+    }
+
+    this.repairing = true;
+    console.debug("Starting repair");
+
+    if (this.screencaster) {
+      this.screencaster.endAllTargets();
+    }
+
+    try {
+      // will probably fail, but just in case the repair was not necessary
+      await this.browser.close();
+    } catch (e) {
+      console.debug("Unable to close browser.");
+    }
+
+    try {
+      await this.init();
+    } catch (err) {
+      console.debug("Unable to restart chrome.");
+    }
+    this.repairRequested = false;
+    this.repairing = false;
+    this.waitingForRepairResolvers.forEach(resolve => resolve());
+    this.waitingForRepairResolvers = [];
   }
 
   async getNewPage() {
@@ -30,7 +70,7 @@ class ReuseWindowConcurrency extends SingleBrowserImplementation {
         targetId = res.targetId;
       } catch (e) {
         console.warn(e);
-        return null;
+        await this.repair();
       }
 
       const target = this.pendingTargets.get(targetId);
@@ -41,23 +81,31 @@ class ReuseWindowConcurrency extends SingleBrowserImplementation {
 
       this.pendingTargets.delete(targetId);
 
-      return {page: await target.page(), count: 0};
+      return {page: await target.page(), count: 0, id: this.sessionId};
     }
   }
 
   async createResources() {
     if (this.pages.length) {
-      return this.pages.shift();
+      const res = this.pages.shift();
+      if (res.id === this.sessionId) {
+        return res;
+      } else {
+        // page is using stale session (eg. from crashed/previous browser instance), don't attempt to reuse
+      }
     }
     return await this.getNewPage();
   }
 
   async freeResources(resources) {
-    if (++resources.count <= this.reuseCount) {
-      this.pages.push(resources);
-    } else {
-      //console.log(`page not reused, ${this.reuseCount} reached`);
+    // if marked as failed, don't try to reuse
+    if (resources.page.__failed) {
       await resources.page.close();
+    }
+    if (++resources.count > this.reuseCount) {
+      await resources.page.close();
+    } else {
+      this.pages.push(resources);
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,10 +4246,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   dependencies:
     debug "^4.1.1"
 
-puppeteer-core@^16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-16.1.0.tgz#0485312363e6e1d65889d4b31de677bd36f872e4"
-  integrity sha512-Eu9FCqdWU2PU/RY53sa+JTsbFiQg5fJyaHX5DP0WZ4+lVLVdMfR9dwPimRkSl9NEcArm7lZMpiDlVCYelE90ZA==
+puppeteer-core@^16.1.1:
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-16.1.1.tgz#2c26c560934a1c524a767c9ec0818520b7adb22a"
+  integrity sha512-ls+A6t+cbeNtsNIEyWkGoVJRHseEvBhS3NlI2DBFaJNBUG6kUfmAVyColu1ubgy4VuWLKpGUcwrPTVIvNd1Dew==
   dependencies:
     cross-fetch "3.1.5"
     debug "4.3.4"


### PR DESCRIPTION
Various improvements to opening multiple windows + recovering from errors, likely fix for #156, which was occurring more generally:
- Call CDP command to open a window specifically in new window, avoid creating separate window and using `window.open`. Ensure window is always created
- Repair capability: if CDP new window creation fails, likely something wrong, repair browser session by recreating browser in puppeteer. Mark existing pages as invalid
- Page reuse flexibility: Instead of always reusing existing pages, have a max reuse number (25 page by default), also don't reuse pages if browser is repaired, or page load failure occurs (eg. cdp connection error), but *not* a regular timeout.
- Screencaster cleanup: when a page fails, or browser is repaired, cleanup all cached targets in screencaster, to avoid sending stale data.
- Rename NewWindowPage -> ReuseWindowConcurrency and move to windowconcur.js
- bump to 0.7.0-beta.3