### PR TITLE
Add option to log errors to redis

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -175,6 +175,11 @@ export class Crawler {
       logger.debug(`Saving crawl state every ${this.params.saveStateInterval} seconds, keeping last ${this.params.saveStateHistory} states`, {}, "state");
     }
 
+    if (this.params.logErrorsToRedis) {
+      logger.setLogErrorsToRedis(true);
+      logger.setCrawlState(this.crawlState);
+    }
+
     return this.crawlState;
   }
 

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -360,6 +360,12 @@ class ArgParser {
         alias: ["desc"],
         describe: "If set, write supplied description into WACZ datapackage.json metadata",
         type: "string"
+      },
+
+      "logErrorsToRedis": {
+        descripe: "If set, write error messages to redis",
+        type: "boolean",
+        default: false,
       }
     };
   }

--- a/util/logger.js
+++ b/util/logger.js
@@ -15,8 +15,10 @@ class Logger
   constructor() {
     this.logStream = null;
     this.debugLogging = null;
+    this.logErrorsToRedis = false;
     this.logLevels = [];
     this.contexts = [];
+    this.crawlState = null;
   }
 
   setExternalLogStream(logFH) {
@@ -27,12 +29,20 @@ class Logger
     this.debugLogging = debugLog;
   }
 
+  setLogErrorsToRedis(logErrorsToRedis) {
+    this.logErrorsToRedis = logErrorsToRedis;
+  }
+
   setLogLevel(logLevels) {
     this.logLevels = logLevels;
   }
 
   setContext(contexts) {
     this.contexts = contexts;
+  }
+
+  setCrawlState(crawlState) {
+    this.crawlState = crawlState;
   }
 
   logAsJSON(message, data, context, logLevel="info") {
@@ -65,6 +75,10 @@ class Logger
     console.log(string);
     if (this.logStream) {
       this.logStream.write(string + "\n");
+    }
+
+    if (this.logErrorsToRedis && logLevel === "error") {
+      this.crawlState.logError(string);
     }
   }
 


### PR DESCRIPTION
Fixes #278 

This PR adds a `--logErrorsToRedis` crawler arg that when enabled adds the serialized JSON strings for all errors to Redis.