### PR TITLE
link extraction optimization: for scopeType page, set depth == extraH…

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -1142,6 +1142,7 @@ self.__bx_behaviors.selectMainBehavior();
 
     // skip extraction if at max depth
     if (seed.isAtMaxDepth(depth) || !selectorOptsList) {
+      logger.debug("Skipping Link Extraction, At Max Depth");
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/util/seeds.js
+++ b/util/seeds.js
@@ -23,6 +23,12 @@ export class ScopedSeed
       this.include = [...include, ...this.include];
     }
 
+    // for page scope, the depth is set to extraHops, as no other
+    // crawling is done
+    if (this.scopeType === "page") {
+      depth = extraHops;
+    }
+
     this.sitemap = this.resolveSiteMap(sitemap);
     this.allowHash = allowHash;
     this.maxExtraHops = extraHops;


### PR DESCRIPTION
For `scopeType: page`, we know there won't be any additional links, unless extraHops is set, so set the depth == extraHops, so the depth check can skip the link extraction.
Add debug logging and bump to 0.10.5