### PR TITLE
more logging improvements

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -592,9 +592,10 @@ self.__bx_behaviors.selectMainBehavior();
         frames.map(frame => this.browser.evaluateWithCLI(page, frame, cdp, `
           if (!self.__bx_behaviors) {
             console.error("__bx_behaviors missing, can't run behaviors");
-            return;
-          }
-          self.__bx_behaviors.run();`, logDetails, "behavior"))
+          } else {
+            self.__bx_behaviors.run();
+          }`
+        , logDetails, "behavior"))
       );
 
       for (const {status, reason} in results) {

--- a/util/browser.js
+++ b/util/browser.js
@@ -163,7 +163,13 @@ export class BaseBrowser
   }
 
   async evaluateWithCLI_(cdp, frame, cdpContextId, funcString, logData, contextName) {
-    let details = {frameUrl: frame.url(), ...logData};
+    const frameUrl = frame.url();
+    let details = {frameUrl, ...logData};
+
+    if (!frameUrl || frame.isDetached()) {
+      logger.info("Run Script Skipped, frame no longer attached or has no URL", details, contextName);
+      return false;
+    }
 
     logger.info("Run Script Started", details, contextName);
 


### PR DESCRIPTION
two logging improvements:
- run behaviors: check if behaviors object exists before trying to run behaviors to avoid failure message, instead log console.error(), which will be logged as a warning.
- iframe check: don't log warning if iframe is being skipped