### PR TITLE
Switch to Brave Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BROWSER_VERSION=112
-ARG BROWSER_IMAGE_BASE=webrecorder/browsertrix-browser-base:chrome-${BROWSER_VERSION}
+ARG BROWSER_VERSION=1.58.135
+ARG BROWSER_IMAGE_BASE=webrecorder/browsertrix-browser-base:brave-${BROWSER_VERSION}
 
 FROM ${BROWSER_IMAGE_BASE}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.11.3",
+  "version": "0.12.0-beta.0",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/tests/adblockrules.test.js
+++ b/tests/adblockrules.test.js
@@ -27,6 +27,7 @@ function doesCDXContain(coll, value) {
 test("test crawl without ad block for specific URL", () => {
   const config = {
     "url": "https://www.mozilla.org/en-US/firefox/",
+    "pageExtraDelay": 10
   };
 
   runCrawl("adblock-no-block", config);

--- a/tests/blockrules.test.js
+++ b/tests/blockrules.test.js
@@ -27,6 +27,7 @@ function doesCDXContain(coll, value) {
 test("test crawl without block for specific URL", () => {
   const config = {
     "url": "https://www.iana.org/",
+    "pageExtraDelay": 10
   };
 
   runCrawl("block-1-no-block", config);


### PR DESCRIPTION
To simplify keeping up with latest Chromium changes, and to benefit from improved ad-blocking in Brave, switching to using Brave for crawling. See #189 for more details.

Includes:
- switch base browser to brave base image 1.58.135
- bump to 0.11.3