### PR TITLE
Logging and Behavior Tweaks

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -432,7 +432,7 @@ export class Crawler {
           this.logger.info("Skipping behaviors for non-HTML page", logDetails, "behavior");
         } else {
           const behaviorTimeout = this.params.behaviorTimeout / 1000;
-          this.logger.info("Behaviors started", {...logDetails, behaviorTimeout}, "behavior");
+          this.logger.info("Behaviors started", {behaviorTimeout, ...logDetails}, "behavior");
           const res = await Promise.race([
             this.sleep(behaviorTimeout),
             Promise.allSettled(
@@ -442,7 +442,7 @@ export class Crawler {
             )
           ]);
           if (res && res.length) {
-            this.logger.info("Behaviors finished", {...logDetails, finished: res.length}, "behavior");
+            this.logger.info("Behaviors finished", {finished: res.length, ...logDetails}, "behavior");
           } else {
             this.logger.error("Behaviors timed out", logDetails, "behavior");
           }
@@ -456,7 +456,7 @@ export class Crawler {
       await this.serializeConfig();
 
     } catch (e) {
-      this.logger.error("Page Errored", {...logDetails, ...e}, "pageStatus");
+      this.logger.error("Page Errored", {...e, ...logDetails}, "pageStatus");
       await this.markPageFailed(page);
     }
   }
@@ -477,7 +477,7 @@ export class Crawler {
     }
 
     if (!res) {
-      this.logger.info("Skipping behavior for frame", {...logDetails, url}, "behavior");
+      this.logger.info("Skipping behavior for frame", {url, ...logDetails}, "behavior");
     }
 
     return res;
@@ -882,7 +882,7 @@ export class Crawler {
       let msg = e.message || "";
       if (!msg.startsWith("net::ERR_ABORTED") || !ignoreAbort) {
         const mainMessage = e.name === "TimeoutError" ? "Page Load Timeout" : "Page Load Error";
-        this.logger.error(mainMessage, {...logDetails, msg});
+        this.logger.error(mainMessage, {msg, ...logDetails});
         this.errorCount++;
       }
     }

--- a/crawler.js
+++ b/crawler.js
@@ -881,7 +881,8 @@ export class Crawler {
     } catch (e) {
       let msg = e.message || "";
       if (!msg.startsWith("net::ERR_ABORTED") || !ignoreAbort) {
-        this.logger.error("Page Load Error", {...logDetails, msg});
+        const mainMessage = e.name === "TimeoutError" ? "Page Load Timeout" : "Page Load Error";
+        this.logger.error(mainMessage, {...logDetails, msg});
         this.errorCount++;
       }
     }
@@ -897,8 +898,6 @@ export class Crawler {
     await this.checkCF(page, logDetails);
 
     await this.netIdle(page, logDetails);
-
-    //await this.sleep(5);
 
     // skip extraction if at max depth
     if (seed.isAtMaxDepth(depth) || !selectorOptsList) {

--- a/crawler.js
+++ b/crawler.js
@@ -166,7 +166,7 @@ export class Crawler {
 
       this.logger.info(`Storing state via Redis ${redisUrl} @ key prefix "${this.crawlId}"`, {}, "state");
 
-      this.crawlState = new RedisCrawlState(redis, this.params.crawlId, this.params.timeout * 2, os.hostname());
+      this.crawlState = new RedisCrawlState(redis, this.params.crawlId, this.params.behaviorTimeout + this.params.timeout, os.hostname());
 
     } else {
       this.logger.info("Storing state in memory", {}, "state");
@@ -324,8 +324,9 @@ export class Crawler {
     }
   }
 
-  _behaviorLog({data, type}) {
+  _behaviorLog({data, type}, pageUrl) {
     let behaviorLine;
+    data.page = pageUrl;
 
     switch (type) {
     case "info":
@@ -349,7 +350,12 @@ export class Crawler {
   }
 
   async crawlPage(opts) {
+    await this.writeStats();
+
     const {page, data} = opts;
+    const {url} = data;
+
+    const logDetails = {page: url};
 
     if (!this.isInScope(data)) {
       this.logger.info("Page no longer in scope", data);
@@ -358,7 +364,7 @@ export class Crawler {
 
     try {
       if (this.screencaster) {
-        await this.screencaster.screencastTarget(page.target(), data.url);
+        await this.screencaster.screencastTarget(page.target(), url);
       }
 
       if (this.emulateDevice) {
@@ -372,7 +378,7 @@ export class Crawler {
       await page.evaluateOnNewDocument("Object.defineProperty(navigator, \"webdriver\", {value: false});");
 
       if (this.params.behaviorOpts && !page.__bx_inited) {
-        await page.exposeFunction(BEHAVIOR_LOG_FUNC, (logdata) => this._behaviorLog(logdata));
+        await page.exposeFunction(BEHAVIOR_LOG_FUNC, (logdata) => this._behaviorLog(logdata, url));
         await page.evaluateOnNewDocument(behaviors + `;\nself.__bx_behaviors.init(${this.params.behaviorOpts});`);
         page.__bx_inited = true;
       }
@@ -384,10 +390,10 @@ export class Crawler {
 
       if (this.params.screenshot) {
         if (!page.isHTMLPage) {
-          this.logger.info("Skipping screenshots for non-HTML page");
+          this.logger.info("Skipping screenshots for non-HTML page", logDetails);
         }
         const archiveDir = path.join(this.collDir, "archive");
-        const screenshots = new Screenshots({page, url: data.url, directory: archiveDir});
+        const screenshots = new Screenshots({page, url, directory: archiveDir});
         if (this.params.screenshot.includes("view")) {
           await screenshots.take();
         }
@@ -410,29 +416,34 @@ export class Crawler {
 
       if (this.params.behaviorOpts) {
         if (!page.isHTMLPage) {
-          this.logger.info("Skipping behaviors for non-HTML page", data, "behavior");
+          this.logger.info("Skipping behaviors for non-HTML page", logDetails, "behavior");
         } else {
-          await Promise.allSettled(
-            page.frames().
-              filter(frame => this.shouldRunBehavior(frame)).
-              map(frame => evaluateWithCLI(frame, "self.__bx_behaviors.run();"))
-          );
-
-          // also wait for general net idle
-          await this.netIdle(page);
+          const behaviorTimeout = this.params.behaviorTimeout / 1000;
+          this.logger.info("Behaviors started", {...logDetails, behaviorTimeout}, "behavior");
+          const res = await Promise.race([
+            this.sleep(behaviorTimeout),
+            Promise.allSettled(
+              page.frames().
+                filter(frame => this.shouldRunBehavior(frame)).
+                map(frame => evaluateWithCLI(frame, "self.__bx_behaviors.run();", logDetails, "behavior"))
+            )
+          ]);
+          if (res && res.length) {
+            this.logger.info("Behaviors finished", {...logDetails, finished: res.length}, "behavior");
+          } else {
+            this.logger.error("Behaviors timed out", logDetails, "behavior");
+          }
         }
       }
 
-      this.logger.info("Page graph data for successfully crawled page", data, "pageGraph");
-
-      await this.writeStats();
+      this.logger.info("Page finished", logDetails, "pageStatus");
 
       await this.checkLimits();
 
       await this.serializeConfig();
 
     } catch (e) {
-      this.logger.error(`Error crawling page ${data.url}`, e);
+      this.logger.error("Page Errored", {...logDetails, ...e}, "pageStatus");
       await this.markPageFailed(page);
     }
   }
@@ -591,7 +602,8 @@ export class Crawler {
       concurrency: this.params.newContext,
       maxConcurrency: this.params.workers,
       skipDuplicateUrls: false,
-      timeout: this.params.timeout * 2,
+      // effectively disable
+      timeout: 1e8,
       puppeteerOptions: this.puppeteerArgs,
       puppeteer,
       monitor: false
@@ -645,6 +657,8 @@ export class Crawler {
       await this.pagesFH.close();
     }
 
+    await this.writeStats(true);
+
     // extra wait for all resources to land into WARCs
     await this.awaitPendingClear();
 
@@ -656,8 +670,6 @@ export class Crawler {
       this.logger.info("Generating CDX");
       await this.awaitProcess(child_process.spawn("wb-manager", ["reindex", this.params.collection], {cwd: this.params.cwd}));
     }
-
-    await this.writeStats(true);
 
     if (this.params.generateWACZ && (!this.interrupted || this.finalExit || this.clearOnExit)) {
       await this.generateWACZ();
@@ -783,7 +795,7 @@ export class Crawler {
       "pendingPages": pendingList.map(x => JSON.stringify(x))
     };
 
-    this.logger.info("Crawl statistics", stats, "crawlState");
+    this.logger.info("Crawl statistics", stats, "crawlStatus");
 
     if (toFile && this.params.statsFilename) {
       try {
@@ -796,6 +808,8 @@ export class Crawler {
 
   async loadPage(page, urlData, selectorOptsList = DEFAULT_SELECTORS) {
     const {url, seedId, depth, extraHops = 0} = urlData;
+
+    const logDetails = {page: url};
 
     let isHTMLPage = true;
 
@@ -840,13 +854,13 @@ export class Crawler {
     try {
       await page.goto(url, gotoOpts);
       if (this.errorCount > 0) {
-        this.logger.info(`Page loaded, resetting error count ${this.errorCount} to 0`);
+        this.logger.info(`Page loaded, resetting error count ${this.errorCount} to 0`, logDetails);
         this.errorCount = 0;
       }
     } catch (e) {
       let msg = e.message || "";
       if (!msg.startsWith("net::ERR_ABORTED") || !ignoreAbort) {
-        this.logger.error(`Load Error: ${url}: ${msg}`);
+        this.logger.error("Page Load Error", {...logDetails, msg});
         this.errorCount++;
       }
     }
@@ -859,9 +873,9 @@ export class Crawler {
 
     const seed = this.params.scopedSeeds[seedId];
 
-    await this.checkCF(page);
+    await this.checkCF(page, logDetails);
 
-    await this.netIdle(page);
+    await this.netIdle(page, logDetails);
 
     //await this.sleep(5);
 
@@ -884,7 +898,7 @@ export class Crawler {
     }
   }
 
-  async netIdle(page) {
+  async netIdle(page, details) {
     if (!this.params.netIdleWait) {
       return;
     }
@@ -895,7 +909,7 @@ export class Crawler {
     try {
       await page.waitForNetworkIdle({timeout: this.params.netIdleWait * 1000});
     } catch (e) {
-      this.logger.info("note: waitForNetworkIdle timed out, ignoring");
+      this.logger.info("waitForNetworkIdle timed out, ignoring", details);
       // ignore, continue
     }
   }
@@ -956,14 +970,14 @@ export class Crawler {
     }
   }
 
-  async checkCF(page) {
+  async checkCF(page, logDetails) {
     try {
       while (await page.$("div.cf-browser-verification.cf-im-under-attack")) {
-        this.logger.info("Cloudflare Check Detected, waiting for reload...");
+        this.logger.info("Cloudflare Check Detected, waiting for reload...", logDetails);
         await this.sleep(5.5);
       }
     } catch (e) {
-      //this.logger.warn("Check CF failed, ignoring", e);
+      //this.logger.warn("Check CF failed, ignoring");
     }
   }
 

--- a/crawler.js
+++ b/crawler.js
@@ -466,18 +466,18 @@ export class Crawler {
       return true;
     }
 
-    const url = frame.url();
+    const frameUrl = frame.url();
 
     let res;
 
-    if (url === "about:blank") {
-      res = true;
+    if (frameUrl === "about:blank") {
+      res = false;
     } else {
-      res = !(await this.adBlockRules.shouldBlock(null, url, logDetails));
+      res = !(await this.adBlockRules.shouldBlock(null, frameUrl, logDetails));
     }
 
     if (!res) {
-      this.logger.info("Skipping behavior for frame", {url, ...logDetails}, "behavior");
+      this.logger.info("Skipping behavior for frame", {frameUrl, ...logDetails}, "behavior");
     }
 
     return res;

--- a/crawler.js
+++ b/crawler.js
@@ -863,7 +863,7 @@ export class Crawler {
 
     await this.netIdle(page);
 
-    await this.sleep(5);
+    //await this.sleep(5);
 
     // skip extraction if at max depth
     if (seed.isAtMaxDepth(depth) || !selectorOptsList) {
@@ -963,7 +963,7 @@ export class Crawler {
         await this.sleep(5.5);
       }
     } catch (e) {
-      this.logger.warn("Check CF failed, ignoring", e);
+      //this.logger.warn("Check CF failed, ignoring", e);
     }
   }
 
@@ -1090,10 +1090,7 @@ export class Crawler {
 
     const redis = await initRedis("redis://localhost/0");
 
-    // wait for pending requests upto 120 secs, unless canceling
-    const MAX_WAIT = 120;
-
-    for (let i = 0; i < MAX_WAIT && !this.interrupted; i++) {
+    while (!this.interrupted) {
       try {
         const count = Number(await redis.get(`pywb:${this.params.collection}:pending`) || 0);
         if (count <= 0) {

--- a/crawler.js
+++ b/crawler.js
@@ -326,20 +326,33 @@ export class Crawler {
 
   _behaviorLog({data, type}, pageUrl) {
     let behaviorLine;
-    data.page = pageUrl;
+    let message;
+    let details;
+
+    if (typeof(data) === "string") {
+      message = data;
+      details = {};
+    } else {
+      message = type === "info" ? "Behavior log" : "Behavior debug";
+      details = typeof(data) === "object" ? data : {};
+    }
+
+    if (pageUrl) {
+      details.page = pageUrl;
+    }
 
     switch (type) {
     case "info":
       behaviorLine = JSON.stringify(data);
       if (behaviorLine != this._behaviorLastLine) {
-        this.logger.info("Behavior log", data, "behavior");
+        this.logger.info(message, details, "behaviorScript");
         this._behaviorLastLine = behaviorLine;
       }
       break;
 
     case "debug":
     default:
-      this.logger.debug("Behavior debug", data, "behavior");
+      this.logger.debug(message, details, "behaviorScript");
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@novnc/novnc": "1.4.0-beta",
     "abort-controller": "^3.0.0",
-    "browsertrix-behaviors": "github:webrecorder/browsertrix-behaviors#opt-autoplay",
+    "browsertrix-behaviors": "^0.4.1",
     "get-folder-size": "^4.0.0",
     "ioredis": "^4.27.1",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@novnc/novnc": "1.4.0-beta",
     "abort-controller": "^3.0.0",
-    "browsertrix-behaviors": "^0.4.1",
+    "browsertrix-behaviors": "^0.4.2",
     "get-folder-size": "^4.0.0",
     "ioredis": "^4.27.1",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.8.0-beta.2",
+  "version": "0.8.1",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",
@@ -13,7 +13,7 @@
   "dependencies": {
     "@novnc/novnc": "1.4.0-beta",
     "abort-controller": "^3.0.0",
-    "browsertrix-behaviors": "^0.4.1",
+    "browsertrix-behaviors": "github:webrecorder/browsertrix-behaviors#opt-autoplay",
     "get-folder-size": "^4.0.0",
     "ioredis": "^4.27.1",
     "js-yaml": "^4.1.0",

--- a/util/blockrules.js
+++ b/util/blockrules.js
@@ -84,13 +84,12 @@ export class BlockRules
 
     await page.setRequestInterception(true);
 
-    const logDetails = {page: page.url()};
-
     page.on("request", async (request) => {
+      const logDetails = {page: page.url()};
       try {
         await this.handleRequest(request, logDetails);
       } catch (e) {
-        this.logger.warn("Error handling request", {...logDetails, ...e}, "blocking");
+        this.logger.warn("Error handling request", {...e, ...logDetails}, "blocking");
       }
     });
   }
@@ -110,7 +109,7 @@ export class BlockRules
       }
 
     } catch (e) {
-      this.logger.debug(`Block: (${blockState}) Failed On: ${url}`, {...logDetails, ...e}, "blocking");
+      this.logger.debug(`Block: (${blockState}) Failed On: ${url}`, {...e, ...logDetails}, "blocking");
     }
   }
 
@@ -157,10 +156,10 @@ export class BlockRules
 
       if (block) {
         if (blockState === BlockState.BLOCK_PAGE_NAV) {
-          this.logger.warn("Block rule match for page request ignored, set --exclude to block full pages", {...logDetails, url}, "blocking");
+          this.logger.warn("Block rule match for page request ignored, set --exclude to block full pages", {url, ...logDetails}, "blocking");
           return BlockState.ALLOW;
         }
-        this.logger.debug("URL Blocked in iframe", {...logDetails, url, frameUrl}, "blocking");
+        this.logger.debug("URL Blocked in iframe", {url, frameUrl, ...logDetails}, "blocking");
         await this.recordBlockMsg(url);
         return blockState;
       }
@@ -210,7 +209,7 @@ export class BlockRules
       return !!text.match(frameTextMatch);
 
     } catch (e) {
-      this.logger.debug("Error determining text match", {...logDetails, ...e}, "blocking");
+      this.logger.debug("Error determining text match", {...e, ...logDetails}, "blocking");
     }
   }
 
@@ -250,13 +249,13 @@ export class AdBlockRules extends BlockRules
 
     await page.setRequestInterception(true);
 
-    const logDetails = {page: page.url()};
-
     page.on("request", async (request) => {
+      const logDetails = {page: page.url()};
+
       try {
         await this.handleRequest(request, logDetails);
       } catch (e) {
-        this.logger.warn("Error handling request", {...logDetails, ...e}, "blocking");
+        this.logger.warn("Error handling request", {...e, ...logDetails}, "blocking");
       }
     });
   }
@@ -265,7 +264,7 @@ export class AdBlockRules extends BlockRules
     const fragments = url.split("/");
     const domain = fragments.length > 2 ? fragments[2] : null;
     if (this.adhosts.includes(domain)) {
-      this.logger.debug("URL blocked for being an ad", {...logDetails, url}, "blocking");
+      this.logger.debug("URL blocked for being an ad", {url, ...logDetails}, "blocking");
       await this.recordBlockMsg(url);
       return BlockState.BLOCK_AD;
     }

--- a/util/browser.js
+++ b/util/browser.js
@@ -145,9 +145,8 @@ export function chromeArgs (proxy, userAgent=null, extraArgs=[]) {
 
 export async function evaluateWithCLI(frame, funcString, logData, contextName) {
   const context = await frame.executionContext();
-  const url = frame.url();
 
-  let details = {url, ...logData};
+  let details = {frameUrl: frame.url(), ...logData};
 
   logger.info("Run Script Started", details, contextName);
 

--- a/util/browser.js
+++ b/util/browser.js
@@ -143,11 +143,13 @@ export function chromeArgs (proxy, userAgent=null, extraArgs=[]) {
 }
 
 
-export async function evaluateWithCLI(frame, funcString, name = "behaviors") {
+export async function evaluateWithCLI(frame, funcString, logData, contextName) {
   const context = await frame.executionContext();
   const url = frame.url();
 
-  logger.info(`Running ${name}...`, {url});
+  let details = {...logData, url};
+
+  logger.info("Run Script Started", details, contextName);
 
   // from puppeteer _evaluateInternal() but with includeCommandLineAPI: true
   const contextId = context._contextId;
@@ -164,13 +166,12 @@ export async function evaluateWithCLI(frame, funcString, name = "behaviors") {
     });
 
   if (exceptionDetails) {
-    const details = exceptionDetails.stackTrace || {};
-    details.url = url;
-    logger.error(
-      `Run ${name} failed: ${exceptionDetails.text}`, details
-    );
+    if (exceptionDetails.stackTrace) {
+      details = {...details, ...exceptionDetails.stackTrace, text: exceptionDetails.text};
+    }
+    logger.error("Run Script Failed", details, contextName);
   } else {
-    logger.info(`Run ${name} finished`, {url});
+    logger.info("Run Script Finished", details, contextName);
   }
 
   return result.value;

--- a/util/browser.js
+++ b/util/browser.js
@@ -147,7 +147,7 @@ export async function evaluateWithCLI(frame, funcString, logData, contextName) {
   const context = await frame.executionContext();
   const url = frame.url();
 
-  let details = {...logData, url};
+  let details = {url, ...logData};
 
   logger.info("Run Script Started", details, contextName);
 
@@ -167,7 +167,7 @@ export async function evaluateWithCLI(frame, funcString, logData, contextName) {
 
   if (exceptionDetails) {
     if (exceptionDetails.stackTrace) {
-      details = {...details, ...exceptionDetails.stackTrace, text: exceptionDetails.text};
+      details = {...exceptionDetails.stackTrace, text: exceptionDetails.text, ...details};
     }
     logger.error("Run Script Failed", details, contextName);
   } else {

--- a/util/state.js
+++ b/util/state.js
@@ -326,11 +326,11 @@ return 0;
       data = JSON.parse(json);
     } catch(e) {
       logger.error("Invalid queued json", json);
-      return null;
+      return undefined;
     }
 
     if (!data) {
-      return null;
+      return undefined;
     }
 
     const url = data.url;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,9 +1148,10 @@ browserslist@^4.21.3:
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.9"
 
-"browsertrix-behaviors@github:webrecorder/browsertrix-behaviors#opt-autoplay":
-  version "0.4.2"
-  resolved "https://codeload.github.com/webrecorder/browsertrix-behaviors/tar.gz/faf939b3953a0feab8ab989c1abfc3cd2bb5869d"
+browsertrix-behaviors@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.4.1.tgz#dfa5beb66348df28ccbaad4ba66fe49ca0dde947"
+  integrity sha512-zG6eNWqT9z+WvdUSSWg6de8NtYnGs7MHpzezKUgMJg+ze1+xtBgc6jkLT1d64eXC0cZQgwW+WV/e0yLAi1PyPA==
 
 bser@2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,10 +1148,9 @@ browserslist@^4.21.3:
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.9"
 
-browsertrix-behaviors@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.4.1.tgz#dfa5beb66348df28ccbaad4ba66fe49ca0dde947"
-  integrity sha512-zG6eNWqT9z+WvdUSSWg6de8NtYnGs7MHpzezKUgMJg+ze1+xtBgc6jkLT1d64eXC0cZQgwW+WV/e0yLAi1PyPA==
+"browsertrix-behaviors@github:webrecorder/browsertrix-behaviors#opt-autoplay":
+  version "0.4.2"
+  resolved "https://codeload.github.com/webrecorder/browsertrix-behaviors/tar.gz/faf939b3953a0feab8ab989c1abfc3cd2bb5869d"
 
 bser@2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,10 +1148,10 @@ browserslist@^4.21.3:
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.9"
 
-browsertrix-behaviors@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.4.1.tgz#dfa5beb66348df28ccbaad4ba66fe49ca0dde947"
-  integrity sha512-zG6eNWqT9z+WvdUSSWg6de8NtYnGs7MHpzezKUgMJg+ze1+xtBgc6jkLT1d64eXC0cZQgwW+WV/e0yLAi1PyPA==
+browsertrix-behaviors@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.4.2.tgz#830f4e37ddebf10dd923237dfd75c734d5d211e9"
+  integrity sha512-5w6kPL3NB/BkmEGxWt3NT3iddAaSzMR1TtDPS7b66fM9kkhpCjCv/R/zR951jWDIeV3flJFBOy09uI5o8asPqg==
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
- Ensure `page` is included in all logging details
- Update logging messages to be a single string, with variables added in the details
- Always wait for all pending wait requests to finish (unless counter <0)
- Don't set puppeteer-cluster timeout (prep for removing puppeeteer-cluster)
- Add behaviorTimeout to running behaviors in crawler, in addition to in behaviors themselves.
- Add logging for behavior start, finish and timeout
- Move writeStats() logging to beginning of each page as well as at the end, to avoid confusion about pending pages.
- deps: bump browsertrix-behaviors to 0.4.2
- version: bump to 0.8.1