### PR TITLE
Handle HTTP 429 errors + add failure limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Here's how you can use some of the command-line options to configure the crawl:
 
 - To limit the crawl time, set `--timeLimit` (in seconds)
 
+- To limit the crawl to a maximum number of failures, set `--failedLimit` (in number of pages)
+
 - To run more than one browser worker and crawl in parallel, and `--workers N` where N is number of browsers to run in parallel. More browsers will require more CPU and network bandwidth, and does not guarantee faster crawling.
 
 - To crawl into a new directory, specify a different name for the `--collection` param, or, if omitted, a new collection directory based on current time will be created. Adding the `--overwrite` flag will delete the collection directory at the start of the crawl, if it exists.
@@ -224,6 +226,9 @@ Options:
       --timeLimit                           If set, save state and exit after ti
                                             me limit, in seconds
                                                            [number] [default: 0]
+      --failedLimit                         If set, save state and exit if numbe
+                                            r of failed pages exceeds this value
+                                                           [number] [default: 0]
       --healthCheckPort                     port to run healthcheck on
                                                            [number] [default: 0]
       --overwrite                           overwrite current crawl data: if set
@@ -260,6 +265,12 @@ Options:
                                             code 1 if any seed fails
                                                       [boolean] [default: false]
       --config                              Path to YAML config file
+      --pageLoadAttempts                    How many times the crawler retries t
+                                            o load a page if the error is recove
+                                            rable
+      --defaultRetryPause                   How long the crawler pauses when an
+                                            HTTP 429 error is received without `
+                                            Retry-After` header
 
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -226,9 +226,6 @@ Options:
       --timeLimit                           If set, save state and exit after ti
                                             me limit, in seconds
                                                            [number] [default: 0]
-      --failedLimit                         If set, save state and exit if numbe
-                                            r of failed pages exceeds this value
-                                                           [number] [default: 0]
       --healthCheckPort                     port to run healthcheck on
                                                            [number] [default: 0]
       --overwrite                           overwrite current crawl data: if set

--- a/crawler.js
+++ b/crawler.js
@@ -1159,14 +1159,14 @@ self.__bx_behaviors.selectMainBehavior();
 
         // HTTP 429, let's make a pause (even if max attempts has been reached, to not overload the website)
         if (statusCode === 429) {
-          const retryAfterStr = "Retry-After" in resp.headers() ? resp.headers()["Retry-After"] : undefined;
+          const retryAfterStr = "retry-after" in resp.headers() ? resp.headers()["retry-after"] : undefined;
           if (retryAfterStr) {
             const retryAfterInt = Number.isInteger(retryAfterStr) ? parseInt(retryAfterStr): Math.ceil((Date.parse(retryAfterStr) - Date.now()) / 1000);
             logger.warn("HTTP 429 with Retry-After, waiting", {retryAfterInt, ...logDetails});
-            sleep(retryAfterInt);
+            await sleep(retryAfterInt);
           } else {
             logger.warn("HTTP 429 without Retry-After, waiting", {...logDetails});
-            sleep(this.params.defaultRetryPause);
+            await sleep(this.params.defaultRetryPause);
           }
           if (nbAttempts < this.params.pageLoadAttempts) {
             // Retry if we have attempts left

--- a/crawler.js
+++ b/crawler.js
@@ -1159,8 +1159,8 @@ self.__bx_behaviors.selectMainBehavior();
 
         // HTTP 429, let's make a pause (even if max attempts has been reached, to not overload the website)
         if (statusCode === 429) {
-          const retryAfterStr = "retry-after" in resp.headers() ? resp.headers()["retry-after"] : undefined;
-          if (retryAfterStr) {
+          const retryAfterStr = resp.headers()["retry-after"];
+          if (retryAfterStr != null) {
             const retryAfterInt = Number.isInteger(retryAfterStr) ? parseInt(retryAfterStr): Math.ceil((Date.parse(retryAfterStr) - Date.now()) / 1000);
             logger.warn("HTTP 429 with Retry-After, waiting", {retryAfterInt, ...logDetails});
             await sleep(retryAfterInt);

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -334,6 +334,12 @@ class ArgParser {
         default: 0,
       },
 
+      "failedLimit": {
+        describe: "If set, save state and exit if number of failed pages exceeds this value",
+        type: "number",
+        default: 0,
+      },
+
       "healthCheckPort": {
         describe: "port to run healthcheck on",
         type: "number",
@@ -401,6 +407,18 @@ class ArgParser {
       "customBehaviors": {
         describe: "injects a custom behavior file or set of behavior files in a directory",
         type: ["string"]
+      },
+
+      "pageLoadAttempts": {
+        describe: "How many time the crawler retries to load a page if the error is recoverable",
+        type: "number",
+        default: 2,
+      },
+
+      "defaultRetryPause": {
+        describe: "How long the crawler pauses when an HTTP 429 error is received without `Retry-After` header",
+        type: "number",
+        default: 60,
       },
     };
   }

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -334,12 +334,6 @@ class ArgParser {
         default: 0,
       },
 
-      "failedLimit": {
-        describe: "If set, save state and exit if number of failed pages exceeds this value",
-        type: "number",
-        default: 0,
-      },
-
       "healthCheckPort": {
         describe: "port to run healthcheck on",
         type: "number",


### PR DESCRIPTION
Fix #392 (mostly, see NB below, but this is ok for me)

# Changes
- add a `failedLimit` CLI argument which interrupts the crawler if the number of failed pages is greater or equal to this limit
- add a `pageLoadAttempts` + `defaultRetryPause` CLI arguments. In case of HTTP 429 error:
  - the crawler will retry up to `pageLoadAttempts` times
  - the pause between retries will be based on the `Retry-After` HTTP response header
    - both absolute <http-date> and relative <delay-seconds> formats are supported 
  - if the header is not provided, the pause will default to `defaultRetryPause` seconds
  - for now, other statuses are not retried (HTTP 503 could theoretically be retried as well, but with even larger pauses so not very practical for a crawler especially since the chance of getting a good response are typically lower than on HTTP 429)

NB: the `failedLimit` argument is not based on a count of successive failures as originally suggested in the issue, because it is indeed way more complex + potentially not that great (e.g. if there is many failures but some random success, the limit might not apply ; if there is random failures on a limited number of pages, the limit might never apply but the result be pretty bad)