### PR TITLE
Execution Time Follow-Up Work

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -173,6 +173,8 @@ export class Crawler {
 
     this.crawlState = new RedisCrawlState(redis, this.params.crawlId, this.maxPageTime, os.hostname());
 
+    await this.crawlState.setStartTime();
+
     // clear any pending URLs from this instance
     await this.crawlState.clearOwnPendingLocks();
 
@@ -302,6 +304,8 @@ export class Crawler {
   }
 
   async run() {
+    await this.initCrawlState();
+
     await this.bootstrap();
 
     let status = "done";
@@ -760,10 +764,6 @@ self.__bx_behaviors.selectMainBehavior();
       logger.warn(`Error importing driver ${this.params.driver}`, e);
       return;
     }
-
-    await this.initCrawlState();
-
-    await this.crawlState.setStartTime();
 
     let initState = await this.crawlState.getStatus();
 

--- a/util/state.js
+++ b/util/state.js
@@ -202,9 +202,11 @@ return 0;
     if (!endTimeTs) {
       endTimeTs = Date.now();
     }
-    const prevStartTime = await this.redis.getset(this.startkey, "0");
+    const prevStartTime = await this.redis.getset(this.startkey, 0);
     if (prevStartTime) {
-      await this.redis.incrby(this.execTimeKey, (endTimeTs - Number(prevStartTime)) / 1000);
+      const newExecTime = Math.ceil((endTimeTs - Number(prevStartTime)) / 1000);
+      logger.debug("Adding exec time", {newExecTime}, "state");
+      await this.redis.incrby(this.execTimeKey, newExecTime);
       return true;
     }
     return false;

--- a/util/state.js
+++ b/util/state.js
@@ -202,7 +202,7 @@ return 0;
     if (!endTimeTs) {
       endTimeTs = Date.now();
     }
-    const prevStartTime = await this.redis.getset(this.startkey, 0);
+    const prevStartTime = Number(await this.redis.getset(this.startkey, "0") || 0);
     if (prevStartTime) {
       const newExecTime = Math.ceil((endTimeTs - Number(prevStartTime)) / 1000);
       logger.debug("Adding exec time", {newExecTime}, "state");

--- a/util/state.js
+++ b/util/state.js
@@ -202,7 +202,7 @@ return 0;
     if (!endTimeTs) {
       endTimeTs = Date.now();
     }
-    const prevStartTime = await this.redis.getdel(this.startkey);
+    const prevStartTime = await this.redis.getset(this.startkey, "0");
     if (prevStartTime) {
       await this.redis.incrby(this.execTimeKey, (endTimeTs - Number(prevStartTime)) / 1000);
       return true;


### PR DESCRIPTION
Update execution time system to new approach described in https://github.com/webrecorder/browsertrix-cloud/pull/1218#issuecomment-1747988456, follow-up to #397 

Using a single `:start:<id>` key per instance

Also move setStartTime() earlier in init process.