### PR TITLE
Fix disk utilization computation errors

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -13,7 +13,7 @@ import * as warcio from "warcio";
 
 import { HealthChecker } from "./util/healthcheck.js";
 import { TextExtract } from "./util/textextract.js";
-import { initStorage, getFileSize, getDirSize, interpolateFilename, getDiskUsage, calculatePercentageUsed } from "./util/storage.js";
+import { initStorage, getFileSize, getDirSize, interpolateFilename, checkDiskUtilization } from "./util/storage.js";
 import { ScreenCaster, WSTransport, RedisPubSubTransport } from "./util/screencaster.js";
 import { Screenshots } from "./util/screenshots.js";
 import { parseArgs } from "./util/argParser.js";
@@ -610,30 +610,9 @@ export class Crawler {
     }
 
     if (this.params.diskUtilization) {
-      // Check that disk usage isn't already above threshold
-      const diskUsage = await getDiskUsage();
-      const usedPercentage = parseInt(diskUsage["Use%"].slice(0, -1));
-      if (usedPercentage >= this.params.diskUtilization) {
-        logger.info(`Disk utilization threshold reached ${usedPercentage}% > ${this.params.diskUtilization}%, stopping`);
-        interrupt = true;
-      }
-
-      // Check that disk usage isn't likely to cross threshold
-      const kbUsed = parseInt(diskUsage["Used"]);
-      const kbTotal = parseInt(diskUsage["1K-blocks"]);
-
-      let kbArchiveDirSize = Math.round(size/1024);
-      if (this.params.combineWARC && this.params.generateWACZ) {
-        kbArchiveDirSize *= 4;
-      } else if (this.params.combineWARC || this.params.generateWACZ) {
-        kbArchiveDirSize *= 2;
-      }
-
-      const projectedTotal = kbUsed + kbArchiveDirSize;
-      const projectedUsedPercentage = calculatePercentageUsed(projectedTotal, kbTotal);
-
-      if (projectedUsedPercentage >= this.params.diskUtilization) {
-        logger.info(`Disk utilization projected to reach threshold ${projectedUsedPercentage}% > ${this.params.diskUtilization}%, stopping`);
+      // Check that disk usage isn't already or soon to be above threshold
+      const diskUtil = await checkDiskUtilization(this.params, size);
+      if (diskUtil.stop === true) {
         interrupt = true;
       }
     }

--- a/crawler.js
+++ b/crawler.js
@@ -611,10 +611,7 @@ export class Crawler {
 
     if (this.params.diskUtilization) {
       // Check that disk usage isn't already above threshold
-      let diskUsage = await getDiskUsage();
-      if (!diskUsage) {
-        diskUsage = await getDiskUsage("/");
-      }
+      const diskUsage = await getDiskUsage();
       const usedPercentage = parseInt(diskUsage["Use%"].slice(0, -1));
       if (usedPercentage >= this.params.diskUtilization) {
         logger.info(`Disk utilization threshold reached ${usedPercentage}% > ${this.params.diskUtilization}%, stopping`);

--- a/crawler.js
+++ b/crawler.js
@@ -629,7 +629,7 @@ export class Crawler {
       }
 
       const projectedTotal = kbUsed + kbArchiveDirSize;
-      const projectedUsedPercentage = Math.round((projectedTotal/kbTotal) * 100)
+      const projectedUsedPercentage = Math.round((projectedTotal/kbTotal) * 100);
       if (projectedUsedPercentage >= this.params.diskUtilization) {
         logger.info(`Disk utilization projected to reach threshold ${projectedUsedPercentage}% > ${this.params.diskUtilization}%, stopping`);
         interrupt = true;

--- a/crawler.js
+++ b/crawler.js
@@ -629,7 +629,7 @@ export class Crawler {
       }
 
       const projectedTotal = kbUsed + kbArchiveDirSize;
-      const projectedUsedPercentage = Math.floor(kbTotal/projectedTotal);
+      const projectedUsedPercentage = Math.round((projectedTotal/kbTotal) * 100)
       if (projectedUsedPercentage >= this.params.diskUtilization) {
         logger.info(`Disk utilization projected to reach threshold ${projectedUsedPercentage}% > ${this.params.diskUtilization}%, stopping`);
         interrupt = true;

--- a/crawler.js
+++ b/crawler.js
@@ -611,7 +611,10 @@ export class Crawler {
 
     if (this.params.diskUtilization) {
       // Check that disk usage isn't already above threshold
-      const diskUsage = await getDiskUsage();
+      let diskUsage = await getDiskUsage();
+      if (!diskUsage) {
+        diskUsage = await getDiskUsage("/");
+      }
       const usedPercentage = parseInt(diskUsage["Use%"].slice(0, -1));
       if (usedPercentage >= this.params.diskUtilization) {
         logger.info(`Disk utilization threshold reached ${usedPercentage}% > ${this.params.diskUtilization}%, stopping`);

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,0 +1,3 @@
+import { jest } from "@jest/globals";
+
+global.jest = jest;

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,4 +1,6 @@
-import { calculatePercentageUsed } from "../util/storage.js";
+import { jest } from "@jest/globals";
+import { calculatePercentageUsed, checkDiskUtilization } from "../util/storage.js";
+
 
 test("ensure calculatePercentageUsed returns expected values", () => {
   expect(calculatePercentageUsed(30, 100)).toEqual(30);
@@ -10,4 +12,48 @@ test("ensure calculatePercentageUsed returns expected values", () => {
   expect(calculatePercentageUsed(140, 70)).toEqual(200);
 
   expect(calculatePercentageUsed(0, 5)).toEqual(0);
+});
+
+
+test("verify end-to-end disk utilization not exceeded threshold", async () => {
+
+  const params = {
+    diskUtilization: 90,
+    combineWARC: true,
+    generateWACZ: true
+  };
+
+ const mockDfOutput = `\
+Filesystem     1K-blocks      Used Available Use% Mounted on
+grpcfuse       971350180 270314600 701035580  28% /crawls`;
+
+  const returnValue = await checkDiskUtilization(params, 7500000 * 1024, mockDfOutput);
+  expect(returnValue).toEqual({
+    stop: false,
+    used: 28,
+    projected: 31,
+    threshold: 90
+  });
+});
+
+
+test("verify end-to-end disk utilization exceeds threshold", async () => {
+
+  const params = {
+    diskUtilization: 90,
+    combineWARC: false,
+    generateWACZ: true
+  };
+
+ const mockDfOutput = `\
+Filesystem     1K-blocks  Used Available Use% Mounted on
+grpcfuse       100000    85000     15000  85% /crawls`;
+
+  const returnValue = await checkDiskUtilization(params, 3000 * 1024, mockDfOutput);
+  expect(returnValue).toEqual({
+    stop: true,
+    used: 85,
+    projected: 91,
+    threshold: 90
+  });
 });

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -24,9 +24,11 @@ test("verify end-to-end disk utilization not exceeded threshold", async () => {
 
   const mockDfOutput = `\
 Filesystem     1K-blocks      Used Available Use% Mounted on
-grpcfuse       971350180 270314600 701035580  28% /crawls`;
+grpcfuse       1000000      285000    715000  28% /crawls`;
 
-  const returnValue = await checkDiskUtilization(params, 7500000 * 1024, mockDfOutput);
+  // with combineWARC + generateWACZ, projected is 285k + 4 * 5k = 310k = 31%
+  // does not exceed 90% threshold
+  const returnValue = await checkDiskUtilization(params, 5000 * 1024, mockDfOutput);
   expect(returnValue).toEqual({
     stop: false,
     used: 28,
@@ -48,6 +50,8 @@ test("verify end-to-end disk utilization exceeds threshold", async () => {
 Filesystem     1K-blocks  Used Available Use% Mounted on
 grpcfuse       100000    85000     15000  85% /crawls`;
 
+  // with generateWACZ, projected is 85k + 3k x 2 = 91k = 91%
+  // exceeds 90% threshold
   const returnValue = await checkDiskUtilization(params, 3000 * 1024, mockDfOutput);
   expect(returnValue).toEqual({
     stop: true,

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,4 +1,3 @@
-import { jest } from "@jest/globals";
 import { calculatePercentageUsed, checkDiskUtilization } from "../util/storage.js";
 
 
@@ -23,7 +22,7 @@ test("verify end-to-end disk utilization not exceeded threshold", async () => {
     generateWACZ: true
   };
 
- const mockDfOutput = `\
+  const mockDfOutput = `\
 Filesystem     1K-blocks      Used Available Use% Mounted on
 grpcfuse       971350180 270314600 701035580  28% /crawls`;
 
@@ -45,7 +44,7 @@ test("verify end-to-end disk utilization exceeds threshold", async () => {
     generateWACZ: true
   };
 
- const mockDfOutput = `\
+  const mockDfOutput = `\
 Filesystem     1K-blocks  Used Available Use% Mounted on
 grpcfuse       100000    85000     15000  85% /crawls`;
 

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,6 +1,6 @@
 import { calculatePercentageUsed } from "../util/storage.js";
 
-test("ensure percentage used values are accurate", () => {
+test("ensure calculatePercentageUsed returns expected values", () => {
   expect(calculatePercentageUsed(30, 100)).toEqual(30);
 
   expect(calculatePercentageUsed(1507, 35750)).toEqual(4);

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,13 @@
+import { calculatePercentageUsed } from "../util/storage.js";
+
+test("ensure percentage used values are accurate", () => {
+  expect(calculatePercentageUsed(30, 100)).toEqual(30);
+
+  expect(calculatePercentageUsed(1507, 35750)).toEqual(4);
+
+  expect(calculatePercentageUsed(33819, 35750)).toEqual(95);
+
+  expect(calculatePercentageUsed(140, 70)).toEqual(200);
+
+  expect(calculatePercentageUsed(0, 5)).toEqual(0);
+});

--- a/util/storage.js
+++ b/util/storage.js
@@ -165,6 +165,10 @@ export async function getDiskUsage(path="/crawls") {
   return rows[0];
 }
 
+export function calculatePercentageUsed(used, total) {
+  return Math.round((used/total) * 100);
+}
+
 function checksumFile(hashName, path) {
   return new Promise((resolve, reject) => {
     const hash = createHash(hashName);

--- a/util/storage.js
+++ b/util/storage.js
@@ -150,10 +150,13 @@ export async function getDirSize(dir) {
   return size;
 }
 
-export async function getDiskUsage(path="/") {
+export async function getDiskUsage(path="/crawls") {
   const exec = util.promisify(child_process.exec);
   const result = await exec(`df ${path}`);
   const lines = result.stdout.split("\n");
+  if (lines.length < 1) {
+    return;
+  }
   const keys = lines[0].split(/\s+/ig);
   const rows = lines.slice(1).map(line => {
     const values = line.split(/\s+/ig);

--- a/util/storage.js
+++ b/util/storage.js
@@ -154,9 +154,6 @@ export async function getDiskUsage(path="/crawls") {
   const exec = util.promisify(child_process.exec);
   const result = await exec(`df ${path}`);
   const lines = result.stdout.split("\n");
-  if (lines.length < 1) {
-    return;
-  }
   const keys = lines[0].split(/\s+/ig);
   const rows = lines.slice(1).map(line => {
     const values = line.split(/\s+/ig);


### PR DESCRIPTION
Fixes #308 

- Checks disk size of crawl volume, not root directory
- Fixes calculation of projected directory size
- Adds tests for below / above threshold

Awaiting user testing from users who originally reported the issue.