### PR TITLE
behaviors: don't run behaviors in iframes that are about:blank or are…

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -448,7 +448,7 @@ export class Crawler {
       return false;
     }
 
-    return await this.adBlockRules.shouldBlock(null, url);
+    return !!(await this.adBlockRules.shouldBlock(null, url));
   }
 
   async createWARCInfo(filename) {

--- a/crawler.js
+++ b/crawler.js
@@ -610,9 +610,7 @@ export class Crawler {
 
     await this.initPages();
 
-    //if (this.params.blockAds) {
     this.adBlockRules = new AdBlockRules(this.captureBasePrefix, this.params.adBlockMessage, this.logger);
-    //}
 
     if (this.params.blockRules && this.params.blockRules.length) {
       this.blockRules = new BlockRules(this.params.blockRules, this.captureBasePrefix, this.params.blockMessage, this.logger);

--- a/util/browser.js
+++ b/util/browser.js
@@ -143,15 +143,17 @@ export function chromeArgs (proxy, userAgent=null, extraArgs=[]) {
 }
 
 
-export async function evaluateWithCLI(frame, funcString) {
+export async function evaluateWithCLI(frame, funcString, name = "behaviors") {
   const context = await frame.executionContext();
   const url = frame.url();
+
+  logger.info(`Running ${name}...`, {url});
 
   // from puppeteer _evaluateInternal() but with includeCommandLineAPI: true
   const contextId = context._contextId;
   const expression = funcString + "\n//# sourceURL=__puppeteer_evaluation_script__";
 
-  const { exceptionDetails, result: remoteObject } = await context._client
+  const { exceptionDetails, result } = await context._client
     .send("Runtime.evaluate", {
       expression,
       contextId,
@@ -165,11 +167,13 @@ export async function evaluateWithCLI(frame, funcString) {
     const details = exceptionDetails.stackTrace || {};
     details.url = url;
     logger.error(
-      "Script Evaluation Failed: " + exceptionDetails.text, details
+      `Run ${name} failed: ${exceptionDetails.text}`, details
     );
+  } else {
+    logger.info(`Run ${name} finished`, {url});
   }
 
-  return remoteObject.value;
+  return result.value;
 }
 
 

--- a/util/browser.js
+++ b/util/browser.js
@@ -145,6 +145,7 @@ export function chromeArgs (proxy, userAgent=null, extraArgs=[]) {
 
 export async function evaluateWithCLI(frame, funcString) {
   const context = await frame.executionContext();
+  const url = frame.url();
 
   // from puppeteer _evaluateInternal() but with includeCommandLineAPI: true
   const contextId = context._contextId;
@@ -161,8 +162,10 @@ export async function evaluateWithCLI(frame, funcString) {
     });
 
   if (exceptionDetails) {
+    const details = exceptionDetails.stackTrace || {};
+    details.url = url;
     logger.error(
-      "Behavior Evaluation Failed: " + exceptionDetails.text, exceptionDetails.stackTrace || {}
+      "Script Evaluation Failed: " + exceptionDetails.text, details
     );
   }
 


### PR DESCRIPTION
… from an ad-host (even if ad-blocking is not disabled)

fixes #210

Possibly could add more logging of whether behaviors are injected or skipped