### PR TITLE
worker: lower wait time, in case where no additional pages remain and…

### DIFF
--- a/util/worker.js
+++ b/util/worker.js
@@ -202,7 +202,7 @@ export class PageWorker
         // if pending, sleep and check again
         if (pending) {
           logger.debug("No crawl tasks, but pending tasks remain, waiting", {pending, workerid: this.id}, "worker");
-          await sleep(10);
+          await sleep(0.5);
         } else {
           // if no pending and queue size is still empty, we're done!
           if (!await crawlState.queueSize()) {


### PR DESCRIPTION
… other workers will finish quickly. otherwise, results in a min 10 seconds wait for >1 workers if only one page is encountered.

Seems like simplest solution just to lower this wait time.