### PR TITLE
Crawl log

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -54,7 +54,7 @@ export class Crawler {
     // root collections dir
     this.collDir = path.join(this.params.cwd, "collections", this.params.collection);
     this.logDir = path.join(this.collDir, "logs");
-    this.logFilename = path.join(this.logDir, `crawl-${new Date().toISOString()}.log`);
+    this.logFilename = path.join(this.logDir, `crawl-${new Date().toISOString().replace(/[^\d]/g, '')}.log`);
     this.logFH = fs.createWriteStream(this.logFilename);
 
     const debugLogging = this.params.logging.includes("debug");

--- a/crawler.js
+++ b/crawler.js
@@ -695,6 +695,10 @@ export class Crawler {
       await this.awaitProcess(child_process.spawn("wb-manager", ["reindex", this.params.collection], {cwd: this.params.cwd}));
     }
 
+    // close file-based log
+    setExternalLogStream(null);
+    await new Promise(resolve => this.logFH.close(() => resolve()));
+
     if (this.params.generateWACZ && (!this.interrupted || this.finalExit || this.clearOnExit)) {
       await this.generateWACZ();
 
@@ -719,9 +723,6 @@ export class Crawler {
   }
 
   async generateWACZ() {
-    setExternalLogStream(null);
-    await new Promise(resolve => this.logFH.close(() => resolve()));
-
     this.logger.info("Generating WACZ");
 
     const archiveDir = path.join(this.collDir, "archive");

--- a/crawler.js
+++ b/crawler.js
@@ -54,7 +54,7 @@ export class Crawler {
     // root collections dir
     this.collDir = path.join(this.params.cwd, "collections", this.params.collection);
     this.logDir = path.join(this.collDir, "logs");
-    this.logFilename = path.join(this.logDir, `crawl-${new Date().toISOString().replace(/[^\d]/g, '')}.log`);
+    this.logFilename = path.join(this.logDir, `crawl-${new Date().toISOString().replace(/[^\d]/g, "")}.log`);
     this.logFH = fs.createWriteStream(this.logFilename);
 
     const debugLogging = this.params.logging.includes("debug");

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pywb>=2.7.3
 uwsgi
-wacz>=0.4.6
+wacz>=0.4.8
 requests[socks]

--- a/util/logger.js
+++ b/util/logger.js
@@ -1,5 +1,11 @@
 // ===========================================================================
+let logStream = null;
 
+export function setExternalLogStream(logFH) {
+  logStream = logFH;
+}
+
+// ===========================================================================
 export class Logger
 {
   constructor(debugLogging=false) {
@@ -19,7 +25,11 @@ export class Logger
       "message": message,
       "details": data ? data : {}
     };
-    console.log(JSON.stringify(dataToLog));
+    const string = JSON.stringify(dataToLog);
+    console.log(string);
+    if (logStream) {
+      logStream.write(string + "\n");
+    }
   }
 
   info(message, data={}, context="general") {


### PR DESCRIPTION
Write crawl log to `{coll}/logs/crawl-{iso-timestamp}.log` from when crawl is started to just before WACZ creation starts (to allow storing log in WACZ).

Still requires py-wacz support to add logs.