### PR TITLE
Add screenshot functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,145 +60,162 @@ Browsertrix Crawler includes a number of additional command-line options, explai
       --version                             Show version number        [boolean]
       --seeds, --url                        The URL to start crawling from
                                                            [array] [default: []]
-      --seedFile, --urlFile                 If set, read a list of seed urls,
-                                            one per line, from the specified
+      --seedFile, --urlFile                 If set, read a list of seed urls, on
+                                            e per line, from the specified
                                                                         [string]
-  -w, --workers                             The number of workers to run in
-                                            parallel       [number] [default: 1]
+  -w, --workers                             The number of workers to run in para
+                                            llel           [number] [default: 1]
       --crawlId, --id                       A user provided ID for this crawl or
-                                            crawl configuration (can also be set
-                                            via CRAWL_ID env var)
-                                              [string] [default: <hostname> or CRAWL_ID env variable]
-      --newContext                          The context for each new capture,
-                                            can be a new: page, window, session
-                                            or browser.
-                                                      [string] [default: "page"]
-      --waitUntil                           Puppeteer page.goto() condition to
-                                            wait for before continuing, can be
-                                            multiple separate by ','
-                                                  [default: "load,networkidle2"]
+                                             crawl configuration (can also be se
+                                            t via CRAWL_ID env var)
+                                              [string] [default: "06bf9a4df9f7"]
+      --newContext                          Deprecated as of 0.8.0, any values p
+                                            assed will be ignored
+                                                        [string] [default: null]
+      --waitUntil                           Puppeteer page.goto() condition to w
+                                            ait for before continuing, can be mu
+                                            ltiple separate by ','
+                                                               [default: "load"]
       --depth                               The depth of the crawl for all seeds
                                                           [number] [default: -1]
-      --extraHops                           Number of extra 'hops' to follow,
-                                            beyond the current scope
+      --extraHops                           Number of extra 'hops' to follow, be
+                                            yond the current scope
                                                            [number] [default: 0]
       --limit                               Limit crawl to this number of pages
                                                            [number] [default: 0]
-      --timeout                             Timeout for each page to load (in
-                                            seconds)      [number] [default: 90]
+      --timeout                             Timeout for each page to load (in se
+                                            conds)        [number] [default: 90]
       --scopeType                           A predfined scope of the crawl. For
                                             more customization, use 'custom' and
-                                            set scopeIncludeRx regexes
-       [string] [choices: "page", "page-spa", "prefix", "host", "domain", "any",
-                                                                       "custom"]
-      --scopeIncludeRx, --include           Regex of page URLs that should be
-                                            included in the crawl (defaults to
-                                            the immediate directory of URL)
-      --scopeExcludeRx, --exclude           Regex of page URLs that should be
-                                            excluded from the crawl.
-      --allowHashUrls                       Allow Hashtag URLs, useful for
-                                            single-page-application crawling or
-                                            when different hashtags load dynamic
-                                            content
-      --blockRules                          Additional rules for blocking
-                                            certain URLs from being loaded, by
-                                            URL regex and optionally via text
-                                            match in an iframe
-                                                           [array] [default: []]
+                                             set scopeIncludeRx regexes
+  [string] [choices: "page", "page-spa", "prefix", "host", "domain", "any", "cus
+                                                                           tom"]
+      --scopeIncludeRx, --include           Regex of page URLs that should be in
+                                            cluded in the crawl (defaults to the
+                                             immediate directory of URL)
+      --scopeExcludeRx, --exclude           Regex of page URLs that should be ex
+                                            cluded from the crawl.
+      --allowHashUrls                       Allow Hashtag URLs, useful for singl
+                                            e-page-application crawling or when
+                                            different hashtags load dynamic cont
+                                            ent
+      --blockRules                          Additional rules for blocking certai
+                                            n URLs from being loaded, by URL reg
+                                            ex and optionally via text match in
+                                            an iframe      [array] [default: []]
       --blockMessage                        If specified, when a URL is blocked,
-                                            a record with this error message is
-                                            added instead               [string]
-  -c, --collection                          Collection name to crawl to (replay
-                                            will be accessible under this name
-                                            in pywb preview)
-                                                 [string] [default: "crawl-@ts"]
-      --headless                            Run in headless mode, otherwise
-                                            start xvfb[boolean] [default: false]
-      --driver                              JS driver for the crawler
-                                     [string] [default: "/app/defaultDriver.js"]
-      --generateCDX, --generatecdx,         If set, generate index (CDXJ) for
-      --generateCdx                         use with pywb after crawl is done
+                                             a record with this error message is
+                                             added instead              [string]
+      --blockAds, --blockads                If set, block advertisements from be
+                                            ing loaded (based on Stephen Black's
+                                             blocklist)
                                                       [boolean] [default: false]
-      --combineWARC, --combinewarc,         If set, combine the warcs
-      --combineWarc                                   [boolean] [default: false]
+      --adBlockMessage                      If specified, when an ad is blocked,
+                                             a record with this error message is
+                                             added instead              [string]
+  -c, --collection                          Collection name to crawl to (replay
+                                            will be accessible under this name i
+                                            n pywb preview)
+                                                 [string] [default: "crawl-@ts"]
+      --headless                            Run in headless mode, otherwise star
+                                            t xvfb    [boolean] [default: false]
+      --driver                              JS driver for the crawler
+                                        [string] [default: "./defaultDriver.js"]
+      --generateCDX, --generatecdx, --gene  If set, generate index (CDXJ) for us
+      rateCdx                               e with pywb after crawl is done
+                                                      [boolean] [default: false]
+      --combineWARC, --combinewarc, --comb  If set, combine the warcs
+      ineWarc                                         [boolean] [default: false]
       --rolloverSize                        If set, declare the rollover size
                                                   [number] [default: 1000000000]
-      --generateWACZ, --generatewacz,       If set, generate wacz
-      --generateWacz                                  [boolean] [default: false]
-      --logging                             Logging options for crawler, can
-                                            include: stats, pywb, behaviors,
-                                            behaviors-debug
+      --generateWACZ, --generatewacz, --ge  If set, generate wacz
+      nerateWacz                                      [boolean] [default: false]
+      --logging                             Logging options for crawler, can inc
+                                            lude: stats, pywb, behaviors, behavi
+                                            ors-debug, jserrors
                                                      [string] [default: "stats"]
-      --text                                If set, extract text to the
-                                            pages.jsonl file
-                                                      [boolean] [default: false]
+      --text                                If set, extract text to the pages.js
+                                            onl file  [boolean] [default: false]
       --cwd                                 Crawl working directory for captures
-                                            (pywb root). If not set, defaults to
-                                            process.cwd()
+                                             (pywb root). If not set, defaults t
+                                            o process.cwd()
                                                    [string] [default: "/crawls"]
       --mobileDevice                        Emulate mobile device by name from:
                                             https://github.com/puppeteer/puppete
                                             er/blob/main/src/common/DeviceDescri
                                             ptors.ts                    [string]
-      --userAgent                           Override user-agent with specified
-                                            string                      [string]
-      --userAgentSuffix                     Append suffix to existing browser
-                                            user-agent (ex: +MyCrawler,
-                                            info@example.com)           [string]
-      --useSitemap, --sitemap               If enabled, check for sitemaps at
-                                            /sitemap.xml, or custom URL if URL
-                                            is specified
+      --userAgent                           Override user-agent with specified s
+                                            tring                       [string]
+      --userAgentSuffix                     Append suffix to existing browser us
+                                            er-agent (ex: +MyCrawler, info@examp
+                                            le.com)                     [string]
+      --useSitemap, --sitemap               If enabled, check for sitemaps at /s
+                                            itemap.xml, or custom URL if URL is
+                                            specified
       --statsFilename                       If set, output stats as JSON to this
-                                            file. (Relative filename resolves to
-                                            crawl working directory)
+                                             file. (Relative filename resolves t
+                                            o crawl working directory)
       --behaviors                           Which background behaviors to enable
-                                            on each page
-                           [string] [default: "autoplay,autofetch,siteSpecific"]
-      --behaviorTimeout                     If >0, timeout (in seconds) for
-                                            in-page behavior will run on each
-                                            page. If 0, a behavior can run until
-                                            finish.       [number] [default: 90]
-      --profile                             Path to tar.gz file which will be
-                                            extracted and used as the browser
-                                            profile                     [string]
-      --screencastPort                      If set to a non-zero value, starts
-                                            an HTTP server with screencast
-                                            accessible on this port
+                                             on each page
+                [string] [default: "autoplay,autofetch,autoscroll,siteSpecific"]
+      --behaviorTimeout                     If >0, timeout (in seconds) for in-p
+                                            age behavior will run on each page.
+                                            If 0, a behavior can run until finis
+                                            h.            [number] [default: 90]
+      --profile                             Path to tar.gz file which will be ex
+                                            tracted and used as the browser prof
+                                            ile                         [string]
+      --screenshot                          Screenshot options for crawler, can
+                                            include: view, thumbnail, fullPage
+                                            (comma-separated list)
+                                                          [string] [default: ""]
+      --screencastPort                      If set to a non-zero value, starts a
+                                            n HTTP server with screencast access
+                                            ible on this port
                                                            [number] [default: 0]
-      --screencastRedis                     If set, will use the state store
-                                            redis pubsub for screencasting.
-                                            Requires --redisStoreUrl to be set
+      --screencastRedis                     If set, will use the state store red
+                                            is pubsub for screencasting. Require
+                                            s --redisStoreUrl to be set
                                                       [boolean] [default: false]
-      --warcInfo, --warcinfo                Optional fields added to the
-                                            warcinfo record in combined WARCs
+      --warcInfo, --warcinfo                Optional fields added to the warcinf
+                                            o record in combined WARCs
       --redisStoreUrl                       If set, url for remote redis server
-                                            to store state. Otherwise, using
-                                            in-memory store             [string]
-      --saveState                           If the crawl state should be
-                                            serialized to the crawls/ directory.
-                                            Defaults to 'partial', only saved
-                                            when crawl is interrupted
+                                            to store state. Otherwise, using in-
+                                            memory store                [string]
+      --saveState                           If the crawl state should be seriali
+                                            zed to the crawls/ directory. Defaul
+                                            ts to 'partial', only saved when cra
+                                            wl is interrupted
            [string] [choices: "never", "partial", "always"] [default: "partial"]
-      --saveStateInterval                   If save state is set to 'always',
-                                            also save state during the crawl at
-                                            this interval (in seconds)
+      --saveStateInterval                   If save state is set to 'always', al
+                                            so save state during the crawl at th
+                                            is interval (in seconds)
                                                          [number] [default: 300]
       --saveStateHistory                    Number of save states to keep during
-                                            the duration of a crawl
+                                             the duration of a crawl
                                                            [number] [default: 5]
       --sizeLimit                           If set, save state and exit if size
                                             limit exceeds this value
                                                            [number] [default: 0]
-      --timeLimit                           If set, save state and exit after
-                                            time limit, in seconds
+      --timeLimit                           If set, save state and exit after ti
+                                            me limit, in seconds
                                                            [number] [default: 0]
       --healthCheckPort                     port to run healthcheck on
                                                            [number] [default: 0]
-      --overwrite                           overwrite current crawl data: if
-                                            set, existing collection directory
-                                            will be deleted before crawl is
-                                            started   [boolean] [default: false]
+      --overwrite                           overwrite current crawl data: if set
+                                            , existing collection directory will
+                                             be deleted before crawl is started
+                                                      [boolean] [default: false]
+      --waitOnDone                          if set, wait for interrupt signal wh
+                                            en finished instead of exiting
+                                                      [boolean] [default: false]
+      --netIdleWait                         if set, wait for network idle after
+                                            page load and after behaviors are do
+                                            ne (in seconds). if -1 (default), de
+                                            termine based on scope
+                                                          [number] [default: -1]
       --config                              Path to YAML config file
+
 ```
 </details>
 
@@ -427,6 +444,19 @@ The site-specific behavior (or autoscroll) will start running after the page is 
 
 See [Browsertrix Behaviors](https://github.com/webrecorder/browsertrix-behaviors) for more info on all of the currently available behaviors.
 
+### Screenshots
+
+With version 0.8.0, Browsertrix Crawler includes the ability to take screenshots of each page crawled via the `--screenshot` option.
+
+Three screenshot options are available:
+
+- `--view`: Takes a png screenshot of the initially visible viewport (1920x1080)
+- `--fullPage`: Takes a png screenshot of the full page
+- `--thumbnail`: Takes a jpeg thumbnail of the initially visible viewport (1920x1080)
+
+These can be combined using a comma-separated list passed to the `--screenshot option`, e.g.: `--screenshot thumbnail,view,fullPage`.
+
+Screenshots are written into a `screenshots.warc.gz` WARC file in the `archives/` directory. If the `--generateWACZ` command line option is used, the screenshots WARC is written into the `archive` directory of the WACZ file and indexed alongside the other WARCs.
 
 ### Watching the crawl -- Screencasting
 
@@ -439,16 +469,6 @@ docker run -p 9037:9037 -v $PWD/crawls:/crawls/ webrecorder/browsertrix-crawler 
 ```
 
 Then, you can open `http://localhost:9037/` and watch the crawl.
-
-Note: If specifying multiple workers, the crawler should additional be instructed to open each one in a new window, otherwise the screencasting can only update one page at a time.
-
-For example,
-
-```
-docker run -p 9037:9037 -v $PWD/crawls:/crawls/ webrecorder/browsertrix-crawler crawl --url https://www.example.com --screencastPort 9037 --newContext window --workers 3
-```
-
-will start a crawl with 3 workers, and show the screen of each of the workers from `http://localhost:9037/`.
 
 ### Uploading crawl output to S3-Compatible Storage
 

--- a/crawler.js
+++ b/crawler.js
@@ -20,6 +20,7 @@ import * as warcio from "warcio";
 import { TextExtract } from "./util/textextract.js";
 import { initStorage, getFileSize, getDirSize, interpolateFilename } from "./util/storage.js";
 import { ScreenCaster, WSTransport, RedisPubSubTransport } from "./util/screencaster.js";
+import { Screenshots } from "./util/screenshots.js";
 import { parseArgs } from "./util/argParser.js";
 import { initRedis } from "./util/redis.js";
 
@@ -386,6 +387,24 @@ export class Crawler {
       await this.driver({page, data, crawler: this});
 
       const title = await page.title();
+
+      if (this.params.screenshot) {
+        if (!page.isHTMLPage) {
+          console.log("Skipping screenshots for non-HTML page");
+        }
+        const archiveDir = path.join(this.collDir, "archive");
+        const screenshots = new Screenshots({page, url: data.url, directory: archiveDir});
+        if (this.params.screenshot.includes("view")) {
+          await screenshots.take();
+        }
+        if (this.params.screenshot.includes("fullPage")) {
+          await screenshots.takeFullPage();
+        }
+        if (this.params.screenshot.includes("thumbnail")) {
+          await screenshots.takeThumbnail();
+        }
+      }
+
       let text = "";
       if (this.params.text && page.isHTMLPage) {
         const client = await page.target().createCDPSession();
@@ -429,7 +448,7 @@ export class Crawler {
       "software": `Browsertrix-Crawler ${packageFileJSON.version} (with warcio.js ${warcioPackageJSON.version} pywb ${pywbVersion})`,
       "format": "WARC File Format 1.0"
     };
-    
+
     const warcInfo = {...info, ...this.params.warcInfo, };
     const record = await warcio.WARCRecord.createWARCInfo({filename, type, warcVersion}, warcInfo);
     const buffer = await warcio.WARCSerializer.serialize(record, {gzip: true});

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --experimental-global-webcrypto
 
 import { Crawler } from "./crawler.js";
 

--- a/tests/custom_driver.test.js
+++ b/tests/custom_driver.test.js
@@ -32,4 +32,3 @@ test("ensure custom driver with custom selector crawls JS files as pages", async
   expect(pages).toEqual(expectedPages);
 
 });
- 

--- a/tests/screenshot.test.js
+++ b/tests/screenshot.test.js
@@ -1,0 +1,51 @@
+import child_process from "child_process";
+import fs from "fs";
+
+// screenshot
+
+test("ensure basic crawl run with --screenshot passes", async () => {
+  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection test --url http://www.example.com/ --screenshot view --workers 2");
+});
+
+test("check that a screenshots warc file exists in the test collection", () => {
+  const screenshotWarcExists = fs.existsSync("test-crawls/collections/test/archive/screenshots.warc.gz");
+  expect(screenshotWarcExists).toBe(true);
+});
+
+// fullPageScreenshot
+
+test("ensure basic crawl run with --fullPageScreenshot passes", async () => {
+  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection fullpage --url http://www.example.com/ --screenshot fullPage --workers 2");
+});
+
+test("check that a screenshots warc file exists in the fullpage collection", () => {
+  const screenshotWarcExists = fs.existsSync("test-crawls/collections/fullpage/archive/screenshots.warc.gz");
+  expect(screenshotWarcExists).toBe(true);
+});
+
+// thumbnail
+
+test("ensure basic crawl run with --thumbnail passes", async () => {
+  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection thumbnail --url http://www.example.com/ --screenshot thumbnail --workers 2");
+});
+
+test("check that a screenshots warc file exists in the thumbnail collection", () => {
+  const screenshotWarcExists = fs.existsSync("test-crawls/collections/thumbnail/archive/screenshots.warc.gz");
+  expect(screenshotWarcExists).toBe(true);
+});
+
+// combination
+
+test("ensure basic crawl run with multiple screenshot types and --generateWACZ passes", async () => {
+  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection combined --url http://www.example.com/ --screenshot thumbnail,view,fullPage --generateWACZ --workers 2");
+});
+
+test("check that a screenshots warc file exists in the combined collection", () => {
+  const screenshotWarcExists = fs.existsSync("test-crawls/collections/combined/archive/screenshots.warc.gz");
+  expect(screenshotWarcExists).toBe(true);
+});
+
+test("check that a wacz file exists in the combined collection", () => {
+  const waczExists = fs.existsSync("test-crawls/collections/combined/combined.wacz");
+  expect(waczExists).toBe(true);
+});

--- a/tests/url_file_list.test.js
+++ b/tests/url_file_list.test.js
@@ -22,8 +22,8 @@ test("check that URLs one-depth out from the seed-list are crawled", async () =>
       seed_file_list.push(seed_file[j]);
     }
   }
-  
-  let foundSeedUrl = true; 
+
+  let foundSeedUrl = true;
 
   for (var i = 1; i < seed_file_list.length; i++) {
     if (crawled_pages.indexOf(seed_file_list[i]) == -1){

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -12,6 +12,7 @@ import { ReuseWindowConcurrency } from "./windowconcur.js";
 import { BEHAVIOR_LOG_FUNC, WAIT_UNTIL_OPTS } from "./constants.js";
 import { ScopedSeed } from "./seeds.js";
 import { interpolateFilename } from "./storage.js";
+import { screenshotTypes } from "./screenshots.js";
 
 
 // ============================================================================
@@ -364,12 +365,13 @@ class ArgParser {
     }
 
     // validate screenshot options
-    let screenshotTypes = argv.screenshot.split(",");
-    const allowedScreenshotTypes = ["view", "thumbnail", "fullPage"];
+    let passedScreenshotTypes = argv.screenshot.split(",");
     argv.screenshot = [];
-    screenshotTypes.forEach((element) => {
-      if (allowedScreenshotTypes.includes(element)) {
+    passedScreenshotTypes.forEach((element) => {
+      if (element in screenshotTypes) {
         argv.screenshot.push(element);
+      } else {
+        console.log(`${element} not found in ${screenshotTypes}`);
       }
     });
 

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -46,8 +46,8 @@ class ArgParser {
       },
 
       "newContext": {
-        describe: "The context for each new capture, can be a new: page, window, session or browser.",
-        default: "page",
+        describe: "Deprecated as of 0.8.0, any values passed will be ignored",
+        default: null,
         type: "string"
       },
 
@@ -228,6 +228,12 @@ class ArgParser {
         type: "string",
       },
 
+      "screenshot": {
+        describe: "Screenshot options for crawler, can include: view, thumbnail, fullPage (comma-separated list)",
+        type: "string",
+        default: "",
+      },
+
       "screencastPort": {
         describe: "If set to a non-zero value, starts an HTTP server with screencast accessible on this port",
         type: "number",
@@ -357,6 +363,16 @@ class ArgParser {
       }
     }
 
+    // validate screenshot options
+    let screenshotTypes = argv.screenshot.split(",");
+    const allowedScreenshotTypes = ["view", "thumbnail", "fullPage"];
+    argv.screenshot = [];
+    screenshotTypes.forEach((element) => {
+      if (allowedScreenshotTypes.includes(element)) {
+        argv.screenshot.push(element);
+      }
+    });
+
     // log options
     argv.logging = argv.logging.split(",");
 
@@ -377,33 +393,16 @@ class ArgParser {
     }
     argv.behaviorOpts = JSON.stringify(behaviorOpts);
 
-    if (!argv.newContext) {
-      argv.newContext = "page";
+    if (argv.newContext) {
+      console.log("Note: The newContext argument is deprecated in 0.8.0. Values passed to this option will be ignored");
     }
 
-    switch (argv.newContext) {
-    case "page":
-      argv.newContext = Cluster.CONCURRENCY_PAGE;
-      if (argv.screencastPort && argv.workers > 1) {
-        console.log("Note: to support screencasting with >1 workers, newContext set to 'window' instead of 'page'");
-        argv.newContext = ReuseWindowConcurrency;
-      }
-      break;
-
-    case "session":
-      argv.newContext = Cluster.CONCURRENCY_CONTEXT;
-      break;
-
-    case "browser":
-      argv.newContext = Cluster.CONCURRENCY_BROWSER;
-      break;
-
-    case "window":
+    if (argv.workers > 1) {
+      console.log("Window context being used to support >1 workers");
       argv.newContext = ReuseWindowConcurrency;
-      break;
-
-    default:
-      throw new Error("Invalid newContext, must be one of: page, session, browser");
+    } else {
+      console.log("Page context being used with 1 worker");
+      argv.newContext = Cluster.CONCURRENCY_PAGE;
     }
 
     if (argv.mobileDevice) {

--- a/util/screenshots.js
+++ b/util/screenshots.js
@@ -1,0 +1,84 @@
+import fs from "fs";
+import path from "path";
+import * as warcio from "warcio";
+
+
+// ============================================================================
+
+class Screenshots {
+
+  constructor({page, url, date, directory}) {
+    this.page = page;
+    this.url = url;
+    this.directory = directory;
+    this.warcName = path.join(this.directory, "screenshots.warc.gz");
+    this.date = date ? date : new Date();
+
+    this.screenshotOptions = {
+      name: "screenshot",
+      options: {
+        type: "png",
+        omitBackground: true,
+        fullPage: false
+      }
+    };
+
+    this.screenshotFullPageOptions = {
+      name: "screenshot-fullpage",
+      options: {
+        type: "png",
+        omitBackground: true,
+        fullPage: true
+      }
+    };
+
+    this.thumbnailOptions = {
+      name: "thumbnail",
+      options: {
+        type: "jpeg",
+        omitBackground: true,
+        fullPage: false,
+        quality: 75
+      }
+    };
+  }
+
+  async take(typeOptions = this.screenshotOptions) {
+    try {
+      await this.page.setViewport({width: 1920, height: 1080});
+      let screenshotBuffer = await this.page.screenshot(typeOptions.options);
+      let warcRecord = await this.wrap(screenshotBuffer, typeOptions.name, typeOptions.options.type);
+      let warcRecordBuffer = await warcio.WARCSerializer.serialize(warcRecord, {gzip: true});
+      fs.appendFileSync(this.warcName, warcRecordBuffer);
+      console.log(`Screenshot (type: ${typeOptions.name}) for ${this.url} written to ${this.warcName}`);
+    } catch (e) {
+      console.log(`Taking screenshot (type: ${typeOptions.name}) failed for ${this.url}`, e);
+    }
+  }
+
+  async takeFullPage() {
+    await this.take(this.screenshotFullPageOptions);
+  }
+
+  async takeThumbnail() {
+    await this.take(this.thumbnailOptions);
+  }
+
+  async wrap(buffer, screenshotType="screenshot", imageType="png") {
+    const warcVersion = "WARC/1.1";
+    const warcRecordType = "resource";
+    const warcHeaders = {"Content-Type": `image/${imageType}`};
+    async function* content() {
+      yield buffer;
+    }
+    let screenshotUrl = `urn:${screenshotType}:` + this.url;
+    return warcio.WARCRecord.create({
+      url: screenshotUrl,
+      date: this.date.toISOString(),
+      type: warcRecordType,
+      warcVersion,
+      warcHeaders}, content());
+  }
+}
+
+export { Screenshots };


### PR DESCRIPTION
Connected to #11 

Introduces a `--screenshot` CLI option, which takes a comma-separated list of screenshot types: `view,fullPage,thumbnail`.

Thumbnails are the same size in terms of height and width as the other screenshots (1920x1080) to capture standard page layout but are taken as JPEGs at 75% quality, which are significantly smaller in terms of bytes than the pngs.

This PR also simplifies `newContext` by deprecating the command line argument and simply using page context for 1 worker and our custom window context for >1 workers. A deprecation notice has been added making it clear that the `--newContext` option has been retained but any values passed to it will be ignored.