### PR TITLE
Surface lastmod option for sitemap parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Options:
       --useSitemap, --sitemap               If enabled, check for sitemaps at /s
                                             itemap.xml, or custom URL if URL is
                                             specified
+      --sitemapLastmod                      If set, filter URLs from sitemaps to
+                                            those greater than or equal to provi
+                                            ded YYYY-MM-DD string       [string]
       --statsFilename                       If set, output stats as JSON to this
                                              file. (Relative filename resolves t
                                             o crawl working directory)

--- a/README.md
+++ b/README.md
@@ -162,9 +162,10 @@ Options:
       --useSitemap, --sitemap               If enabled, check for sitemaps at /s
                                             itemap.xml, or custom URL if URL is
                                             specified
-      --sitemapFromDate                     If set, filter URLs from sitemaps to
-                                            those greater than or equal to provi
-                                            ded YYYY-MM-DD string       [string]
+      --sitemapFromDate, --sitemapFrom      If set, filter URLs from sitemaps to
+                                             those greater than or equal to prov
+                                            ided ISO Date string (YYYY-MM-DD or
+                                            YYYY-MM-DDTHH:MM:SS or partial date)
       --statsFilename                       If set, output stats as JSON to this
                                              file. (Relative filename resolves t
                                             o crawl working directory)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Options:
       --useSitemap, --sitemap               If enabled, check for sitemaps at /s
                                             itemap.xml, or custom URL if URL is
                                             specified
-      --sitemapLastmod                      If set, filter URLs from sitemaps to
+      --sitemapFromDate                     If set, filter URLs from sitemaps to
                                             those greater than or equal to provi
                                             ded YYYY-MM-DD string       [string]
       --statsFilename                       If set, output stats as JSON to this

--- a/crawler.js
+++ b/crawler.js
@@ -791,7 +791,7 @@ self.__bx_behaviors.selectMainBehavior();
       }
 
       if (seed.sitemap) {
-        await this.parseSitemap(seed.sitemap, i, this.params.sitemapLastmod);
+        await this.parseSitemap(seed.sitemap, i, this.params.sitemapFromDate);
       }
     }
 
@@ -1420,30 +1420,30 @@ self.__bx_behaviors.selectMainBehavior();
     }
   }
 
-  async parseSitemap(url, seedId, sitemapLastmod) {
-
+  async parseSitemap(url, seedId, sitemapFromDate) {
     // handle sitemap last modified date if passed
-    let lastmodTimestamp = null;
-    const dateObj = new Date(sitemapLastmod);
+    let lastmodFromTimestamp = null;
+    const dateObj = new Date(sitemapFromDate);
     if (isNaN(dateObj.getTime())) {
-      logger.warn(`Invalid sitemapLastmod date: ${sitemapLastmod}`);
+      logger.info("Fetching full sitemap (fromDate not specified/valid)", {url, sitemapFromDate}, "sitemap");
     } else {
-      lastmodTimestamp = dateObj.getTime();
+      lastmodFromTimestamp = dateObj.getTime();
+      logger.info("Fetching and filtering sitemap by date", {url, sitemapFromDate}, "sitemap");
     }
 
     const sitemapper = new Sitemapper({
       url,
       timeout: 15000,
       requestHeaders: this.headers,
-      lastmod: lastmodTimestamp
+      lastmod: lastmodFromTimestamp
     });
 
     try {
       const { sites } = await sitemapper.fetch();
-      logger.debug(`${sites.length} urls discovered from sitemap`);
+      logger.info("Sitemap Urls Found", {urls: sites.length}, "sitemap");
       await this.queueInScopeUrls(seedId, sites, 0);
     } catch(e) {
-      logger.warn("Error fetching sites from sitemap", e);
+      logger.warn("Error fetching sites from sitemap", e, "sitemap");
     }
   }
 

--- a/crawler.js
+++ b/crawler.js
@@ -791,7 +791,7 @@ self.__bx_behaviors.selectMainBehavior();
       }
 
       if (seed.sitemap) {
-        await this.parseSitemap(seed.sitemap, i);
+        await this.parseSitemap(seed.sitemap, i, this.params.sitemapLastmod);
       }
     }
 
@@ -1420,15 +1420,27 @@ self.__bx_behaviors.selectMainBehavior();
     }
   }
 
-  async parseSitemap(url, seedId) {
+  async parseSitemap(url, seedId, sitemapLastmod) {
+
+    // handle sitemap last modified date if passed
+    let lastmodTimestamp = null;
+    const dateObj = new Date(sitemapLastmod);
+    if (isNaN(dateObj.getTime())) {
+      logger.warn(`Invalid sitemapLastmod date: ${sitemapLastmod}`);
+    } else {
+      lastmodTimestamp = dateObj.getTime();
+    }
+
     const sitemapper = new Sitemapper({
       url,
       timeout: 15000,
-      requestHeaders: this.headers
+      requestHeaders: this.headers,
+      lastmod: lastmodTimestamp
     });
 
     try {
       const { sites } = await sitemapper.fetch();
+      logger.debug(`${sites.length} urls discovered from sitemap`);
       await this.queueInScopeUrls(seedId, sites, 0);
     } catch(e) {
       logger.warn("Error fetching sites from sitemap", e);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "minio": "7.0.26",
     "puppeteer-core": "^20.7.4",
     "sharp": "^0.32.1",
-    "sitemapper": "^3.1.2",
+    "sitemapper": "^3.2.5",
     "uuid": "8.3.2",
     "warcio": "^1.6.0",
     "ws": "^7.4.4",

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -227,6 +227,10 @@ class ArgParser {
         describe: "If enabled, check for sitemaps at /sitemap.xml, or custom URL if URL is specified",
       },
 
+      "sitemapLastmod": {
+        describe: "If set, filter URLs from sitemaps to those greater than or equal to provided YYYY-MM-DD string",
+      },
+
       "statsFilename": {
         describe: "If set, output stats as JSON to this file. (Relative filename resolves to crawl working directory)"
       },
@@ -514,6 +518,7 @@ class ArgParser {
     const scopeOpts = {
       scopeType: argv.scopeType,
       sitemap: argv.sitemap,
+      sitemapLastmod: argv.sitemapLastmod,
       include: argv.include,
       exclude: argv.exclude,
       depth: argv.depth,

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -519,7 +519,6 @@ class ArgParser {
     const scopeOpts = {
       scopeType: argv.scopeType,
       sitemap: argv.sitemap,
-      sitemapLastmod: argv.sitemapLastmod,
       include: argv.include,
       exclude: argv.exclude,
       depth: argv.depth,

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -227,7 +227,8 @@ class ArgParser {
         describe: "If enabled, check for sitemaps at /sitemap.xml, or custom URL if URL is specified",
       },
 
-      "sitemapLastmod": {
+      "sitemapFromDate": {
+        alias: "sitemapFrom",
         describe: "If set, filter URLs from sitemaps to those greater than or equal to provided YYYY-MM-DD string",
       },
 

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -229,7 +229,7 @@ class ArgParser {
 
       "sitemapFromDate": {
         alias: "sitemapFrom",
-        describe: "If set, filter URLs from sitemaps to those greater than or equal to provided YYYY-MM-DD string",
+        describe: "If set, filter URLs from sitemaps to those greater than or equal to provided ISO Date string (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS or partial date)",
       },
 
       "statsFilename": {


### PR DESCRIPTION
The library [`sitemapper`](https://github.com/seantomburke/sitemapper) used to parse sitemaps for URLs [added an optional "lastmod" argument in v3.2.5](https://github.com/seantomburke/sitemapper/releases/tag/3.2.5) that allows filtering URLs returned by a "last_modified" element present in sitemap XMLs.  This PR would surface that argument to the browsertrix-crawler CLI runtime as an optional parameter.

This could be useful for orienting a crawl around a list of seeds known to contain sitemaps, but are only interested in including URLs that have been modified on or after X date.

Tested locally with and without the flag, both appear to work as expected.  Confirmed that it shows up in `--help` text.  Didn't want to add too much to the logs, but added a `debug` log line that shows how many URLs were collected from a given sitemap XML, which while testing, was helpful to know if the `lastmod` date was dialed in as expected, e.g.:

```json
{"logLevel":"debug","timestamp":"2023-09-06T18:31:50.577Z","context":"general","message":"Queuing url https://<URL_HERE>/sitemap.xml","details":{}}
{"logLevel":"debug","timestamp":"2023-09-06T18:31:54.007Z","context":"general","message":"2 urls discovered from sitemap","details":{}}
```

Closes #357