### PR TITLE
Run in Docker as User

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,8 @@ RUN ln -s /app/main.js /usr/bin/crawl; ln -s /app/create-login-profile.js /usr/b
 
 WORKDIR /crawls
 
+ADD docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 CMD ["crawl"]
 

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ The script profile creation system also take a screenshot so you can check if th
 For example, to create a profile logged in to Twitter, you can run:
 
 ```bash
-docker run -v $PWD/crawls/profiles:/output/ -it webrecorder/browsertrix-crawler create-login-profile --url "https://twitter.com/login"
+docker run -v $PWD/crawls/profiles:/crawls/profiles -it webrecorder/browsertrix-crawler create-login-profile --url "https://twitter.com/login"
 ```
 
 The script will then prompt you for login credentials, attempt to login and create a tar.gz file in `./crawls/profiles/profile.tar.gz`.
@@ -582,7 +582,7 @@ Browsertrix Crawler will then create a profile as before using the current state
 For example, to start in interactive profile creation mode, run:
 
 ```
-docker run -p 9222:9222 -p 9223:9223 -v $PWD/crawls/profiles:/output/ -it webrecorder/browsertrix-crawler create-login-profile --interactive --url "https://example.com/"
+docker run -p 9222:9222 -p 9223:9223 -v $PWD/crawls/profiles:/crawls/profiles/ -it webrecorder/browsertrix-crawler create-login-profile --interactive --url "https://example.com/"
 ```
 
 Then, open a browser pointing to `http://localhost:9223/` and use the embedded browser to log in to any sites or configure any settings as needed.
@@ -591,7 +591,7 @@ Click 'Create Profile at the top when done. The profile will then be created in 
 It is also possible to extend an existing profiles by also passing in an existing profile via the `--profile` flag. In this way, it is possible to build new profiles by extending previous browsing sessions as needed.
 
 ```
-docker run -p 9222:9222 -p 9223:9223 -v $PWD/crawls/profiles:/profiles --filename /profiles/newProfile.tar.gz -it webrecorder/browsertrix-crawler create-login-profile --interactive --url "https://example.com/ --profile /profiles/oldProfile.tar.gz"
+docker run -p 9222:9222 -p 9223:9223 -v $PWD/crawls/profiles:/crawls/profiles -it webrecorder/browsertrix-crawler create-login-profile --interactive --url "https://example.com/ --filename /crawls/profiles/newProfile.tar.gz --profile /crawls/profiles/oldProfile.tar.gz"
 ```
 
 ### Using Browser Profile with a Crawl

--- a/create-login-profile.js
+++ b/create-login-profile.js
@@ -213,7 +213,7 @@ async function createProfile(params, browser, page, targetFilename = "") {
  
   const outputDir = path.dirname(profileFilename);
   if (outputDir && !fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, {recursive: true})
+    fs.mkdirSync(outputDir, {recursive: true});
   }
 
   saveProfile(profileFilename);

--- a/create-login-profile.js
+++ b/create-login-profile.js
@@ -34,7 +34,7 @@ function cliOpts() {
 
     "filename": {
       describe: "The filename for the profile tarball",
-      default: "/output/profile.tar.gz",
+      default: "/crawls/profiles/profile.tar.gz",
     },
 
     "debugScreenshot": {
@@ -209,7 +209,12 @@ async function createProfile(params, browser, page, targetFilename = "") {
 
   console.log("creating profile");
 
-  const profileFilename = params.filename || "/output/profile.tar.gz";
+  const profileFilename = params.filename || "/crawls/profiles/profile.tar.gz";
+ 
+  const outputDir = path.dirname(profileFilename);
+  if (outputDir && !fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, {recursive: true})
+  }
 
   saveProfile(profileFilename);
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+# Get UID/GID from volume dir
+VOLUME_UID=$(stat -c '%u' /crawls)
+VOLUME_GID=$(stat -c '%g' /crawls)
+
+MY_UID=$(id -u)
+MY_GID=$(id -g)
+
+# Run as custom user
+if [ "$MY_GID" != "$VOLUME_GID" ] || [ "$MY_UID" != "$VOLUME_UID" ]; then
+    # create or modify user and group to match expected uid/gid
+    groupadd --gid $VOLUME_GID archivist || groupmod -o --gid $VOLUME_GID archivist
+    useradd -ms /bin/bash -u $VOLUME_UID -g $VOLUME_GID archivist || usermod -o -u $VOLUME_UID archivist
+
+    cmd="cd $PWD; $@"
+
+    # run process as new archivist user
+    su archivist -c "$cmd"
+
+# run as current user (root)
+else
+    exec $@
+fi
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.7.0-beta.5",
+  "version": "0.7.0-beta.6",
   "main": "browsertrix-crawler",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",
   "author": "Ilya Kreymer <ikreymer@gmail.com>, Webrecorder Software",


### PR DESCRIPTION
This follows a [similar pattern]( https://github.com/webrecorder/pywb/blob/main/docker-entrypoint.sh) to pywb to ensure that the crawler is run as the user that owns the crawls directory. This will make sure that the files that are created will be owned by that user.

I've updated `create-login-profile.js` to use `/crawls/profiles/` instead of `/output/` as the default location to write the profile to. This simplifies the permissions issue introduced by this change, since `docker-entrypoint.sh` doesn't need to look for it. If the directory doesn't exist it will create it.

I've also updated the docs to reflect this change to profile creation, and noticed a small bug in the command line argument ordering for the profile extension example (I think that `--profile` needs to appear after `create-login-profile`).

It's possible that this could impact code that is using browsertrix-crawler, like browsertrix-cloud perhaps?

Closes #170