### PR TITLE
Error handling fixes to avoid crawler getting stuck.

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -820,6 +820,10 @@ self.__bx_behaviors.selectMainBehavior();
         proxy: !process.env.NO_PROXY,
         userAgent: this.emulateDevice.userAgent,
         extraArgs: this.extraChromeArgs()
+      },
+      ondisconnect: (err) => {
+        this.interrupted = true;
+        logger.error("Browser disconnected (crashed?), interrupting crawl", err, "browser");
       }
     });
 

--- a/util/browser.js
+++ b/util/browser.js
@@ -216,6 +216,7 @@ export class Browser extends BaseBrowser
 
   async close() {
     if (this.browser) {
+      this.browser.removeListener("disconnected", this._onDisconnectError);
       await this.browser.close();
       this.browser = null;
     }
@@ -225,8 +226,14 @@ export class Browser extends BaseBrowser
     return page.evaluateOnNewDocument(script);
   }
 
+  _onDisconnectError() {
+    logger.fatal("Browser crashed or disconnected, exiting", {}, "browser");
+  }
+
   async _init(launchOpts) {
     this.browser = await puppeteer.launch(launchOpts);
+
+    this.browser.on("disconnected", this._onDisconnectError);
 
     const target = this.browser.target();
 

--- a/util/logger.js
+++ b/util/logger.js
@@ -65,8 +65,8 @@ class Logger
     }
 
     let dataToLog = {
-      "logLevel": logLevel,
       "timestamp": new Date().toISOString(),
+      "logLevel": logLevel,
       "context": context,
       "message": message,
       "details": data ? data : {}


### PR DESCRIPTION
Logging and error handling improvements, in particular to avoid crawler getting stuck.
- Catch correct event when page crashes, `page.on('error'`) not `page.on('crash')`
- Also catch browser crash/disconnect with `browser.on('disconnected')` and immediately interrupt, but allow the post-crawl state to run to await for pending response to be written to WARC. (Or, could also change logger.fatal() to wait for that as well).
- Add timeout for page.teardown which calls screencaster and `await cdp.send("Page.stopScreencast");`, which can timeout as well (possibly if page crashed).
- Avoid duplicate logging of crash events where possible.
- Switch logging format to put timestamp first.
- Just to be safe: If new page is on a different origin than previous page, always open a new page, don't reuse previous one.