### PR TITLE
Guard against pre-existing user/group

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,26 +1,27 @@
 #!/bin/sh
 
-set -e
-
 # Get UID/GID from volume dir
+
 VOLUME_UID=$(stat -c '%u' /crawls)
 VOLUME_GID=$(stat -c '%g' /crawls)
+
+# Get the UID/GID we are running as
 
 MY_UID=$(id -u)
 MY_GID=$(id -g)
 
-# Run as custom user
+# If we aren't running as the owner of the /crawls/ dir then add a new user
+# btrix with the same UID/GID of the /crawls dir and run as that user instead.
+
 if [ "$MY_GID" != "$VOLUME_GID" ] || [ "$MY_UID" != "$VOLUME_UID" ]; then
-    # create or modify user and group to match expected uid/gid
-    groupadd --gid $VOLUME_GID archivist || groupmod -o --gid $VOLUME_GID archivist
-    useradd -ms /bin/bash -u $VOLUME_UID -g $VOLUME_GID archivist || usermod -o -u $VOLUME_UID archivist
+    groupadd btrix
+    groupmod -o --gid $VOLUME_GID btrix
+
+    useradd -ms /bin/bash -g $VOLUME_GID btrix
+    usermod -o -u $VOLUME_UID btrix > /dev/null
 
     cmd="cd $PWD; $@"
-
-    # run process as new archivist user
-    su archivist -c "$cmd"
-
-# run as current user (root)
+    su btrix -c "$cmd"
 else
     exec $@
 fi


### PR DESCRIPTION
The entrypoint does a bit of work to ensure that files that are written to the /crawls/ directory are owned by the user that owns it, rather than as root. This works by creating a new user/group for the uid/gid that owns /crawls in situations where the owner of /crawls is different than the user we are running as. However we also need to check if the UID/GID that owns /crawls/ already exists. If it does then we run as the user that owns it. Otherwise we create a new user with that UID/GID and run as them. 

Also, warcio.js needed to be pinned since the latest version is an ES module, that requires other changes in browsertrix-crawler.

Closes #174
Closes #175 
