### PR TITLE
stopping: if crawl is marked as stopping, and no warcs found, mark st…

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -853,6 +853,10 @@ export class Crawler {
       if (isFinished) {
         return;
       }
+      // if stopped, won't get anymore data, so consider failed
+      if (await this.crawlState.isCrawlStopped()) {
+        await this.crawlState.setStatus("failed");
+      }
       logger.fatal("No WARC Files, assuming crawl failed");
     }
 


### PR DESCRIPTION
…ate as failed also (to avoid loop in cloud when

crawler is restarted)