### PR TITLE
Healthcheck + Logging Fixes + Iframe Filtering Fixes

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -664,7 +664,6 @@ export class Crawler {
 
     this.workerPool = new WorkerPool({
       maxConcurrency: this.params.workers,
-      timeout: this.params.timeout * 2,
       puppeteerOptions: this.puppeteerArgs,
       crawlState: this.crawlState,
       screencaster: this.screencaster,

--- a/crawler.js
+++ b/crawler.js
@@ -424,6 +424,7 @@ export class Crawler {
 
       let text = "";
       if (this.params.text && page.isHTMLPage) {
+        this.logger.info("Extracting text", logDetails, "general");
         const client = await page.target().createCDPSession();
         const result = await client.send("DOM.getDocument", {"depth": -1, "pierce": true});
         text = await new TextExtract(result).parseTextFromDom();

--- a/crawler.js
+++ b/crawler.js
@@ -167,18 +167,18 @@ export class Crawler {
         }
       }
 
-      this.logger.info(`Storing state via Redis ${redisUrl} @ key prefix "${this.crawlId}"`, {}, "state");
+      this.logger.debug(`Storing state via Redis ${redisUrl} @ key prefix "${this.crawlId}"`, {}, "state");
 
       this.crawlState = new RedisCrawlState(redis, this.params.crawlId, this.params.behaviorTimeout + this.params.timeout, os.hostname());
 
     } else {
-      this.logger.info("Storing state in memory", {}, "state");
+      this.logger.debug("Storing state in memory", {}, "state");
 
       this.crawlState = new MemoryCrawlState();
     }
 
     if (this.params.saveState === "always" && this.params.saveStateInterval) {
-      this.logger.info(`Saving crawl state every ${this.params.saveStateInterval} seconds, keeping last ${this.params.saveStateHistory} states`, {}, "state");
+      this.logger.debug(`Saving crawl state every ${this.params.saveStateInterval} seconds, keeping last ${this.params.saveStateHistory} states`, {}, "state");
     }
 
     return this.crawlState;
@@ -213,7 +213,7 @@ export class Crawler {
     }
 
     if (this.params.overwrite) {
-      this.logger.info(`Clearing ${this.collDir} before starting`);
+      this.logger.debug(`Clearing ${this.collDir} before starting`);
       try {
         fs.rmSync(this.collDir, { recursive: true, force: true });
       } catch(e) {
@@ -224,7 +224,7 @@ export class Crawler {
     const initRes = child_process.spawnSync("wb-manager", ["init", this.params.collection], {cwd: this.params.cwd});
 
     if (initRes.status) {
-      this.logger.info("wb-manager init failed, collection likely already exists");
+      this.logger.debug("wb-manager init failed, collection likely already exists");
     }
 
     let opts = {};
@@ -411,7 +411,7 @@ export class Crawler {
 
       if (this.params.screenshot) {
         if (!page.isHTMLPage) {
-          this.logger.info("Skipping screenshots for non-HTML page", logDetails);
+          this.logger.debug("Skipping screenshots for non-HTML page", logDetails);
         }
         const archiveDir = path.join(this.collDir, "archive");
         const screenshots = new Screenshots({page, url, directory: archiveDir});
@@ -428,7 +428,7 @@ export class Crawler {
 
       let text = "";
       if (this.params.text && page.isHTMLPage) {
-        this.logger.info("Extracting text", logDetails, "general");
+        this.logger.debug("Extracting text", logDetails, "general");
         const client = await page.target().createCDPSession();
         const result = await client.send("DOM.getDocument", {"depth": -1, "pierce": true});
         text = await new TextExtract(result).parseTextFromDom();
@@ -438,7 +438,7 @@ export class Crawler {
 
       if (this.params.behaviorOpts) {
         if (!page.isHTMLPage) {
-          this.logger.info("Skipping behaviors for non-HTML page", logDetails, "behavior");
+          this.logger.debug("Skipping behaviors for non-HTML page", logDetails, "behavior");
         } else {
           const behaviorTimeout = this.params.behaviorTimeout / 1000;
 
@@ -499,7 +499,7 @@ export class Crawler {
     }
 
     if (!res) {
-      this.logger.info("Skipping processing frame", {frameUrl, ...logDetails}, "behavior");
+      this.logger.debug("Skipping processing frame", {frameUrl, ...logDetails}, "behavior");
     }
 
     return res;
@@ -831,7 +831,7 @@ export class Crawler {
 
   awaitProcess(proc) {
     proc.stdout.on("data", (data) => {
-      this.logger.info(data.toString());
+      this.logger.debug(data.toString());
     });
 
     proc.stderr.on("data", (data) => {
@@ -944,7 +944,7 @@ export class Crawler {
     }
 
     if (!isHTMLPage) {
-      this.logger.info("Skipping link extraction for non-HTML page", logDetails);
+      this.logger.debug("Skipping link extraction for non-HTML page", logDetails);
       return;
     }
 
@@ -986,7 +986,7 @@ export class Crawler {
     try {
       await page.waitForNetworkIdle({timeout: this.params.netIdleWait * 1000});
     } catch (e) {
-      this.logger.info("waitForNetworkIdle timed out, ignoring", details);
+      this.logger.debug("waitForNetworkIdle timed out, ignoring", details);
       // ignore, continue
     }
   }
@@ -1062,7 +1062,7 @@ export class Crawler {
       this.logger.debug("Check CF Blocking", logDetails);
 
       while (await page.$("div.cf-browser-verification.cf-im-under-attack")) {
-        this.logger.info("Cloudflare Check Detected, waiting for reload...", logDetails);
+        this.logger.debug("Cloudflare Check Detected, waiting for reload...", logDetails);
         await this.sleep(5.5);
       }
     } catch (e) {
@@ -1110,10 +1110,10 @@ export class Crawler {
         const header = {"format": "json-pages-1.0", "id": "pages", "title": "All Pages"};
         if (this.params.text) {
           header["hasText"] = true;
-          this.logger.info("Text Extraction: Enabled");
+          this.logger.debug("Text Extraction: Enabled");
         } else {
           header["hasText"] = false;
-          this.logger.info("Text Extraction: Disabled");
+          this.logger.debug("Text Extraction: Disabled");
         }
         const header_formatted = JSON.stringify(header).concat("\n");
         await this.pagesFH.writeFile(header_formatted);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "js-yaml": "^4.1.0",
     "minio": "7.0.26",
     "p-queue": "^7.3.0",
-    "puppeteer-core": "^17.1.2",
+    "puppeteer-core": "^19.7.2",
     "request": "^2.88.2",
     "sitemapper": "^3.1.2",
     "uuid": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "AGPL-3.0-or-later",
   "scripts": {
     "lint": "eslint *.js util/*.js tests/*.test.js",
-    "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest --bail 1)"
   },
   "dependencies": {
     "@novnc/novnc": "1.4.0-beta",

--- a/util/blockrules.js
+++ b/util/blockrules.js
@@ -260,10 +260,14 @@ export class AdBlockRules extends BlockRules
     });
   }
 
-  async shouldBlock(request, url, logDetails) {
+  isAdUrl(url) {
     const fragments = url.split("/");
     const domain = fragments.length > 2 ? fragments[2] : null;
-    if (this.adhosts.includes(domain)) {
+    return this.adhosts.includes(domain);
+  }
+ 
+  async shouldBlock(request, url, logDetails) {
+    if (this.isAdUrl(url)) {
       this.logger.debug("URL blocked for being an ad", {url, ...logDetails}, "blocking");
       await this.recordBlockMsg(url);
       return BlockState.BLOCK_AD;

--- a/util/blockrules.js
+++ b/util/blockrules.js
@@ -265,7 +265,7 @@ export class AdBlockRules extends BlockRules
     const domain = fragments.length > 2 ? fragments[2] : null;
     return this.adhosts.includes(domain);
   }
- 
+
   async shouldBlock(request, url, logDetails) {
     if (this.isAdUrl(url)) {
       this.logger.debug("URL blocked for being an ad", {url, ...logDetails}, "blocking");

--- a/util/healthcheck.js
+++ b/util/healthcheck.js
@@ -1,0 +1,49 @@
+import http from "http";
+import url from "url";
+import { Logger } from "./logger.js";
+
+const logger = new Logger();
+
+
+// ===========================================================================
+export class HealthChecker
+{
+  constructor(port, errorThreshold) {
+    this.port = port;
+    this.errorCount = 0;
+    this.errorThreshold = errorThreshold;
+
+    this.healthServer = http.createServer((...args) => this.healthCheck(...args));
+    logger.info(`Healthcheck server started on ${port}`, {}, "healthcheck");
+    this.healthServer.listen(port);
+  }
+
+  async healthCheck(req, res) {
+    const pathname = url.parse(req.url).pathname;
+    switch (pathname) {
+    case "/healthz":
+      if (this.errorCount < this.errorThreshold) {
+        logger.debug(`health check ok, num errors ${this.errorCount} < ${this.errorThreshold}`, {}, "healthcheck");
+        res.writeHead(200);
+        res.end();
+      }
+      return;
+    }
+
+    logger.error(`health check failed: ${this.errorCount} >= ${this.errorThreshold}`, {}, "healthcheck");
+    res.writeHead(503);
+    res.end();
+  }
+
+  resetErrors() {
+    if (this.errorCount > 0) {
+      logger.info(`Page loaded, resetting error count ${this.errorCount} to 0`, {}, "healthcheck");
+      this.errorCount = 0;
+    }
+  }
+
+  incError() {
+    this.errorCount++;
+  }
+}
+

--- a/util/logger.js
+++ b/util/logger.js
@@ -1,8 +1,13 @@
 // ===========================================================================
 let logStream = null;
+let debugLogging = false;
 
 export function setExternalLogStream(logFH) {
   logStream = logFH;
+}
+
+export function setDebugLogging(debugLog) {
+  debugLogging = debugLog;
 }
 
 // ===========================================================================
@@ -19,10 +24,6 @@ export function errJSON(e) {
 // ===========================================================================
 export class Logger
 {
-  constructor(debugLogging=false) {
-    this.debugLogging = debugLogging;
-  }
-
   logAsJSON(message, data, context, logLevel="info") {
     if (data instanceof Error) {
       data = errJSON(data);
@@ -56,7 +57,7 @@ export class Logger
   }
 
   debug(message, data={}, context="general") {
-    if (this.debugLogging) {
+    if (debugLogging) {
       this.logAsJSON(message, data, context, "debug");
     }
   }

--- a/util/worker.js
+++ b/util/worker.js
@@ -189,7 +189,7 @@ export class WorkerPool
     const job = await this.crawlState.shift();
 
     if (!job) {
-      logger.info("No jobs available", {}, "worker");
+      logger.debug("No jobs available - waiting for pending pages to finish", {}, "worker");
       this.freeWorker(worker);
       return;
     }

--- a/util/worker.js
+++ b/util/worker.js
@@ -1,4 +1,4 @@
-import { EventEmitter } from "node:events";
+//import { EventEmitter } from "node:events";
 import PQueue from "p-queue";
 import puppeteer from "puppeteer-core";
 
@@ -6,25 +6,42 @@ import { Logger, errJSON } from "./logger.js";
 
 const logger = new Logger();
 
-class BrowserEmitter extends EventEmitter {}
-const browserEmitter = new BrowserEmitter();
+//class BrowserEmitter extends EventEmitter {}
+//const browserEmitter = new BrowserEmitter();
+
+const MAX_REUSE = 5;
 
 
 // ===========================================================================
 export class Worker
 {
-  constructor(id, browser, timeout, task, puppeteerOptions, screencaster) {
+  constructor(id, browser, task, puppeteerOptions, screencaster, healthChecker) {
     this.id = id;
     this.browser = browser;
-    this.timeout = timeout;
     this.task = task;
     this.puppeteerOptions = puppeteerOptions;
     this.screencaster = screencaster;
+    this.healthChecker = healthChecker;
+
+    this.reuseCount = 0;
+    this.page = null;
     
     this.startPage = "about:blank?_browsertrix" + Math.random().toString(36).slice(2);
   }
 
-  async initPage(job) {
+  async initPage() {
+    if (this.page && ++this.reuseCount <= MAX_REUSE) {
+      logger.debug("Reusing page", {reuseCount: this.reuseCount}, "worker");
+      return this.page;
+    } else if (this.page) {
+      try {
+        await this.page.close();
+      } catch (e) {
+        // ignore
+      }
+      this.page = null;
+    }
+
     //open page in a new tab
     this.pendingTargets = new Map();
 
@@ -34,19 +51,33 @@ export class Worker
       }
     });
 
-    try {
-      const mainTarget = this.browser.target();
-      this.cdp = await mainTarget.createCDPSession();
-      let targetId;
-      const res = await this.cdp.send("Target.createTarget", {url: this.startPage, newWindow: true});
-      targetId = res.targetId;
-      const target = this.pendingTargets.get(targetId);
-      this.pendingTargets.delete(targetId);
-      this.page = await target.page();
-      this.page._workerid = this.id;
-    } catch (err) {
-      logger.warn("Error getting new page in window context", {"workerid": this.id, ...errJSON(err)}, "worker");
-      this.repair(job);
+    this.reuseCount = 1;
+
+    while (true) {
+      try {
+        logger.debug("Opening new page", {}, "worker");
+        const mainTarget = this.browser.target();
+        this.cdp = await mainTarget.createCDPSession();
+        let targetId;
+        const res = await this.cdp.send("Target.createTarget", {url: this.startPage, newWindow: true});
+        targetId = res.targetId;
+        const target = this.pendingTargets.get(targetId);
+        this.pendingTargets.delete(targetId);
+        this.page = await target.page();
+        this.page._workerid = this.id;
+        if (this.healthChecker) {
+          this.healthChecker.resetErrors();
+        }
+        break;
+      } catch (err) {
+        logger.warn("Error getting new page in window context", {"workerid": this.id, ...errJSON(err)}, "worker");
+        await sleep(500);
+        logger.warn("Retry getting new page");
+
+        if (this.healthChecker) {
+          this.healthChecker.incError();
+        }
+      }
     }
   }
 
@@ -56,9 +87,11 @@ export class Worker
     }
 
     const urlData = job.data;
-    await this.initPage(job);
+
+    await this.initPage();
 
     const url = job.getUrl();
+
     logger.info("Starting page", {"workerid": this.id, "page": url}, "worker");
 
     let result;
@@ -68,12 +101,6 @@ export class Worker
       page: this.page,
       data: urlData,
     });
-
-    try {
-      await this.page.close();
-    } catch (e) {
-      // ignore
-    }
 
     if (errorState) {
       return {
@@ -87,16 +114,6 @@ export class Worker
       type: "success",
     };
   }
-
-  repair(job) {
-    logger.info("Starting repair", {workerid: this.id}, "worker");
-    browserEmitter.emit("repair", this, job);
-  }
-
-  async shutdown() {
-    logger.info("Shutting down browser", {workerid: this.id}, "worker");
-    browserEmitter.emit("close");
-  }
 }
 
 
@@ -105,10 +122,10 @@ export class WorkerPool
 {
   constructor(options) {
     this.maxConcurrency = options.maxConcurrency;
-    this.timeout = options.timeout;
     this.puppeteerOptions = options.puppeteerOptions;
     this.crawlState = options.crawlState;
     this.screencaster = options.screencaster;
+    this.healthChecker = options.healthChecker;
 
     this.task = options.task;
 
@@ -118,22 +135,9 @@ export class WorkerPool
     this.workersAvailable = [];
     this.workersBusy = [];
 
-    this.errorCount = 0;
     this.interrupted = false;
 
     this.createWorkers(this.maxConcurrency);
-
-    browserEmitter.on("repair", (worker, job) => {
-      setImmediate(() => {
-        if (!this.interrupted) {
-          this.repair(worker, job);
-        }
-      });
-    });
-
-    browserEmitter.on("close", () => {
-      this.close();
-    });
   }
 
   async createWorkers(numWorkers = 1) {
@@ -150,10 +154,10 @@ export class WorkerPool
     const worker = new Worker(
       id,
       this.browser,
-      this.timeout,
       this.task,
       this.puppeteerOptions,
-      this.screencaster
+      this.screencaster,
+      this.healthChecker
     );
     this.workers.push(worker);
     this.workersAvailable.push(worker);
@@ -167,7 +171,7 @@ export class WorkerPool
     }
 
     // wait half a second and try again
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await sleep(500);
 
     return await this.getAvailableWorker();
     
@@ -196,9 +200,17 @@ export class WorkerPool
       if (job.callbacks) {
         job.callbacks.reject(result.error);
       }
-      this.errorCount += 1;
-    } else if (result.type === "success" && job.callbacks) {
-      job.callbacks.resolve(result.data);
+      if (this.healthChecker) {
+        this.healthChecker.incError();
+      }
+    } else if (result.type === "success") {
+      if (this.healthChecker) {
+        this.healthChecker.resetErrors();
+      }
+
+      if (job.callbacks) {
+        job.callbacks.resolve(result.data);
+      }
     }
 
     this.freeWorker(worker);
@@ -219,7 +231,7 @@ export class WorkerPool
       }
 
       // wait half a second
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await sleep(500);
     }
 
     await queue.onIdle();
@@ -228,22 +240,6 @@ export class WorkerPool
   interrupt() {
     logger.info("Interrupting Crawl", {}, "worker");
     this.interrupted = true;
-  }
-
-  async repair (worker, job) {
-    if (this.screencaster) {
-      this.screencaster.endAllTargets();
-    }
-
-    try {
-      // will probably fail, but just in case the repair was not necessary
-      await this.browser.close();
-    /* eslint-disable no-empty */
-    } catch (e) {}
-    
-    logger.info(`Re-launching job in worker ${worker.id} with repaired browser`, {}, "worker");
-    this.browser = await puppeteer.launch(this.puppeteerOptions);
-    await worker.runTask(job);
   }
 
   async close() {
@@ -256,5 +252,7 @@ export class WorkerPool
   }
 }
 
-
+function sleep(millis) {
+  return new Promise(resolve => setTimeout(resolve, millis));
+}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,6 +1266,13 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chromium-bidi@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.4.4.tgz#44f25d4fa5d2f3debc3fc3948d0657194cac4407"
+  integrity sha512-4BX5cSaponuvVT1+SbLYTOAgDoVtX/Khoc9UsbFJ/AsPVUeFAM3RiIDFI6XFhLYMi9WmVJqh1ZH+dRpNKkKwiQ==
+  dependencies:
+    mitt "3.0.0"
+
 ci-info@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.5.0.tgz#bfac2a29263de4c829d806b1ab478e35091e171f"
@@ -1533,10 +1540,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-devtools-protocol@0.0.1036444:
-  version "0.0.1036444"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1036444.tgz#a570d3cdde61527c82f9b03919847b8ac7b1c2b9"
-  integrity sha512-0y4f/T8H9lsESV9kKP1HDUXgHxCdniFeJh6Erq+FbdOEvp/Ydp9t8kcAAM5gOd17pMrTDlFWntoHtzzeTUWKNw==
+devtools-protocol@0.0.1094867:
+  version "0.0.1094867"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1094867.tgz#2ab93908e9376bd85d4e0604aa2651258f13e374"
+  integrity sha512-pmMDBKiRVjh0uKK6CT1WqZmM3hBVSgD+N2MrgyV1uNizAZMw4tx6i/RTc+/uCsKSCmg0xXx7arCP/OFcIwTsiQ==
 
 diff-sequences@^29.2.0:
   version "29.2.0"
@@ -3231,6 +3238,11 @@ minio@7.0.26:
     xml "^1.0.0"
     xml2js "^0.4.15"
 
+mitt@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.0.tgz#69ef9bd5c80ff6f57473e8d89326d01c414be0bd"
+  integrity sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==
+
 mkdirp-classic@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
@@ -3547,7 +3559,7 @@ pretty-format@^29.2.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-progress@2.0.3, progress@^2.0.0:
+progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -3604,22 +3616,22 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer-core@^17.1.2:
-  version "17.1.2"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-17.1.2.tgz#fdf109fa2d805fdb007b5abfc83728c545ac9ac0"
-  integrity sha512-mUndfkp581aFC9Tj0NQzoQ4kBEiYszvubkAovAfA72cO2VgiAnk4RTeQhgPekdL50+7bvU1JZp+10y2xOBOy0g==
+puppeteer-core@^19.7.2:
+  version "19.7.2"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-19.7.2.tgz#deee9ef915829b6a1d1a3a008625c29eeb251161"
+  integrity sha512-PvI+fXqgP0uGJxkyZcX51bnzjFA73MODZOAv0fSD35yR7tvbqwtMV3/Y+hxQ0AMMwzxkEebP6c7po/muqxJvmQ==
   dependencies:
+    chromium-bidi "0.4.4"
     cross-fetch "3.1.5"
     debug "4.3.4"
-    devtools-protocol "0.0.1036444"
+    devtools-protocol "0.0.1094867"
     extract-zip "2.0.1"
     https-proxy-agent "5.0.1"
-    progress "2.0.3"
     proxy-from-env "1.1.0"
     rimraf "3.0.2"
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
-    ws "8.8.1"
+    ws "8.11.0"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -4401,10 +4413,10 @@ write-file-atomic@^4.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@8.8.1:
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
-  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
+ws@8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
 
 ws@^7.4.4:
   version "7.4.5"


### PR DESCRIPTION
- Refactor healthchecker into own class, increment healthcheck for new page load failures
- Reuse pages (upto 5 page loads per page) before creating a new page (similar to old window-concurrency system)
- iframes: ensure blank iframes are filtered out correctly for both behaviors and link extraction
- adblock: add sync isAdUrl() check
- link extraction: set timeout to avoid hanging in link extraction
- logging: set debug logging globally
- deps: bump puppeteer-core to latest