### PR TITLE
Improve crawler logging

### DIFF
--- a/tests/config_file.test.js
+++ b/tests/config_file.test.js
@@ -45,7 +45,7 @@ test("check yaml config file with seed list is used", async () => {
 test("check yaml config file will be overwritten by command line", async () => {
   try{
 
-    await exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection configtest-2 --config /tests/fixtures/crawl-1.yaml --url https://www.example.com --timeout 20000");
+    await exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection configtest-2 --config /tests/fixtures/crawl-1.yaml --url https://specs.webrecorder.net/ --scopeType page --timeout 20000");
   }
   catch (error) {
     console.log(error);
@@ -61,7 +61,7 @@ test("check yaml config file will be overwritten by command line", async () => {
     }
   }
 
-  expect(pages.has("https://www.example.com/")).toBe(true);
+  expect(pages.has("https://specs.webrecorder.net/")).toBe(true);
   expect(pages.size).toBe(1);
 
 });

--- a/tests/extra_hops_depth.test.js
+++ b/tests/extra_hops_depth.test.js
@@ -8,7 +8,7 @@ const exec = util.promisify(execCallback);
 
 test("check that URLs are crawled 2 extra hops beyond depth", async () => {
   try {
-    await exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection extra-hops-beyond --extraHops 2 --url https://example.com/ --limit 7");
+    await exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection extra-hops-beyond --extraHops 2 --url https://webrecorder.net/ --limit 7");
   }
   catch (error) {
     console.log(error);
@@ -17,13 +17,13 @@ test("check that URLs are crawled 2 extra hops beyond depth", async () => {
   const crawled_pages = fs.readFileSync("test-crawls/collections/extra-hops-beyond/pages/pages.jsonl", "utf8");
 
   const expectedPages = [
-    "https://example.com/",
-    "https://www.iana.org/domains/example",
-    "http://www.iana.org/",
-    "http://www.iana.org/domains",
-    "http://www.iana.org/protocols",
-    "http://www.iana.org/numbers",
-    "http://www.iana.org/about",
+    "https://webrecorder.net/",
+    "https://webrecorder.net/blog",
+    "https://webrecorder.net/tools",
+    "https://webrecorder.net/community",
+    "https://webrecorder.net/about",
+    "https://webrecorder.net/contact",
+    "https://webrecorder.net/faq",
   ];
 
   for (const page of crawled_pages.trim().split("\n")) {

--- a/tests/fixtures/crawl-1.yaml
+++ b/tests/fixtures/crawl-1.yaml
@@ -1,8 +1,8 @@
 name: crawl-test-1
 collection: configtest
 seeds:
-  - https://www.example.org
-  - https://www.iana.org/
+  - https://webrecorder.net/
+  - https://specs.webrecorder.net/
 
 generateWACZ: true
 

--- a/tests/fixtures/urlSeedFile.txt
+++ b/tests/fixtures/urlSeedFile.txt
@@ -1,2 +1,2 @@
-https://www.example.org
-https://www.example.com
+https://webrecorder.net/about/
+https://specs.webrecorder.net/wacz/1.1.1/

--- a/tests/url_file_list.test.js
+++ b/tests/url_file_list.test.js
@@ -4,10 +4,10 @@ import fs from "fs";
 
 const exec = util.promisify(execCallback);
 
-test("check that URLs one-depth out from the seed-list are crawled", async () => {
+test("check that URLs in seed-list are crawled", async () => {
   try {
 
-    await exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection filelisttest --urlFile /tests/fixtures/urlSeedFile.txt --timeout 10000");
+    await exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection filelisttest --urlFile /tests/fixtures/urlSeedFile.txt --timeout 90000");
   }
   catch (error) {
     console.log(error);

--- a/util/logger.js
+++ b/util/logger.js
@@ -1,0 +1,45 @@
+// ===========================================================================
+
+export class Logger
+{
+  constructor(debugLogging=false) {
+    this.debugLogging = debugLogging;
+  }
+
+  logAsJSON(message, data, context, logLevel="info") {
+    if (typeof data !== "object") {
+      data = {"message": data.toString()};
+    }
+    let dataToLog = {
+      "logLevel": logLevel,
+      "timestamp": new Date().toISOString(),
+      "context": context,
+      "message": message,
+      "details": data ? data : {}
+    };
+    console.log(JSON.stringify(dataToLog));
+  }
+
+  info(message, data={}, context="general") {
+    this.logAsJSON(message, data, context);
+  }
+
+  error(message, data={}, context="general") {
+    this.logAsJSON(message, data, context, "error");
+  }
+
+  warn(message, data={}, context="general") {
+    this.logAsJSON(message, data, context, "warn");
+  }
+
+  debug(message, data={}, context="general") {
+    if (this.debugLogging) {
+      this.logAsJSON(message, data, context, "debug");
+    }
+  }
+
+  fatal(message, data={}, context="general", exitCode=1) {
+    this.logAsJSON(`${message}. Quitting`, data, context, "fatal");
+    process.exit(exitCode);
+  }
+}

--- a/util/screenshots.js
+++ b/util/screenshots.js
@@ -2,6 +2,9 @@ import fs from "fs";
 import path from "path";
 import * as warcio from "warcio";
 
+import { Logger } from "./logger.js";
+
+const logger = new Logger();
 
 // ============================================================================
 
@@ -43,9 +46,9 @@ export class Screenshots {
       const warcRecord = await this.wrap(screenshotBuffer, screenshotType, options.type);
       const warcRecordBuffer = await warcio.WARCSerializer.serialize(warcRecord, {gzip: true});
       fs.appendFileSync(this.warcName, warcRecordBuffer);
-      console.log(`Screenshot (type: ${screenshotType}) for ${this.url} written to ${this.warcName}`);
+      logger.info(`Screenshot (type: ${screenshotType}) for ${this.url} written to ${this.warcName}`);
     } catch (e) {
-      console.log(`Taking screenshot (type: ${screenshotType}) failed for ${this.url}`, e);
+      logger.error(`Taking screenshot (type: ${screenshotType}) failed for ${this.url}`, e.message);
     }
   }
 

--- a/util/seeds.js
+++ b/util/seeds.js
@@ -1,7 +1,15 @@
+import { Logger } from "./logger.js";
+
+const logger = new Logger();
+
+
 export class ScopedSeed
 {
   constructor({url, scopeType, include, exclude = [], allowHash = false, depth = -1, sitemap = false, extraHops = 0} = {}) {
     const parsedUrl = this.parseUrl(url);
+    if (!parsedUrl) {
+      logger.fatal(`Invalid Seed "${url}" - not a valid URL`);
+    }
     this.url = parsedUrl.href;
     this.include = this.parseRx(include);
     this.exclude = this.parseRx(exclude);
@@ -36,11 +44,12 @@ export class ScopedSeed
     try {
       parsedUrl = new URL(url.trim());
     } catch (e) {
-      throw new Error(`Invalid Seed "${url}" - not a valid URL`);
+      logger.error(`Invalid Seed "${url}" - not a valid URL`);
     }
 
     if (parsedUrl.protocol !== "http:" && parsedUrl.protocol != "https:") {
-      throw new Error(`Invalid Seed "${url}" - URL must start with http:// or https://`);
+      logger.error(`Invalid Seed "${url}" - URL must start with http:// or https://`);
+      parsedUrl = null;
     }
 
     return parsedUrl;
@@ -91,7 +100,7 @@ export class ScopedSeed
       break;
 
     default:
-      throw new Error(`Invalid scope type "${scopeType}" specified, valid types are: page, page-spa, prefix, host, domain, any`);
+      logger.fatal(`Invalid scope type "${scopeType}" specified, valid types are: page, page-spa, prefix, host, domain, any`);
     }
 
     return [include, allowHash];
@@ -106,9 +115,8 @@ export class ScopedSeed
       return false;
     }
 
-    try {
-      url = this.parseUrl(url);
-    } catch(e) {
+    url = this.parseUrl(url);
+    if (!url) {
       return false;
     }
 

--- a/util/state.js
+++ b/util/state.js
@@ -1,5 +1,10 @@
 import mod from "puppeteer-cluster/dist/Job.js";
+
+import { Logger } from "./logger.js";
+
 const Job = mod.default;
+
+const logger = new Logger();
 
 
 // ============================================================================
@@ -102,7 +107,7 @@ export class MemoryCrawlState extends BaseState
       },
 
       reject(e) {
-        console.warn(`Page Load Failed: ${url}, Reason: ${e}`);
+        logger.warn(`Page Load Failed: ${url}`, e.message);
 
         state.pending.delete(url);
 
@@ -316,7 +321,7 @@ return 0;
     try {
       data = JSON.parse(json);
     } catch(e) {
-      console.error("Invalid queued json: ", json);
+      logger.error("Invalid queued json", json);
       return null;
     }
 
@@ -338,7 +343,7 @@ return 0;
       },
 
       async reject(e) {
-        console.warn(`Page Load Failed: ${url}, Reason: ${e}`);
+        logger.warn(`Page Load Failed: ${url}`, e.message);
         await state._fail(url);
       }
     };
@@ -445,7 +450,7 @@ return 0;
 
     for (const url of pendingUrls) {
       if (await this.redis.requeue(this.pkey, this.qkey, this.pkey + ":" + url, url)) {
-        console.log("Requeued: " + url);
+        logger.info(`Requeued: ${url}`);
       }
     }
   }

--- a/util/windowconcur.js
+++ b/util/windowconcur.js
@@ -1,5 +1,9 @@
 import sbi from "puppeteer-cluster/dist/concurrency/SingleBrowserImplementation.js";
 
+import { Logger } from "./logger.js";
+
+const logger = new Logger();
+
 const SingleBrowserImplementation = sbi.default;
 
 
@@ -40,7 +44,7 @@ export class ReuseWindowConcurrency extends SingleBrowserImplementation {
     }
 
     this.repairing = true;
-    console.debug("Starting repair");
+    logger.warn("Starting browser repair");
 
     if (this.screencaster) {
       this.screencaster.endAllTargets();
@@ -50,13 +54,13 @@ export class ReuseWindowConcurrency extends SingleBrowserImplementation {
       // will probably fail, but just in case the repair was not necessary
       await this.browser.close();
     } catch (e) {
-      console.debug("Unable to close browser.");
+      logger.warn("Unable to close browser");
     }
 
     try {
       await this.init();
     } catch (err) {
-      console.debug("Unable to restart chrome.");
+      logger.warn("Unable to restart chrome");
     }
     this.repairRequested = false;
     this.repairing = false;
@@ -71,7 +75,7 @@ export class ReuseWindowConcurrency extends SingleBrowserImplementation {
         const res = await this.cdp.send("Target.createTarget", {url: this.startPage, newWindow: true});
         targetId = res.targetId;
       } catch (e) {
-        console.warn(e);
+        logger.warn("Error getting new page in window context", e);
         await this.repair();
       }
 


### PR DESCRIPTION
Connected to https://github.com/webrecorder/browsertrix-crawler/issues/74

Related to https://github.com/webrecorder/browsertrix-cloud/issues/330

This PR improves browsertrix-crawler logging. Changes:

- Add Logger class with methods for info, error, warn, and debug
- Replace `console.log`, `console.warn` and `console.error` with appropriate logger methods
- Log messages as [JSON Lines](https://jsonlines.org/) with the following structure:
    - info - general:
    ```
    {"logLevel":"info","timestamp":"2022-12-21T17:58:36.114Z","context":"general","message":"Seeds","details":[{"url":"https://webrecorder.net/","include":[{}],"exclude":[],"scopeType":"prefix","sitemap":false,"allowHash":false,"maxExtraHops":1,"maxDepth":99999}]}
    ```
    - info - pageGraph:
    ```
    {"logLevel":"info","timestamp":"2022-12-21T17:58:45.601Z","context":"pageGraph","message":"Page graph data for successfully crawled page","details":{"url":"https://webrecorder.net/","seedId":0,"depth":0,"started":"2022-12-21T17:58:36.586Z"}}
    ```
    - info - behavior:
    ```
    {"logLevel":"info","timestamp":"2022-12-21T17:59:42.914Z","context":"behavior","message":"Behavior line","details":{"state":{"tweets":1,"images":3,"videos":0},"msg":"Capturing Tweet: https://twitter.com/DaleLore/status/1600896285124399104?cxt=HHwWgMCo0Y-sw7csAAAA"}}
    ```
    - error:
    ```
    {"logLevel":"error","timestamp":"2022-12-21T18:00:01.096Z","context":"general","message":"Failed to load resource: the server responded with a status of 404 (Not Found)","details":{"location":{"url":"https://webrecorder.net/2021/01/04/assets/favicon.ico"}}}
    ```
    - warn:
    ```
    {"logLevel":"warn","timestamp":"2022-12-21T18:07:22.868Z","context":"general","message":"Page Load Failed: https://docnow.io/","details":{"message":"Timeout hit: 180000"}}
    ```
- Remove puppeteer-cluster stats
- Log behaviors by default
- Amend argParser to reflect logging changes

Sample log for a page crawl of https://webrecorder.net with `--extraHops 1`: [webrecorder-sample-log-simple.txt](https://github.com/webrecorder/browsertrix-crawler/files/10280291/webrecorder-sample-log-simple.txt)

