### PR TITLE
Catch 4xx and 5xx page.goto() responses to mark invalid URLs as failed

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -998,6 +998,13 @@ export class Crawler {
     try {
       const resp = await page.goto(url, gotoOpts);
 
+      const status = resp.status();
+      if (status === 400) {
+        // pywb error, mark as page load failed
+        logger.error("Page Load Error, skipping page", {status, ...logDetails});
+        throw new Error(`Page ${url} returned 400 error`);
+      }
+
       const contentType = await resp.headerValue("content-type");
 
       isHTMLPage = this.isHTMLContentType(contentType);

--- a/crawler.js
+++ b/crawler.js
@@ -1008,15 +1008,15 @@ export class Crawler {
     try {
       const resp = await page.goto(url, gotoOpts);
 
-      const status = resp.status();
-      if (status === 400) {
+      // Handle 4xx or 5xx response as a page load error
+      const statusCode = resp.status();
+      if (statusCode.toString().startsWith("4") || statusCode.toString().startsWith("5")) {
         if (failCrawlOnError) {
-          logger.fatal("Page Load Error on Seed, failing crawl", {status, ...logDetails});
+          logger.fatal("Seed Page Load Error, failing crawl", {statusCode, ...logDetails});
         } else {
-          logger.error("Page Load Error, skipping page", {status, ...logDetails});
-          throw new Error(`Page ${url} returned 400 error`);
+          logger.error("Page Load Error, skipping page", {statusCode, ...logDetails});
+          throw new Error(`Page ${url} returned status code ${statusCode}`);
         }
-        
       }
 
       const contentType = await resp.headerValue("content-type");
@@ -1029,7 +1029,7 @@ export class Crawler {
         if (e.name === "TimeoutError") {
           if (data.loadState !== LoadState.CONTENT_LOADED) {
             if (failCrawlOnError) {
-              logger.fatal("Page Load Timeout on Seed, failing crawl", {msg, ...logDetails});
+              logger.fatal("Seed Page Load Timeout, failing crawl", {msg, ...logDetails});
             } else {
               logger.error("Page Load Timeout, skipping page", {msg, ...logDetails});
               throw e;
@@ -1040,7 +1040,7 @@ export class Crawler {
           }
         } else {
           if (failCrawlOnError) {
-            logger.fatal("Page Load Timeout on Seed, failing crawl", {msg, ...logDetails});
+            logger.fatal("Seed Page Load Timeout, failing crawl", {msg, ...logDetails});
           } else {
             logger.error("Page Load Error, skipping page", {msg, ...logDetails});
             throw e;

--- a/crawler.js
+++ b/crawler.js
@@ -352,14 +352,6 @@ export class Crawler {
     return seed.isIncluded(url, depth, extraHops, logDetails);
   }
 
-  isSeedUrl(url) {
-    const seeds = this.params.scopedSeeds.map(seed => seed.url);
-    if (seeds.indexOf(url) != -1){
-      return true;
-    }
-    return false;
-  }
-
   async setupPage({page, cdp, workerid}) {
     await this.browser.setupPage({page, cdp});
 
@@ -949,7 +941,7 @@ export class Crawler {
 
     const logDetails = data.logDetails;
 
-    const failCrawlOnError = (this.isSeedUrl(url) && this.params.failOnFailedSeed);
+    const failCrawlOnError = ((depth === 0) && this.params.failOnFailedSeed);
 
     let isHTMLPage = await timedRun(
       this.isHTML(url),

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -372,6 +372,12 @@ class ArgParser {
         descripe: "If set, write error messages to redis",
         type: "boolean",
         default: false,
+      },
+
+      "failOnFailedSeed": {
+        describe: "If set, crawler will fail with exit code 1 if initial seed fails",
+        type: "boolean",
+        default: false
       }
     };
   }

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -375,7 +375,7 @@ class ArgParser {
       },
 
       "failOnFailedSeed": {
-        describe: "If set, crawler will fail with exit code 1 if initial seed fails",
+        describe: "If set, crawler will fail with exit code 1 if any seed fails",
         type: "boolean",
         default: false
       }


### PR DESCRIPTION
Fixes #286 

Also fixes #207 by introducing a `--failOnFailedSeed` CLI option which, when enabled, will fail the crawl with a status code of 1 if there is a page load error on one of the initial seeds.