### PR TITLE
improve exit features: individual instance exit + exit code for interrupt

### DIFF
--- a/util/state.js
+++ b/util/state.js
@@ -207,7 +207,15 @@ return 0;
   }
 
   async isCrawlStopped() {
-    return await this.redis.get(`${this.key}:stopping`) === "1";
+    if (await this.redis.get(`${this.key}:stopping`) === "1") {
+      return true;
+    }
+
+    if (await this.redis.hget(`${this.key}:stopone`, this.uid) === "1") {
+      return true;
+    }
+
+    return false;
   }
 
   // note: not currently called in crawler, but could be


### PR DESCRIPTION
- if interrupted (via signal or due to limits) and not finished, return error code 11 to indicate interruption
- allow stopping single instances with hset `<crawlid>:stopone` uid (similar to status)
- deliberate stop via redis not considered interruption (exit 0)
- lower edit recheck time