### PR TITLE
Add timedRun to prevent async operations from hanging

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -41,7 +41,7 @@ const HTTP_AGENT = HTTPAgent();
 
 const behaviors = fs.readFileSync(new URL("./node_modules/browsertrix-behaviors/dist/behaviors.js", import.meta.url), {encoding: "utf8"});
 
-const FETCH_TIMEOUT_SECS = 60;
+const FETCH_TIMEOUT_SECS = 30;
 const PAGE_OP_TIMEOUT_SECS = 5;
 
 

--- a/crawler.js
+++ b/crawler.js
@@ -876,7 +876,6 @@ export class Crawler {
           "Direct fetch capture attempt timed out",
           logDetails
         );
-        this.logger.info("captureResult", captureResult);
         if (captureResult.value) {
           return;
         }


### PR DESCRIPTION
Fixes #239 

`timedRun` is not applied to Puppeteer methods likely to time out such as `page.goto()`, as Puppeteer has its own timeouts for these methods, as described here: https://stackoverflow.com/a/58001115.