### PR TITLE
various fixes regarding state restart:

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -658,25 +658,14 @@ self.__bx_behaviors.selectMainBehavior();
 
     if (interrupt) {
       this.uploadAndDeleteLocal = true;
-      this.gracefulFinish();
+      this.gracefulFinishOnInterrupt();
     }
   }
 
-  gracefulFinish() {
+  gracefulFinishOnInterrupt() {
     this.interrupted = true;
     logger.info("Crawler interrupted, gracefully finishing current pages");
     if (!this.params.waitOnDone && !this.params.restartsOnError) {
-      this.finalExit = true;
-    }
-  }
-
-  prepareForExit(markDone = true) {
-    if (!markDone) {
-      this.params.waitOnDone = false;
-      this.uploadAndDeleteLocal = true;
-      logger.info("SIGNAL: Preparing for exit of this crawler instance only");
-    } else {
-      logger.info("SIGNAL: Preparing for final exit of all crawlers");
       this.finalExit = true;
     }
   }

--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ async function handleTerminate(signame) {
   try {
     if (!crawler.interrupted) {
       logger.info("SIGNAL: gracefully finishing current pages...");
-      crawler.gracefulFinish();
+      crawler.gracefulFinishOnInterrupt();
 
     } else if (forceTerm || (Date.now() - lastSigInt) > 200) {
       logger.info("SIGNAL: stopping crawl now...");
@@ -47,18 +47,6 @@ process.on("SIGTERM", () => handleTerminate("SIGTERM"));
 process.on("SIGABRT", async () => {
   logger.info("SIGABRT received, will force immediate exit on SIGTERM/SIGINT");
   forceTerm = true;
-});
-
-process.on("SIGUSR1", () => {
-  if (crawler) {
-    crawler.prepareForExit(true);
-  }
-});
-
-process.on("SIGUSR2", () => {
-  if (crawler) {
-    crawler.prepareForExit(false);
-  }
 });
 
 crawler = new Crawler();

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -347,6 +347,12 @@ class ArgParser {
         default: false
       },
 
+      "restartsOnError": {
+        describe: "if set, assume will be restarted if interrupted, don't run post-crawl processes on interrupt",
+        type: "boolean",
+        default: false
+      },
+
       "netIdleWait": {
         describe: "if set, wait for network idle after page load and after behaviors are done (in seconds). if -1 (default), determine based on scope",
         type: "number",

--- a/util/logger.js
+++ b/util/logger.js
@@ -101,7 +101,7 @@ class Logger
     }
   }
 
-  fatal(message, data={}, context="general", exitCode=1) {
+  fatal(message, data={}, context="general", exitCode=17) {
     this.logAsJSON(`${message}. Quitting`, data, context, "fatal");
     process.exit(exitCode);
   }


### PR DESCRIPTION
This PR is designed to address a few edge-cases when using crawler in Browsertrix Cloud (>=1.7.0 beta 0)
- Add --restartOnError flag, which tells crawler that it will be restarted if it receives a signal and will not perform post-crawl processes on non-zero exit.
- If a crawl is being stopped gracefully, but is also interrupted via signal (due to size/time/disk limit or other interruption) but is able to complete, it *will* attempt post-crawl processes / exit with success
- If no WARCs are found, but number of pages written >0, assume crawler was restarted, and don't fail!
- use distinct exit code for subsequent interrupt (13) and fatal interrupt (17)