### PR TITLE
Store done in redis as integer and only save full json in redis for failed pages

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -912,12 +912,14 @@ export class Crawler {
     const realSize = await this.crawlState.queueSize();
     const pendingList = await this.crawlState.getPendingList();
     const done = await this.crawlState.numDone();
-    const total = realSize + pendingList.length + done;
+    const failed = await this.crawlState.numFailed();
+    const total = realSize + pendingList.length + done + failed;
     const limit = {max: this.pageLimit || 0, hit: this.limitHit};
     const stats = {
       "crawled": done,
       "total": total,
       "pending": pendingList.length,
+      "failed": failed,
       "limit": limit,
       "pendingPages": pendingList.map(x => JSON.stringify(x))
     };

--- a/crawler.js
+++ b/crawler.js
@@ -913,7 +913,7 @@ export class Crawler {
     const pendingList = await this.crawlState.getPendingList();
     const done = await this.crawlState.numDone();
     const failed = await this.crawlState.numFailed();
-    const total = realSize + pendingList.length + done + failed;
+    const total = realSize + pendingList.length + done;
     const limit = {max: this.pageLimit || 0, hit: this.limitHit};
     const stats = {
       "crawled": done,

--- a/util/state.js
+++ b/util/state.js
@@ -53,7 +53,11 @@ export class RedisCrawlState
     this.qkey = this.key + ":q";
     this.pkey = this.key + ":p";
     this.skey = this.key + ":s";
+    // done (integer)
     this.dkey = this.key + ":d";
+    // failed
+    this.fkey = this.key + ":f";
+    // crawler errors
     this.ekey = this.key + ":e";
 
     this._initLuaCommands(this.redis);
@@ -112,7 +116,7 @@ end
 `
     });
 
-    redis.defineCommand("movedone", {
+    redis.defineCommand("movefailed", {
       numberOfKeys: 2,
       lua: `
 local json = redis.call('hget', KEYS[1], ARGV[1]);
@@ -169,13 +173,13 @@ return 0;
   }
 
   async markFinished(url) {
-    const finished = this._timestamp();
+    await this.redis.call("hdel", this.pkey, url);
 
-    return await this.redis.movedone(this.pkey, this.dkey, url, finished, "finished");
+    return await this.redis.incr(this.dkey);
   }
 
   async markFailed(url) {
-    return await this.redis.movedone(this.pkey, this.dkey, url, "1", "failed");
+    return await this.redis.movefailed(this.pkey, this.dkey, url, "1", "failed");
   }
 
   recheckScope(data, seeds) {
@@ -241,12 +245,13 @@ return 0;
 
   async serialize() {
     //const queued = await this._iterSortKey(this.qkey);
+    const done = await this.numDone();
     const queued = await this._iterSortedKey(this.qkey);
-    const done = await this._iterListKeys(this.dkey);
     const pending = await this.getPendingList();
+    const failed = await this._iterListKeys(this.fkey);
     const errors = await this.getErrorList();
 
-    return {queued, pending, done, errors};
+    return {done, queued, pending, failed, errors};
   }
 
   _getScore(data) {
@@ -285,6 +290,7 @@ return 0;
     await this.redis.del(this.qkey);
     await this.redis.del(this.pkey);
     await this.redis.del(this.dkey);
+    await this.redis.del(this.fkey);
     await this.redis.del(this.skey);
     await this.redis.del(this.ekey);
 
@@ -312,13 +318,20 @@ return 0;
       seen.push(data.url);
     }
 
+    // retained in modified form for backwards compatibility
     for (const json of state.done) {
       const data = JSON.parse(json);
       if (data.failed) {
         await this.redis.zadd(this.qkey, this._getScore(data), json);
       } else {
-        await this.redis.rpush(this.dkey, json);
+        await this.redis.incr(this.dkey);
       }
+      seen.push(data.url);
+    }
+
+    for (const json of state.failed) {
+      const data = JSON.parse(json);
+      await this.redis.zadd(this.qkey, this._getScore(data), json);
       seen.push(data.url);
     }
 
@@ -331,7 +344,7 @@ return 0;
   }
 
   async numDone() {
-    return await this.redis.llen(this.dkey);
+    return await this.redis.get(this.dkey);
   }
 
   async numSeen() {

--- a/util/state.js
+++ b/util/state.js
@@ -179,7 +179,9 @@ return 0;
   }
 
   async markFailed(url) {
-    return await this.redis.movefailed(this.pkey, this.dkey, url, "1", "failed");
+    await this.redis.movefailed(this.pkey, this.dkey, url, "1", "failed");
+
+    return await this.redis.incr(this.dkey);
   }
 
   recheckScope(data, seeds) {

--- a/util/state.js
+++ b/util/state.js
@@ -179,7 +179,7 @@ return 0;
   }
 
   async markFailed(url) {
-    await this.redis.movefailed(this.pkey, this.dkey, url, "1", "failed");
+    await this.redis.movefailed(this.pkey, this.fkey, url, "1", "failed");
 
     return await this.redis.incr(this.dkey);
   }

--- a/util/state.js
+++ b/util/state.js
@@ -344,7 +344,8 @@ return 0;
   }
 
   async numDone() {
-    return await this.redis.get(this.dkey);
+    const done = await this.redis.get(this.dkey);
+    return parseInt(done);
   }
 
   async numSeen() {

--- a/util/state.js
+++ b/util/state.js
@@ -362,6 +362,10 @@ return 0;
     return res;
   }
 
+  async numFailed() {
+    return await this.redis.llen(this.fkey);
+  }
+
   async getPendingList() {
     const list = await this.redis.hvals(this.pkey);
     return list.map(x => JSON.parse(x));


### PR DESCRIPTION
Fixes #280 

This PR removes the done list from Redis and replaces it with an integer that is incremented each time a page is successfully finished.

It also adds a failed list to Redis and modifies serialization and crawler stats accordingly.