### PR TITLE
Disable Chrome optimization logic

### DIFF
--- a/util/browser.js
+++ b/util/browser.js
@@ -323,7 +323,8 @@ export const defaultArgs = [
   "--disable-extensions",
   // AvoidUnnecessaryBeforeUnloadCheckSync - https://github.com/microsoft/playwright/issues/14047
   // Translate - https://github.com/microsoft/playwright/issues/16126
-  "--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate",
+  // Optimization* - https://bugs.chromium.org/p/chromium/issues/detail?id=1311753
+  "--disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate,OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPrediction,OptimizationHints",
   "--allow-pre-commit-input",
   "--disable-hang-monitor",
   "--disable-ipc-flooding-protection",


### PR DESCRIPTION
These optimizations can often lead to Chrome downloading large ML models in the background, which then end up in the web crawling archives, even though they don't have anything to do with the crawl.

Fixes #311.