### PR TITLE
Catch loading issues

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -469,10 +469,6 @@ export class Crawler {
     }
   }
 
-  async workerDone(/*workerid*/) {
-    // track worker done
-  }
-
   async runBehaviors(page, frames, logDetails) {
     try {
       frames = frames || page.frames();

--- a/crawler.js
+++ b/crawler.js
@@ -431,8 +431,10 @@ export class Crawler {
 
     // if page loaded, considered page finished successfully
     // (even if behaviors timed out)
+    const { loadState, logDetails } = data;
+
     if (data.loadState >= LoadState.FULL_PAGE_LOADED) {
-      logger.info("Page Finished", data.logDetails, "pageStatus");
+      logger.info("Page Finished", {loadState, ...logDetails}, "pageStatus");
 
       await this.crawlState.markFinished(data.url);
 
@@ -440,7 +442,7 @@ export class Crawler {
         this.healthChecker.resetErrors();
       }
     } else {
-      logger.warn("Page Load Failed", data.logDetails, "pageStatus");
+      logger.warn("Page Load Failed", {loadState, ...logDetails}, "pageStatus");
 
       await this.crawlState.markFailed(data.url);
 

--- a/crawler.js
+++ b/crawler.js
@@ -462,7 +462,7 @@ export class Crawler {
     }
   }
 
-  async workerEmpty(workerid) {
+  async workerIdle(workerid) {
     if (this.screencaster) {
       //logger.debug("End Screencast", {workerid}, "screencast");
       await this.screencaster.stopById(workerid, true);

--- a/crawler.js
+++ b/crawler.js
@@ -460,11 +460,15 @@ export class Crawler {
     }
   }
 
-  async workerDone(workerid) {
+  async workerEmpty(workerid) {
     if (this.screencaster) {
       //logger.debug("End Screencast", {workerid}, "screencast");
       await this.screencaster.stopById(workerid, true);
     }
+  }
+
+  async workerDone(/*workerid*/) {
+    // track worker done
   }
 
   async runBehaviors(page, frames, logDetails) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@novnc/novnc": "^1.4.0",
-    "browsertrix-behaviors": "github:webrecorder/browsertrix-behaviors#autoscroll-fix",
+    "browsertrix-behaviors": "^0.5.0-beta.0",
     "get-folder-size": "^4.0.0",
     "ioredis": "^4.27.1",
     "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@novnc/novnc": "^1.4.0",
-    "browsertrix-behaviors": "^0.4.2",
+    "browsertrix-behaviors": "github:webrecorder/browsertrix-behaviors#autoscroll-fix",
     "get-folder-size": "^4.0.0",
     "ioredis": "^4.27.1",
     "js-yaml": "^4.1.0",

--- a/util/browser.js
+++ b/util/browser.js
@@ -69,6 +69,10 @@ export class Browser
     return {page: this.firstPage, cdp: this.firstCDP};
   }
 
+  numPages() {
+    return this.context ? this.context.pages().length : 0;
+  }
+
   async newWindowPageWithCDP() {
     // unique url to detect new pages
     const startPage = "about:blank?_browsertrix" + Math.random().toString(36).slice(2);

--- a/util/screencaster.js
+++ b/util/screencaster.js
@@ -251,7 +251,7 @@ class ScreenCaster
 
     logger.info("Started Screencast", {workerid: id}, "screencast");
 
-    await cdp.send("Page.startScreencast", {format: "png", everyNthFrame: 2, maxWidth: this.maxWidth, maxHeight: this.maxHeight});
+    await cdp.send("Page.startScreencast", {format: "png", everyNthFrame: 1, maxWidth: this.maxWidth, maxHeight: this.maxHeight});
   }
 
   async stopCast(cdp, id) {

--- a/util/state.js
+++ b/util/state.js
@@ -186,7 +186,7 @@ return 0;
 
     await this.markStarted(data.url);
 
-    return data;
+    return new PageState(data);
   }
 
   async has(url) {
@@ -325,3 +325,26 @@ return 0;
   }
 }
 
+
+// ============================================================================
+class PageState
+{
+  constructor(redisData) {
+    this.url = redisData.url;
+    this.seedId = redisData.seedId;
+    this.depth = redisData.depth;
+    this.extraHops = redisData.extraHops;
+
+    this.workerid = null;
+    this.title = null;
+
+    this.isHTMLPage = null;
+    this.text = null;
+
+    this.skipBehaviors = false;
+    this.filteredFrames = [];
+
+    this.pageLoaded = false;
+    this.behaviorsFinished = false;
+  }
+}

--- a/util/state.js
+++ b/util/state.js
@@ -31,6 +31,7 @@ export class PageState
     this.filteredFrames = [];
 
     this.loadState = LoadState.FAILED;
+    this.logDetails = {};
   }
 }
 

--- a/util/state.js
+++ b/util/state.js
@@ -4,6 +4,38 @@ import { MAX_DEPTH } from "./constants.js";
 
 
 // ============================================================================
+export const LoadState = {
+  FAILED: 0,
+  CONTENT_LOADED: 1,
+  FULL_PAGE_LOADED: 2,
+  EXTRACTION_DONE: 3,
+  BEHAVIORS_DONE: 4,
+};
+
+// ============================================================================
+export class PageState
+{
+  constructor(redisData) {
+    this.url = redisData.url;
+    this.seedId = redisData.seedId;
+    this.depth = redisData.depth;
+    this.extraHops = redisData.extraHops;
+
+    this.workerid = null;
+    this.title = null;
+
+    this.isHTMLPage = null;
+    this.text = null;
+
+    this.skipBehaviors = false;
+    this.filteredFrames = [];
+
+    this.loadState = LoadState.FAILED;
+  }
+}
+
+
+// ============================================================================
 export class RedisCrawlState
 {
   constructor(redis, key, pageTimeout, uid) {
@@ -325,26 +357,3 @@ return 0;
   }
 }
 
-
-// ============================================================================
-class PageState
-{
-  constructor(redisData) {
-    this.url = redisData.url;
-    this.seedId = redisData.seedId;
-    this.depth = redisData.depth;
-    this.extraHops = redisData.extraHops;
-
-    this.workerid = null;
-    this.title = null;
-
-    this.isHTMLPage = null;
-    this.text = null;
-
-    this.skipBehaviors = false;
-    this.filteredFrames = [];
-
-    this.pageLoaded = false;
-    this.behaviorsFinished = false;
-  }
-}

--- a/util/timing.js
+++ b/util/timing.js
@@ -19,7 +19,7 @@ export function timedRun(promise, seconds, message="Promise timed out", logDetai
       if (err == "timeout reached") {
         logger.error(message, {"seconds": seconds, ...logDetails}, context);
       } else {
-        logger.error("Promise rejected", {...err, ...logDetails}, context);
+        logger.error("Other error", {...err, ...logDetails}, context);
       }
     });
 }

--- a/util/timing.js
+++ b/util/timing.js
@@ -1,4 +1,4 @@
-import { logger } from "./logger.js";
+import { logger, errJSON } from "./logger.js";
 
 export function sleep(seconds) {
   return new Promise(resolve => setTimeout(resolve, seconds * 1000));
@@ -19,7 +19,7 @@ export function timedRun(promise, seconds, message="Promise timed out", logDetai
       if (err == "timeout reached") {
         logger.error(message, {"seconds": seconds, ...logDetails}, context);
       } else {
-        logger.error("Other error", {...err, ...logDetails}, context);
+        logger.error("Unknown exception", {...errJSON(err), ...logDetails}, context);
       }
     });
 }

--- a/util/worker.js
+++ b/util/worker.js
@@ -74,7 +74,7 @@ export class PageWorker
         const { page, cdp } = await timedRun(
           this.crawler.browser.newWindowPageWithCDP(),
           NEW_WINDOW_TIMEOUT,
-          "New Window Timed Out!",
+          "New Window Timed Out",
           {workerid},
           "worker"
         );

--- a/util/worker.js
+++ b/util/worker.js
@@ -175,8 +175,9 @@ export class PageWorker
         await this.timedCrawlPage({...opts, data});
 
       } else {
-        // indicate that the worker is empty (mostly for screencasting, status, etc...)
-        this.crawler.workerEmpty(this.id);
+        // indicate that the worker has no more work (mostly for screencasting, status, etc...)
+        // depending on other works, will either get more work or crawl will end
+        this.crawler.workerIdle(this.id);
 
         // check if any pending urls
         const pending = await crawlState.numPending();

--- a/util/worker.js
+++ b/util/worker.js
@@ -177,6 +177,8 @@ export class PageWorker
         await this.timedCrawlPage({...opts, data});
 
       } else {
+        // indicate that the worker is empty (mostly for screencasting, status, etc...)
+        this.crawler.workerEmpty(this.id);
 
         // otherwise, see if any pending urls
         const pending = await crawlState.numPending();

--- a/util/worker.js
+++ b/util/worker.js
@@ -157,8 +157,6 @@ export class PageWorker
       logger.info("Worker exiting, all tasks complete", {workerid: this.id}, "worker");
     } catch (e) {
       logger.error("Worker errored", e, "worker");
-    } finally {
-      this.crawler.workerDone(this.id);
     }
   }
 
@@ -180,7 +178,7 @@ export class PageWorker
         // indicate that the worker is empty (mostly for screencasting, status, etc...)
         this.crawler.workerEmpty(this.id);
 
-        // otherwise, see if any pending urls
+        // check if any pending urls
         const pending = await crawlState.numPending();
 
         // if pending, sleep and check again

--- a/util/worker.js
+++ b/util/worker.js
@@ -12,7 +12,8 @@ export function runWorkers(crawler, numWorkers, timeout) {
   const workers = [];
 
   for (let i = 0; i < numWorkers; i++) {
-    workers.push(new PageWorker(`worker-${i+1}`, crawler, timeout));
+    //workers.push(new PageWorker(`worker-${i+1}`, crawler, timeout));
+    workers.push(new PageWorker(i, crawler, timeout));
   }
 
   return Promise.allSettled(workers.map((worker) => worker.run()));
@@ -33,35 +34,43 @@ export class PageWorker
 
     this.opts = null;
 
-    this.failed = false;
     this.logDetails = {workerid: this.id};
+
+    this.crashed = false;
+    this.markCrashed = null;
+    this.crashBreak = null;
   }
 
   async closePage() {
     if (this.page) {
-      await this.crawler.teardownPage(this.opts);
 
-      try {
-        await this.cdp.detach();
-      } catch (e) {
-        // ignore
+      if (!this.crashed) {
+        await this.crawler.teardownPage(this.opts);
+      } else {
+        logger.debug("Closing crashed page", {workerid: this.id}, "worker");
       }
-      this.cdp = null;
 
       try {
         await this.page.close();
       } catch (e) {
         // ignore
       }
+
+      if (this.crashed) {
+        const numPagesRemaining = this.crawler.browser.numPages() - 1;
+        logger.debug("Skipping teardown of crashed page", {numPagesRemaining, workerid: this.id}, "worker");
+      }
+
+      this.cdp = null;
       this.page = null;
     }
   }
 
   async initPage() {
-    if (this.page && ++this.reuseCount <= MAX_REUSE) {
+    if (!this.crashed && this.page && ++this.reuseCount <= MAX_REUSE) {
       logger.debug("Reusing page", {reuseCount: this.reuseCount}, "worker");
       return this.opts;
-    } else {
+    } else if (this.page) {
       await this.closePage();
     }
     
@@ -84,13 +93,16 @@ export class PageWorker
         this.opts = {page: this.page, cdp: this.cdp, workerid};
 
         // updated per page crawl
-        this.failed = false;
+        this.crashed = false;
+        this.crashBreak = new Promise((resolve, reject) => this.markCrashed = reject);
+
         this.logDetails = {page: this.page.url(), workerid};
 
         // more serious page crash, mark as failed
-        this.page.on("crash", () => {
-          logger.error("Page Crash", ...this.logDetails, "worker");
-          this.failed = true;
+        this.page.on("crash", (details) => {
+          logger.error("Page Crash", {details, ...this.logDetails}, "worker");
+          this.crashed = true;
+          this.markCrashed("crashed");
         });
 
         await this.crawler.setupPage(this.opts);
@@ -111,36 +123,30 @@ export class PageWorker
 
   async timedCrawlPage(opts) {
     const workerid = this.id;
-    const url = opts.data.url;
+    const { data } = opts;
+    const { url } = data;
 
     logger.info("Starting page", {workerid, "page": url}, "worker");
 
     this.logDetails = {page: url, workerid};
 
-    this.failed = false;
-
     try {
-      const result = await timedRun(
-        this.crawler.crawlPage(opts),
-        this.timeout,
-        "Page Worker Timeout",
-        {workerid},
-        "worker"
-      );
-
-      this.failed = this.failed || !result;
+      await Promise.race([
+        timedRun(
+          this.crawler.crawlPage(opts),
+          this.timeout,
+          "Page Worker Timeout",
+          {workerid},
+          "worker"
+        ),
+        this.crashBreak
+      ]);
 
     } catch (e) {
       logger.error("Worker Exception", {...errJSON(e), ...this.logDetails}, "worker");
-      this.failed = true;
     } finally {
-      if (this.failed) {
-        logger.warn("Page Load Failed", this.logDetails, "worker");
-        this.crawler.markPageFailed(url);
-      }
+      await this.crawler.pageFinished(data);
     }
-
-    return this.failed;
   }
 
   async run() {
@@ -151,6 +157,8 @@ export class PageWorker
       logger.info("Worker exiting, all tasks complete", {workerid: this.id}, "worker");
     } catch (e) {
       logger.error("Worker errored", e, "worker");
+    } finally {
+      this.crawler.workerDone(this.id);
     }
   }
 
@@ -166,14 +174,8 @@ export class PageWorker
         const opts = await this.initPage();
 
         // run timed crawl of page
-        const failed = await this.timedCrawlPage({...opts, data});
+        await this.timedCrawlPage({...opts, data});
 
-        // close page if failed
-        if (failed) {
-          logger.debug("Resetting failed page", {}, "worker");
-
-          await this.closePage();
-        }
       } else {
 
         // otherwise, see if any pending urls

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,9 +1079,10 @@ browserslist@^4.21.3:
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.9"
 
-"browsertrix-behaviors@github:webrecorder/browsertrix-behaviors#autoscroll-fix":
+browsertrix-behaviors@^0.5.0-beta.0:
   version "0.5.0-beta.0"
-  resolved "https://codeload.github.com/webrecorder/browsertrix-behaviors/tar.gz/8fed92de2e9e827841d0cdd5675982e3d14b40cb"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.5.0-beta.0.tgz#d1a7c35cda31d740a374df1e833f36bd1890768d"
+  integrity sha512-RQMQlbV4OBAzYyhTI7imoem8p4MTj2XSDzlIZvA5sC5U89OMnJ0VM5KBAJzET3PUJkQlUQEOTiXtnsnodHXTUQ==
 
 bser@2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,10 +1079,9 @@ browserslist@^4.21.3:
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.9"
 
-browsertrix-behaviors@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.4.2.tgz#830f4e37ddebf10dd923237dfd75c734d5d211e9"
-  integrity sha512-5w6kPL3NB/BkmEGxWt3NT3iddAaSzMR1TtDPS7b66fM9kkhpCjCv/R/zR951jWDIeV3flJFBOy09uI5o8asPqg==
+"browsertrix-behaviors@github:webrecorder/browsertrix-behaviors#autoscroll-fix":
+  version "0.5.0-beta.0"
+  resolved "https://codeload.github.com/webrecorder/browsertrix-behaviors/tar.gz/8fed92de2e9e827841d0cdd5675982e3d14b40cb"
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Fixes for various loading issues

when goto() times out, detect if 'domcontentloaded' at least happened
- if not, fail page immediately
- if yes, at least extract links, but don't run behaviors

for frames:
- detect if frame actually not from a frame tag (eg. OBJECT) tag, and skip as well

screencaster:
- set Nth frame to 1 to avoid no screencast data when page is static

behaviors:
- update to 0.5.0-beta.0 (includes autoscroll improvements)