### PR TITLE
Remove dead pywb configuration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,4 @@
 debug: true
-
  
 proxy:
   coll: ${COLL}
@@ -14,10 +13,6 @@ recorder:
   cache: always
   rollover_size: ${ROLLOVER_SIZE}
   enable_put_custom_record: true
-
-#autoindex: 10
-
-#enable_auto_fetch: true
 
 collections:
   live: $live


### PR DESCRIPTION
This PR originally addressed the need to turn on autofetch in pywb because I noticed it was commented out, and srcset images were not being archived as part of a crawl I was doing.

But after further conversation I see now that failure was the result of my browsertrix-crawler configuration which specified behaviors, but not `autofetch`--effectively turning it off.  browsertrix-crawler uses [browsertrix-behaviors](https://github.com/webrecorder/browsertrix-behaviors)' autofetch, which is different from pywb's, which will perhaps one day replace.

I removed the dead/commented out portions of the default pywb configuration to hopefully prevent future confusion. 