### PR TITLE
Log fatal messages to redis errors

### DIFF
--- a/util/logger.js
+++ b/util/logger.js
@@ -77,7 +77,8 @@ class Logger
       this.logStream.write(string + "\n");
     }
 
-    if (this.logErrorsToRedis && logLevel === "error") {
+    const toLogToRedis = ["error", "fatal"];
+    if (this.logErrorsToRedis && toLogToRedis.includes(logLevel)) {
       this.crawlState.logError(string);
     }
   }


### PR DESCRIPTION
Follow up to https://github.com/webrecorder/browsertrix-crawler/issues/278

This PR adds `fatal` log lines to the errors pushed to Redis for browsertrix-cloud.