### PR TITLE
Add requests[socks] python dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pywb>=2.7.2
 uwsgi
 wacz>=0.4.6
+requests[socks]


### PR DESCRIPTION
Add requests[socks] python dependency to enable SOCKS proxy support for pywb inside the docker container. This fixes a bug with a missing dependency when trying to use a socks proxy with the browsertrix-crawler.