### PR TITLE
Interrupt Handling Fixes

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -353,7 +353,7 @@ class Crawler {
     const {page, data} = opts;
 
     if (!this.isInScope(data)) {
-      console.log(`No longer in scope: ${data}`);
+      console.log(`No longer in scope: ${JSON.stringify(data)}`);
       return;
     }
 

--- a/util/seeds.js
+++ b/util/seeds.js
@@ -119,6 +119,10 @@ class ScopedSeed
 
     url = url.href;
 
+    if (url === this.url) {
+      return true;
+    }
+
     // skip already crawled
     // if (this.seenList.has(url)) {
     //  return false;


### PR DESCRIPTION
Improvements to interrupt handling, for Browsertrix Cloud
- Scope check performed on each URL before starting crawl, in case crawl scope has changed
- SIGUSR1 waits for page to finish, marks crawler as done, to prevent restart (for full crawl stop)
- SIGUSR2 waits for page to finish, exits immediately (for scale-down)