### PR TITLE
Fix disk utilization check

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -611,10 +611,7 @@ export class Crawler {
 
     if (this.params.diskUtilization) {
       // Check that disk usage isn't already above threshold
-      let diskUsage = await getDiskUsage();
-      if (!diskUsage) {
-        diskUsage = await getDiskUsage("/");
-      }
+      const diskUsage = await getDiskUsage();
       const usedPercentage = parseInt(diskUsage["Use%"].slice(0, -1));
       if (usedPercentage >= this.params.diskUtilization) {
         logger.info(`Disk utilization threshold reached ${usedPercentage}% > ${this.params.diskUtilization}%, stopping`);

--- a/crawler.js
+++ b/crawler.js
@@ -629,7 +629,7 @@ export class Crawler {
       }
 
       const projectedTotal = kbUsed + kbArchiveDirSize;
-      const projectedUsedPercentage = Math.round((projectedTotal/kbTotal) * 100)
+      const projectedUsedPercentage = Math.round((projectedTotal/kbTotal) * 100);
       if (projectedUsedPercentage >= this.params.diskUtilization) {
         logger.info(`Disk utilization projected to reach threshold ${projectedUsedPercentage}% > ${this.params.diskUtilization}%, stopping`);
         interrupt = true;

--- a/crawler.js
+++ b/crawler.js
@@ -629,7 +629,7 @@ export class Crawler {
       }
 
       const projectedTotal = kbUsed + kbArchiveDirSize;
-      const projectedUsedPercentage = Math.floor(kbTotal/projectedTotal);
+      const projectedUsedPercentage = Math.round((projectedTotal/kbTotal) * 100)
       if (projectedUsedPercentage >= this.params.diskUtilization) {
         logger.info(`Disk utilization projected to reach threshold ${projectedUsedPercentage}% > ${this.params.diskUtilization}%, stopping`);
         interrupt = true;

--- a/crawler.js
+++ b/crawler.js
@@ -611,7 +611,10 @@ export class Crawler {
 
     if (this.params.diskUtilization) {
       // Check that disk usage isn't already above threshold
-      const diskUsage = await getDiskUsage();
+      let diskUsage = await getDiskUsage();
+      if (!diskUsage) {
+        diskUsage = await getDiskUsage("/");
+      }
       const usedPercentage = parseInt(diskUsage["Use%"].slice(0, -1));
       if (usedPercentage >= this.params.diskUtilization) {
         logger.info(`Disk utilization threshold reached ${usedPercentage}% > ${this.params.diskUtilization}%, stopping`);

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,13 @@
+import { calculatePercentageUsed } from "../util/storage.js";
+
+test("ensure percentage used values are accurate", () => {
+  expect(calculatePercentageUsed(30, 100)).toEqual(30);
+
+  expect(calculatePercentageUsed(1507, 35750)).toEqual(4);
+
+  expect(calculatePercentageUsed(33819, 35750)).toEqual(95);
+
+  expect(calculatePercentageUsed(140, 70)).toEqual(200);
+
+  expect(calculatePercentageUsed(0, 5)).toEqual(200);
+});

--- a/util/storage.js
+++ b/util/storage.js
@@ -165,6 +165,10 @@ export async function getDiskUsage(path="/crawls") {
   return rows[0];
 }
 
+export function calculatePercentageUsed(used, total) {
+  return Math.round((used/total) * 100);
+}
+
 function checksumFile(hashName, path) {
   return new Promise((resolve, reject) => {
     const hash = createHash(hashName);

--- a/util/storage.js
+++ b/util/storage.js
@@ -150,10 +150,13 @@ export async function getDirSize(dir) {
   return size;
 }
 
-export async function getDiskUsage(path="/") {
+export async function getDiskUsage(path="/crawls") {
   const exec = util.promisify(child_process.exec);
   const result = await exec(`df ${path}`);
   const lines = result.stdout.split("\n");
+  if (lines.length < 1) {
+    return;
+  }
   const keys = lines[0].split(/\s+/ig);
   const rows = lines.slice(1).map(line => {
     const values = line.split(/\s+/ig);

--- a/util/storage.js
+++ b/util/storage.js
@@ -154,9 +154,6 @@ export async function getDiskUsage(path="/crawls") {
   const exec = util.promisify(child_process.exec);
   const result = await exec(`df ${path}`);
   const lines = result.stdout.split("\n");
-  if (lines.length < 1) {
-    return;
-  }
   const keys = lines[0].split(/\s+/ig);
   const rows = lines.slice(1).map(line => {
     const values = line.split(/\s+/ig);


### PR DESCRIPTION
Fixes #308 

- Checks disk size of crawl volume, not root directory
- Fixes calculation of projected directory size
- Adds tests (WIP)

Awaiting user testing from users who originally reported the issue.