### PR TITLE
Serialize Redis pending pages as JSON objects

### DIFF
--- a/tests/redis_crawl_state.js
+++ b/tests/redis_crawl_state.js
@@ -4,7 +4,7 @@ import child_process from "child_process";
 test("ensure crawl run with redis passes", async () => {
   const redis = child_process.spawn("docker run -d --name test-crawl-redis -p 6379:6379 redis");
 
-  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://www.example.com/ --generateWACZ  --text --collection redis-crawl --redisStoreUrl 127.0.0.1:6379 --workers 2");
+  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://www.example.com/ --generateWACZ  --text --collection redis-crawl --redisStoreUrl redis://127.0.0.1:6379 --workers 2");
 
   redis.kill("SIGINT");
 });

--- a/util/state.js
+++ b/util/state.js
@@ -366,7 +366,7 @@ return 0;
   async serialize() {
     const queued = await this._iterListKeys(this.qkey);
     const done = await this._iterListKeys(this.dkey);
-    const pending = await this.redis.hvals(this.pkey);
+    const pending = await this.getPendingList();
 
     return {queued, pending, done};
   }


### PR DESCRIPTION
Fixes https://github.com/webrecorder/browsertrix-crawler/issues/209

Commit https://github.com/webrecorder/browsertrix-crawler/commit/a767721f5e3482d5fdaf55fe02af64e2b5a1bd76 fixed the main issue here by outputting pending pages as JSON objects to the logger. This PR follows up on that to apply the same logic to `RedisCrawlState.serialize() (and adds a missing `redis://` prefix to the redis URL passed in the `redis_crawl_state` test).