### PR TITLE
allow adding --include with pre-existing --scopeType values (besides …

### DIFF
--- a/tests/scopes.test.js
+++ b/tests/scopes.test.js
@@ -186,10 +186,12 @@ seeds:
    - url: https://example.com/subpath/file.html
      scopeType: prefix
 
+   - url: https://example.com/subpath/file.html
+
 include: https://example.com/onlythispath
 `);
 
-  expect(seeds.length).toEqual(3);
+  expect(seeds.length).toEqual(4);
 
   expect(seeds[0].scopeType).toEqual("custom");
   expect(seeds[0].url).toEqual("https://example.com/1");
@@ -203,9 +205,13 @@ include: https://example.com/onlythispath
 
   expect(seeds[2].scopeType).toEqual("prefix");
   expect(seeds[2].url).toEqual("https://example.com/subpath/file.html");
-  expect(seeds[2].include).toEqual([/^https?:\/\/example\.com\/subpath\//]);
+  expect(seeds[2].include).toEqual([/^https?:\/\/example\.com\/subpath\//, /https:\/\/example.com\/onlythispath/]);
   expect(seeds[2].exclude).toEqual([]);
 
+  expect(seeds[3].scopeType).toEqual("custom");
+  expect(seeds[3].url).toEqual("https://example.com/subpath/file.html");
+  expect(seeds[3].include).toEqual([/https:\/\/example.com\/onlythispath/]);
+  expect(seeds[3].exclude).toEqual([]);
 });
 
 

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -494,14 +494,6 @@ class ArgParser {
       //logger.debug(`Set netIdleWait to ${argv.netIdleWait} seconds`);
     }
 
-    // prefer argv.include only if string or a non-empty array
-    if (argv.include && (typeof(argv.include) === "string" || argv.include.length)) {
-      if (argv.scopeType && argv.scopeType !== "custom") {
-        logger.info("You've specified a --scopeType and a --scopeIncludeRx / --include regex. The custom scope regex will take precedence, overriding the scopeType");
-        argv.scopeType = "custom";
-      }
-    }
-
     const scopeOpts = {
       scopeType: argv.scopeType,
       sitemap: argv.sitemap,

--- a/util/seeds.js
+++ b/util/seeds.js
@@ -19,7 +19,8 @@ export class ScopedSeed
     }
 
     if (this.scopeType !== "custom") {
-      [this.include, allowHash] = this.scopeFromType(this.scopeType, parsedUrl);
+      [include, allowHash] = this.scopeFromType(this.scopeType, parsedUrl);
+      this.include = [...include, ...this.include];
     }
 
     this.sitemap = this.resolveSiteMap(sitemap);
@@ -138,7 +139,7 @@ export class ScopedSeed
 
     // check scopes
     for (const s of this.include) {
-      if (s.exec(url)) {
+      if (s.test(url)) {
         inScope = true;
         break;
       }
@@ -157,7 +158,7 @@ export class ScopedSeed
 
     // check exclusions
     for (const e of this.exclude) {
-      if (e.exec(url)) {
+      if (e.test(url)) {
         //console.log(`Skipping ${url} excluded by ${e}`);
         return false;
       }


### PR DESCRIPTION
…custom) (fixes #318)

remove warning when --scopeType and --include used together tests: update tests to reflect new semantics of --include + --scopeType

Simplifies 'extra scope URL' in webrecorder/browsertrix-cloud#378