### PR TITLE
Ensure crawler can't run out of space with --diskUtilization param

### DIFF
--- a/util/argParser.js
+++ b/util/argParser.js
@@ -294,7 +294,7 @@ class ArgParser {
       "diskUtilization": {
         describe: "If set, save state and exit if disk utilization exceeds this percentage value",
         type: "number",
-        default: 0,
+        default: 90,
       },
 
       "timeLimit": {
@@ -471,16 +471,9 @@ class ArgParser {
       argv.statsFilename = path.resolve(argv.cwd, argv.statsFilename);
     }
 
-    if (!argv.diskUtilization) {
-      if (argv.combineWARC && argv.generateWACZ) {
-        argv.diskUtilization = 30;
-      } else if (argv.combineWARC || argv.generateWACZ) {
-        argv.diskUtilization = 45;
-      } else {
-        argv.diskUtilization = 90;
-      }
+    if ((argv.diskUtilization < 0 || argv.diskUtilization > 99)) {
+      argv.diskUtilization = 90;
     }
-
 
     return true;
   }

--- a/util/storage.js
+++ b/util/storage.js
@@ -152,7 +152,7 @@ export async function getDirSize(dir) {
 
 export async function getDiskUsage(path="/") {
   const exec = util.promisify(child_process.exec);
-  const result = await exec(`df -H ${path}`);
+  const result = await exec(`df ${path}`);
   const lines = result.stdout.split("\n");
   const keys = lines[0].split(/\s+/ig);
   const rows = lines.slice(1).map(line => {


### PR DESCRIPTION
Fixes #242 

The first commit implements `--diskUtilization` as described in the issue. I found that this stopped a lot of crawls prematurely in local testing even though the total size, even after combining WARCs and generating WACZ, still wouldn't have crossed the disk threshold.

The second commit modifies the routine to keep the disk utilization percentage high (90% by default) but instead projects whether that threshold is likely to be reached based on the size of the current archive directory (x4 if combineWARC and generateWACZ are passed, x2 if only one of them).