### PR TITLE
Fix --overwrite CLI flag

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -202,6 +202,15 @@ export class Crawler {
   async bootstrap() {
     const logs = path.join(this.collDir, "logs");
 
+    if (this.params.overwrite) {
+      this.logger.info(`Clearing ${this.collDir} before starting`);
+      try {
+        fs.rmSync(this.collDir, { recursive: true, force: true });
+      } catch(e) {
+        this.logger.error(`Unable to clear ${this.collDir}`, e);
+      }
+    }
+
     const initRes = child_process.spawnSync("wb-manager", ["init", this.params.collection], {cwd: this.params.cwd});
 
     if (initRes.status) {
@@ -235,15 +244,6 @@ export class Crawler {
     const subprocesses = [];
 
     subprocesses.push(child_process.spawn("redis-server", {cwd: "/tmp/", stdio: redisStdio}));
-
-    if (this.params.overwrite) {
-      this.logger.info(`Clearing ${this.collDir} before starting`);
-      try {
-        fs.rmSync(this.collDir, { recursive: true, force: true });
-      } catch(e) {
-        this.logger.error(`Unable to clear ${this.collDir}`, e);
-      }
-    }
 
     opts.env = {...process.env, COLL: this.params.collection, ROLLOVER_SIZE: this.params.rolloverSize};
 

--- a/tests/crawl_overwrite.js
+++ b/tests/crawl_overwrite.js
@@ -1,0 +1,31 @@
+import child_process from "child_process";
+import fs from "fs";
+
+
+test("ensure --overwrite with existing collection results in a successful crawl", async () => {
+  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://www.example.com/ --generateWACZ  --collection overwrite");
+
+  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://www.example.com/ --generateWACZ  --collection overwrite --overwrite");
+});
+
+test("check that the pages.jsonl file exists in the collection under the pages folder", () => {
+  expect(fs.existsSync("test-crawls/collections/overwrite/pages/pages.jsonl")).toBe(true);
+});
+
+test("check that the WACZ file exists in the collection", () => {
+  expect(fs.existsSync("test-crawls/collections/overwrite/pages/pages.jsonl")).toBe(true);
+});
+
+//-----------
+
+test("ensure --overwrite results in a successful crawl even if collection didn't exist", async () => {
+  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://www.example.com/ --generateWACZ  --collection overwrite-nothing --overwrite");
+});
+
+test("check that the pages.jsonl file exists in the collection under the pages folder", () => {
+  expect(fs.existsSync("test-crawls/collections/overwrite-nothing/pages/pages.jsonl")).toBe(true);
+});
+
+test("check that the WACZ file exists in the collection", () => {
+  expect(fs.existsSync("test-crawls/collections/overwrite-nothing/pages/pages.jsonl")).toBe(true);
+});


### PR DESCRIPTION
Connected to #213 

This PR fixes the `--overwrite` flag by deleting the existing collection before `wb-manager init` is run, so that the collection can be successfully recreated/overwritten.