### PR TITLE
Quick exit on redis connection error after interrupt

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env -S node --experimental-global-webcrypto
 
 import { logger } from "./util/logger.js";
+import { setExitOnRedisError } from "./util/redis.js";
 import { Crawler } from "./crawler.js";
+
 
 var crawler = null;
 
@@ -20,6 +22,8 @@ async function handleTerminate(signame) {
     logger.info("success: crawler done, exiting");
     process.exit(0);
   }
+
+  setExitOnRedisError(true);
 
   try {
     if (!crawler.interrupted) {

--- a/util/redis.js
+++ b/util/redis.js
@@ -4,6 +4,7 @@ import { logger } from "./logger.js";
 const error = console.error;
 
 let lastLogTime = 0;
+let exitOnError = false;
 
 // log only once every 10 seconds
 const REDIS_ERROR_LOG_INTERVAL_SECS = 10000;
@@ -17,6 +18,9 @@ console.error = function (...args) {
     let now = Date.now();
 
     if ((now - lastLogTime) > REDIS_ERROR_LOG_INTERVAL_SECS) {
+      if (lastLogTime && exitOnError) {
+        logger.fatal("Crawl interrupted, redis gone, exiting", {}, "redis");
+      }
       logger.warn("ioredis error", {error: args[0]}, "redis");
       lastLogTime = now;
     }
@@ -29,4 +33,8 @@ export async function initRedis(url) {
   const redis = new Redis(url, {lazyConnect: true});
   await redis.connect();
   return redis;
+}
+
+export function setExitOnRedisError() {
+  exitOnError = true;
 }


### PR DESCRIPTION
Optimization for Browsertrix Cloud: often if the crawler and redis pods are being shutdown together, and redis exits quickly while crawler may attempt to finish current work and reconnect to redis.
If redis connection disappears after interrupt signal is received (and still there after the REDIS_ERROR_LOG_INTERVAL_SECS), assume redis has been shutdown and crawler also should exit immediately.