### PR TITLE
Update argParser.js for #307

### DIFF
--- a/util/argParser.js
+++ b/util/argParser.js
@@ -386,7 +386,7 @@ class ArgParser {
     argv = argv || process.argv;
 
     if (process.env.CRAWL_ARGS) {
-      argv = argv.concat(process.env.CRAWL_ARGS.split(" "));
+      argv = yargs(process.env.CRAWL_ARGS).parse();
     }
 
     let origConfig = {};


### PR DESCRIPTION
This change uses the yargs argument parser rather than just splitting the CRAWL_ARGS environment variable.

**WARNING:** This has not been tested yet!