### PR TITLE
Enhance file stats test to detect file modification

### DIFF
--- a/tests/file_stats.test.js
+++ b/tests/file_stats.test.js
@@ -1,24 +1,52 @@
 import child_process from "child_process";
 import fs from "fs";
 
+test("ensure that stats file is modified", async () => {
 
-test("ensure crawl run with docker with stats file passes", async () => {
-  child_process.execSync("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://www.example.com/ --generateWACZ  --text --collection file-stats --statsFilename progress.json");
+  const child = child_process.exec("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --generateWACZ  --text  --limit 3 --collection file-stats --statsFilename progress.json");
 
-});
+  // detect crawler exit
+  let crawler_exited = false;
+  child.on("exit", function() {
+    crawler_exited = true;
+  });
 
-test("check that a stats file exists", () => {
-  expect(fs.existsSync("test-crawls/progress.json")).toBe(true);
+  // helper function to sleep
+  const sleep = ms => new Promise( res => setTimeout(res, ms));
+
+  // wait for stats file creation up to 30 secs (to not wait indefinitely)
+  let counter = 0;
+  while (!fs.existsSync("test-crawls/progress.json")) {
+    await sleep(100);
+    counter++;
+    expect(counter < 300).toBe(true);
+  }
+
+  // get initial modification time
+  const initial_mtime = fs.fstatSync(fs.openSync("test-crawls/progress.json", "r")).mtime;
+
+  // wait for crawler exit
+  while (!crawler_exited) {
+    await sleep(100);
+  }
+
+  // get final modification time
+  const final_mtime = fs.fstatSync(fs.openSync("test-crawls/progress.json", "r")).mtime;
+
+  // compare initial and final modification time
+  const diff = Math.abs(final_mtime - initial_mtime);
+  expect(diff > 0).toBe(true);
+
 });
 
 test("check that stats file format is correct", () => {
   const data = fs.readFileSync("test-crawls/progress.json", "utf8");
   const dataJSON = JSON.parse(data);
-  expect(dataJSON.crawled).toEqual(1);
-  expect(dataJSON.total).toEqual(1);
+  expect(dataJSON.crawled).toEqual(3);
+  expect(dataJSON.total).toEqual(3);
   expect(dataJSON.pending).toEqual(0);
   expect(dataJSON.failed).toEqual(0);
-  expect(dataJSON.limit.max).toEqual(0);
-  expect(dataJSON.limit.hit).toBe(false);
+  expect(dataJSON.limit.max).toEqual(3);
+  expect(dataJSON.limit.hit).toBe(true);
   expect(dataJSON.pendingPages.length).toEqual(0);
 });

--- a/tests/file_stats.test.js
+++ b/tests/file_stats.test.js
@@ -3,7 +3,7 @@ import fs from "fs";
 
 test("ensure that stats file is modified", async () => {
 
-  const child = child_process.exec("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --generateWACZ  --text  --limit 3 --collection file-stats --statsFilename progress.json");
+  const child = child_process.exec("docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --generateWACZ --text --limit 3 --collection file-stats --statsFilename progress.json");
 
   // detect crawler exit
   let crawler_exited = false;
@@ -12,7 +12,7 @@ test("ensure that stats file is modified", async () => {
   });
 
   // helper function to sleep
-  const sleep = ms => new Promise( res => setTimeout(res, ms));
+  const sleep = ms => new Promise(res => setTimeout(res, ms));
 
   // wait for stats file creation up to 30 secs (to not wait indefinitely)
   let counter = 0;


### PR DESCRIPTION
Follow-up to #374 to enhance test.

Test will now:
  - wait for stat file creation up to 30 secs
  - grab the initial stat file modification time
  - wait for crawl termination
  - grab the final stat file modification time
  - ensure that initial and final modification times are different