### PR TITLE
mark for upload-and-delete when crawl is interrupted for any limit: 

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -630,7 +630,6 @@ self.__bx_behaviors.selectMainBehavior();
       if (size >= this.params.sizeLimit) {
         logger.info(`Size threshold reached ${size} >= ${this.params.sizeLimit}, stopping`);
         interrupt = true;
-        this.uploadAndDeleteLocal = true;
       }
     }
 
@@ -651,6 +650,7 @@ self.__bx_behaviors.selectMainBehavior();
     }
 
     if (interrupt) {
+      this.uploadAndDeleteLocal = true;
       this.gracefulFinish();
     }
   }


### PR DESCRIPTION
size limit, time limit, or disk limit. after previous fix in #347, was only setting the flag after size limit