### PR TITLE
logging: serialize regex as string to avoid empty '{}' when logging s…

### DIFF
--- a/util/logger.js
+++ b/util/logger.js
@@ -5,6 +5,10 @@ export function setExternalLogStream(logFH) {
   logStream = logFH;
 }
 
+// to fix serialization of regexes for logging purposes
+RegExp.prototype.toJSON = RegExp.prototype.toString;
+
+
 // ===========================================================================
 export class Logger
 {


### PR DESCRIPTION
…coping rules, fixes #234

(Per recommendation from: https://stackoverflow.com/questions/12075927/serialization-of-regexp)