### PR TITLE
optimize link extraction: (fixes #376)

### DIFF
--- a/tests/limit_reached.test.js
+++ b/tests/limit_reached.test.js
@@ -1,0 +1,15 @@
+import child_process from "child_process";
+import fs from "fs";
+
+test("ensure page limit reached", async () => {
+  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --scopeType prefix --behaviors \"\" --url https://webrecorder.net/ --limit 12 --workers 2 --collection limit-test --statsFilename stats.json");
+
+});
+
+test("check limit written to stats file is as expected", () => {
+  const data = fs.readFileSync("test-crawls/stats.json", "utf8");
+  const dataJSON = JSON.parse(data);
+  expect(dataJSON.crawled).toEqual(12);
+  expect(dataJSON.total).toEqual(12);
+  expect(dataJSON.limit.hit).toBe(true);
+});

--- a/util/browser.js
+++ b/util/browser.js
@@ -51,6 +51,7 @@ export class BaseBrowser
       handleSIGHUP: signals,
       handleSIGINT: signals,
       handleSIGTERM: signals,
+      protocolTimeout: 0,
 
       defaultViewport,
       waitForInitialPage: false,

--- a/util/constants.js
+++ b/util/constants.js
@@ -2,6 +2,7 @@
 export const HTML_TYPES = ["text/html", "application/xhtml", "application/xhtml+xml"];
 export const WAIT_UNTIL_OPTS = ["load", "domcontentloaded", "networkidle0", "networkidle2"];
 export const BEHAVIOR_LOG_FUNC = "__bx_log";
+export const ADD_LINK_FUNC = "__bx_addLink";
 export const MAX_DEPTH = 1000000;
 
 export const DEFAULT_SELECTORS = [{


### PR DESCRIPTION
- dedup URLs in browser first
- don't return entire list of URLs, process one-at-a-time via registered callback function
- add exposeFunction per page in setupPage, then register 'addLink' callback for each pages' handler
- optimize addqueue: atomically check if already at max urls and if url already seen in one redis call, as links can be added async
- better logging: log rejected promises for link extraction
- browser: set protocolTimeout to 0 to avoid CDP timeout errors