### PR TITLE
Reset locked pending URLs when crawler restarts.

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -161,7 +161,7 @@ export class Crawler {
     this.crawlState = new RedisCrawlState(redis, this.params.crawlId, this.maxPageTime, os.hostname());
 
     // clear any pending URLs from this instance
-    await this.crawlState.clearOwnPending();
+    await this.crawlState.clearOwnPendingLocks();
 
     if (this.params.saveState === "always" && this.params.saveStateInterval) {
       logger.debug(`Saving crawl state every ${this.params.saveStateInterval} seconds, keeping last ${this.params.saveStateHistory} states`, {}, "state");

--- a/crawler.js
+++ b/crawler.js
@@ -160,6 +160,9 @@ export class Crawler {
 
     this.crawlState = new RedisCrawlState(redis, this.params.crawlId, this.maxPageTime, os.hostname());
 
+    // clear any pending URLs from this instance
+    await this.crawlState.clearOwnPending();
+
     if (this.params.saveState === "always" && this.params.saveStateInterval) {
       logger.debug(`Saving crawl state every ${this.params.saveStateInterval} seconds, keeping last ${this.params.saveStateHistory} states`, {}, "state");
     }

--- a/util/state.js
+++ b/util/state.js
@@ -99,7 +99,7 @@ end
 `
     });
 
-    redis.defineCommand("unmarkpending", {
+    redis.defineCommand("unlockpending", {
       numberOfKeys: 1,
       lua: `
 local value = redis.call('get', KEYS[1]);
@@ -347,12 +347,12 @@ return 0;
     return list.map(x => JSON.parse(x));
   }
 
-  async clearOwnPending() {
+  async clearOwnPendingLocks() {
     try {
       const pendingUrls = await this.redis.hkeys(this.pkey);
 
       for (const url of pendingUrls) {
-        await this.redis.unmarkpending(this.pkey + ":" + url, this.uid);
+        await this.redis.unlockpending(this.pkey + ":" + url, this.uid);
       }
     } catch (e) {
       logger.error("Redis Del Pending Failed", e, "state");


### PR DESCRIPTION
Currently, for every URL added to the pending set `<crawl-id>:p`, a 'lock' key is created `<crawl-id>:p:<url>` to indicate that this pending URL is still locked, eg. being processed by a crawler.

If a crawler crashes/is restarted however, the lock keys remain in Redis, even though those URLs should no longer be locked.

This PR sets the lock key to the unique id (usually hostname) of the crawler.
Then, on restart, the crawler will clear its own lock keys before resuming the crawl, as they are no longer being processed.
This allows pending URLs to be retried again (or marked as failed) more quickly.

This clearOwnPending() checks for every `<crawl-id>:p:<url>` if the lock is held by the current crawler, and if so, removes it.