### PR TITLE
Bump to Chrome 109, Beta 0.8.0-beta.1 Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV PROXY_HOST=localhost \
 WORKDIR /app
 
 ADD requirements.txt /app/
-RUN pip install 'uwsgi==2.0.20'
+RUN pip install 'uwsgi==2.0.21'
 RUN pip install -U setuptools; pip install -r requirements.txt
 
 ADD package.json /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-ARG BROWSER_IMAGE_BASE=webrecorder/browsertrix-browser-base
-ARG BROWSER_VERSION=105
+ARG BROWSER_VERSION=109
+ARG BROWSER_IMAGE_BASE=webrecorder/browsertrix-browser-base:chrome-${BROWSER_VERSION}
 
-FROM ${BROWSER_IMAGE_BASE}:${BROWSER_VERSION}
-
-# TODO: Move this into base image
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy jq x11vnc
+FROM ${BROWSER_IMAGE_BASE}
 
 # needed to add args to main build stage
 ARG BROWSER_VERSION

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.8.0-beta.0",
+  "version": "0.8.0-beta.1",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",


### PR DESCRIPTION
Bumps to Chrome 109 base image, remove installations moved to base image
update to latest uwsgi