### PR TITLE
state: adjust redis keys to be more consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.10.0-beta.1",
+  "version": "0.10.0-beta.2",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/util/state.js
+++ b/util/state.js
@@ -60,8 +60,6 @@ export class RedisCrawlState
     // crawler errors
     this.ekey = this.key + ":e";
 
-    this.crawlSizeKey = "crawl-size";
-
     this._initLuaCommands(this.redis);
   }
 
@@ -205,17 +203,17 @@ return 0;
   }
 
   async setArchiveSize(size) {
-    return await this.redis.hset(this.crawlSizeKey, this.uid, size);
+    return await this.redis.hset(`${this.key}:size`, this.uid, size);
   }
 
   async isCrawlStopped() {
-    return await this.redis.get("crawl-stop") === "1";
+    return await this.redis.get(`${this.key}:stopping`) === "1";
   }
 
   // note: not currently called in crawler, but could be
   // crawl may be stopped by setting this elsewhere in shared redis
   async stopCrawl() {
-    await this.redis.set("crawl-stop", "1");
+    await this.redis.set(`${this.key}:stopping`, "1");
   }
 
   async incFailCount() {


### PR DESCRIPTION
- use <crawlid>:stopping for crawl stop request
- use <crawlid>:size for total setting crawl total size
bump to 0.10.0-beta.2