### PR TITLE
additional fixes for worker getting stuck

### DIFF
--- a/util/worker.js
+++ b/util/worker.js
@@ -7,6 +7,7 @@ const MAX_REUSE = 5;
 
 const NEW_WINDOW_TIMEOUT = 20;
 const TEARDOWN_TIMEOUT = 10;
+const FINISHED_TIMEOUT = 60;
 
 // ===========================================================================
 export function runWorkers(crawler, numWorkers, maxPageTime) {
@@ -81,7 +82,13 @@ export class PageWorker
 
     try {
       logger.debug("Closing page", {crashed: this.crashed, workerid: this.id}, "worker");
-      await this.page.close();
+      await timedRun(
+        this.page.close(),
+        TEARDOWN_TIMEOUT,
+        "Page Close Timed Out",
+        this.logDetails,
+        "worker"
+      );
     } catch (e) {
       // ignore
     } finally {
@@ -203,7 +210,13 @@ export class PageWorker
         logger.error("Worker Exception", {...errJSON(e), ...this.logDetails}, "worker");
       }
     } finally {
-      await this.crawler.pageFinished(data);
+      await timedRun(
+        this.crawler.pageFinished(data),
+        FINISHED_TIMEOUT,
+        "Page Finished Timed Out",
+        this.logDetails,
+        "worker"
+      );
     }
   }
 


### PR DESCRIPTION
Based on analysis of logs where a worker appeared to be stuck, adding additional timeouts to operations:
- await page.close() if not finished within 20s
- await crawler.pageFinished() if not finished within 60s (in case config is being written)

Hopefully fix for #391 