### PR TITLE
worker index: set worker index automatically to work with k8s naming

### DIFF
--- a/util/worker.js
+++ b/util/worker.js
@@ -1,5 +1,7 @@
+import os from "os";
 import { logger, errJSON } from "./logger.js";
 import { sleep, timedRun } from "./timing.js";
+import { rxEscape } from "./seeds.js";
 
 const MAX_REUSE = 5;
 
@@ -10,10 +12,25 @@ export function runWorkers(crawler, numWorkers, maxPageTime) {
   logger.info(`Creating ${numWorkers} workers`, {}, "worker");
 
   const workers = [];
+  let offset = 0;
+
+  // automatically set worker start by ordinal in k8s
+  // if hostname is "crawl-id-name-N"
+  // while CRAWL_ID is "crawl-id-name", then set starting
+  // worker index offset to N * numWorkers
+
+  if (process.env.CRAWL_ID) {
+    const rx = new RegExp(rxEscape(process.env.CRAWL_ID) + "\\-([\\d]+)$");
+    const m = os.hostname().match(rx);
+    if (m) {
+      offset = m[1] * numWorkers;
+      logger.info("Starting workerid index at " + offset, "worker");
+    }
+  }
 
   for (let i = 0; i < numWorkers; i++) {
     //workers.push(new PageWorker(`worker-${i+1}`, crawler, maxPageTime));
-    workers.push(new PageWorker(i, crawler, maxPageTime));
+    workers.push(new PageWorker(i + offset, crawler, maxPageTime));
   }
 
   return Promise.allSettled(workers.map((worker) => worker.run()));


### PR DESCRIPTION
- if CRAWL_ID env var set to 'crawl-id-name' while hostname is 'crawl-id-name-N' (automatically set via k8s statefulsets), then set starting worker index to N * numWorkers