### PR TITLE
Bump browsertrix-behaviors to ^0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@novnc/novnc": "^1.4.0",
-    "browsertrix-behaviors": "^0.5.0-beta.0",
+    "browsertrix-behaviors": "^0.5.1",
     "get-folder-size": "^4.0.0",
     "ioredis": "^4.27.1",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
Tested with Twitter, behavior is now working correctly again for account timelines and single tweets. Home timeline appears to need a bit more work - see: https://github.com/webrecorder/browsertrix-crawler/issues/339#issuecomment-1623883972