### PR TITLE
favicon: use 127.0.0.1 instead of localhost

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -446,16 +446,20 @@ self.__bx_behaviors.selectMainBehavior();
   }
 
   async getFavicon(page, logDetails) {
-    const resp = await fetch("http://localhost:9221/json");
-    if (resp.status === 200) {
-      const browserJson = await resp.json();
-      for (const jsons of browserJson) {
-        if (jsons.id === page.target()._targetId) {
-          return jsons.faviconUrl;
+    try {
+      const resp = await fetch("http://127.0.0.1:9221/json");
+      if (resp.status === 200) {
+        const browserJson = await resp.json();
+        for (const jsons of browserJson) {
+          if (jsons.id === page.target()._targetId) {
+            return jsons.faviconUrl;
+          }
         }
       }
+    } catch (e) {
+      // ignore
     }
-    logger.warn("Failed to fetch Favicon from localhost debugger", logDetails);
+    logger.warn("Failed to fetch favicon from browser /json endpoint", logDetails);
   }
 
   async crawlPage(opts) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",


### PR DESCRIPTION
For some reason, internal fetch sometimes fails if using localhost instead of 127.0.0.1 so switch to that.
Also, catch exception if favicon fetch fails!
bump to 0.11.1