### PR TITLE
Ignore spaces in double quotes when splitting process.env.CRAWL_ARGS

### DIFF
--- a/util/argParser.js
+++ b/util/argParser.js
@@ -386,7 +386,7 @@ class ArgParser {
     argv = argv || process.argv;
 
     if (process.env.CRAWL_ARGS) {
-      argv = argv.concat(process.env.CRAWL_ARGS.split(" "));
+      argv = argv.concat(this.splitCrawlArgsQuoteSafe(process.env.CRAWL_ARGS));
     }
 
     let origConfig = {};
@@ -407,6 +407,11 @@ class ArgParser {
     return {parsed, origConfig};
   }
 
+  splitCrawlArgsQuoteSafe(crawlArgs) {
+    // Split process.env.CRAWL_ARGS on spaces but retaining spaces within double quotes
+    const regex = /"[^"]+"|[^\s]+/g;
+    return crawlArgs.match(regex).map(e => e.replace(/"(.+)"/, "$1"));
+  }
 
   validateArgs(argv) {
     argv.collection = interpolateFilename(argv.collection, argv.crawlId);


### PR DESCRIPTION
Fixes #307

Tested manually by setting the following ENV var in the Dockerfile, then running a crawl via `docker compose run crawler crawl`:

```
ENV CRAWL_ARGS='--url https://specs.webrecorder.net --scopeType page --logging stats,behaviors,debug --generateWACZ --text --collection thecrawl ----userAgentSuffix "bl.uk_ldfc_bot/btrix (+ http://www.bl.uk/aboutus/legaldeposit/websites/websites/faqswebmaster/index.html)"'
```

After un-gzipping the WARCS, I can see that the user agent for the requests is now as we'd want it to be:

```
GET https://www.w3.org/StyleSheets/TR/2016/base.css HTTP/1.1
Host: www.w3.org
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.49 Safari/537.36 bl.uk_ldfc_bot/btrix (+ http://www.bl.uk/aboutus/legaldeposit/websites/websites/faqswebmaster/index.html)
```
