### PR TITLE
Add --maxPageLimit override

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Here's how you can use some of the command-line options to configure the crawl:
 
 - To include automated text extraction for full text search, add the `--text` flag.
 
-- To limit the crawl to a maximum number of pages, add `--limit P` where P is the number of pages that will be crawled.
+- To limit the crawl to a maximum number of pages, add `--pageLimit P` where P is the number of pages that will be crawled.
 
 - To limit the crawl to a maximum size, set `--sizeLimit` (size in bytes)
 
@@ -80,7 +80,10 @@ Browsertrix Crawler includes a number of additional command-line options, explai
       --extraHops                           Number of extra 'hops' to follow, be
                                             yond the current scope
                                                            [number] [default: 0]
-      --limit                               Limit crawl to this number of pages
+      --pageLimit, --limit                  Limit crawl to this number of pages
+                                                           [number] [default: 0]
+      --maxPageLimit                        Maximum pages to crawl, overriding 
+                                            pageLimit if both are set
                                                            [number] [default: 0]
       --pageLoadTimeout, --timeout          Timeout for each page to load (in se
                                             conds)        [number] [default: 90]

--- a/crawler.js
+++ b/crawler.js
@@ -75,6 +75,12 @@ export class Crawler {
 
     // was the limit hit?
     this.limitHit = false;
+    this.pageLimit = this.params.pageLimit;
+
+    // resolve maxPageLimit and ensure pageLimit is no greater than maxPageLimit
+    if (this.params.maxPageLimit) {
+      this.pageLimit = this.pageLimit ? Math.min(this.pageLimit, this.params.maxPageLimit) : this.params.maxPageLimit;
+    }
 
     this.saveStateFiles = [];
     this.lastSaveTime = 0;
@@ -892,7 +898,7 @@ export class Crawler {
     const pendingList = await this.crawlState.getPendingList();
     const done = await this.crawlState.numDone();
     const total = realSize + pendingList.length + done;
-    const limit = {max: this.params.limit || 0, hit: this.limitHit};
+    const limit = {max: this.pageLimit || 0, hit: this.limitHit};
     const stats = {
       "crawled": done,
       "total": total,
@@ -1141,7 +1147,7 @@ export class Crawler {
       return false;
     }
 
-    if (this.params.limit > 0 && (await this.crawlState.numSeen() >= this.params.limit)) {
+    if (this.pageLimit > 0 && (await this.crawlState.numSeen() >= this.pageLimit)) {
       this.limitHit = true;
       return false;
     }

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -68,8 +68,15 @@ class ArgParser {
         type: "number"
       },
 
-      "limit": {
+      "pageLimit": {
+        alias: "limit",
         describe: "Limit crawl to this number of pages",
+        default: 0,
+        type: "number",
+      },
+
+      "maxPageLimit": {
+        describe: "maximum pages to crawl, overriding pageLimit if both are set",
         default: 0,
         type: "number",
       },

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -76,7 +76,7 @@ class ArgParser {
       },
 
       "maxPageLimit": {
-        describe: "maximum pages to crawl, overriding pageLimit if both are set",
+        describe: "Maximum pages to crawl, overriding pageLimit if both are set",
         default: 0,
         type: "number",
       },

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -76,7 +76,7 @@ class ArgParser {
       },
 
       "maxPageLimit": {
-        describe: "Maximum pages to crawl, overriding pageLimit if both are set",
+        describe: "Maximum pages to crawl, overriding  pageLimit if both are set",
         default: 0,
         type: "number",
       },


### PR DESCRIPTION
Adding a new `--maxPageLimit` flag as the best solution for webrecorder/browsertrix-cloud#716

The new flag overrides the `--pageLimit/--limit` flag to ensure the limit is no greater than maxPageLimit if both are set.
This allows for the regular `--pageLimit` to be configured by user in user crawl config settings, while the `--maxPageLimit` can be configured by an admin.

Also rename `--limit` -> `--pageLimit` for clarity, keeping `--limit` as alias.