### PR TITLE
Consolidate wacz error loglines

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -927,7 +927,7 @@ export class Crawler {
 
     return new Promise((resolve) => {
       proc.on("close", (code) => {
-        if (stdout) {
+        if (stdout.length) {
           logger.debug(stdout.join("\n"));
         }
         if (stderr && this.params.logging.includes("debug")) {

--- a/crawler.js
+++ b/crawler.js
@@ -930,7 +930,7 @@ export class Crawler {
         if (stdout.length) {
           logger.debug(stdout.join("\n"));
         }
-        if (stderr && this.params.logging.includes("debug")) {
+        if (stderr.length && this.params.logging.includes("debug")) {
           logger.error(stderr.join("\n"));
         }
         resolve(code);

--- a/crawler.js
+++ b/crawler.js
@@ -909,15 +909,27 @@ export class Crawler {
   }
 
   awaitProcess(proc) {
+    let stdout = [];
+    let stderr = [];
+
     proc.stdout.on("data", (data) => {
-      logger.debug(data.toString());
+      stdout.push(data.toString());
     });
 
     proc.stderr.on("data", (data) => {
-      logger.error(data.toString());
+      stderr.push(data.toString());
     });
+
     return new Promise((resolve) => {
-      proc.on("close", (code) => resolve(code));
+      proc.on("close", (code) => {
+        if (stdout) {
+          logger.debug(stdout.join("\n"));
+        }
+        if (stderr) {
+          logger.error(stderr.join("\n"));
+        }
+        resolve(code);
+      });
     });
   }
 

--- a/crawler.js
+++ b/crawler.js
@@ -784,7 +784,12 @@ export class Crawler {
 
     if (this.params.generateCDX) {
       logger.info("Generating CDX");
-      await this.awaitProcess(child_process.spawn("wb-manager", ["reindex", this.params.collection], {cwd: this.params.cwd}));
+      const indexResult = await this.awaitProcess(child_process.spawn("wb-manager", ["reindex", this.params.collection], {cwd: this.params.cwd}));
+      if (indexResult === 0) {
+        logger.debug("Indexing complete, CDX successfully created");
+      } else {
+        logger.error("Error indexing and generating CDX", {"status code": indexResult});
+      }
     }
 
     await this.closeLog();
@@ -925,7 +930,7 @@ export class Crawler {
         if (stdout) {
           logger.debug(stdout.join("\n"));
         }
-        if (stderr) {
+        if (stderr && this.params.logging.includes("debug")) {
           logger.error(stderr.join("\n"));
         }
         resolve(code);


### PR DESCRIPTION
This PR modifies `awaitProcess` to log stdout and stderr as single lines to consolidate e.g. stacktraces from the subprocesses being called. These messages are only logged if debug is enabled, otherwise just a generic error message is printed to the logs if called for.

In addition, for CDX generation we now check the status code and log a message appropriately.