### PR TITLE
Fast cancelation + remove time counter

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,8 @@ async function handleTerminate(signame) {
   setExitOnRedisError(true);
 
   try {
+    crawler.checkCanceled();
+
     if (!crawler.interrupted) {
       logger.info("SIGNAL: gracefully finishing current pages...");
       crawler.gracefulFinishOnInterrupt();

--- a/util/logger.js
+++ b/util/logger.js
@@ -19,6 +19,12 @@ class Logger
     this.logLevels = [];
     this.contexts = [];
     this.crawlState = null;
+
+    this.fatalExitCode = 17;
+  }
+
+  setDefaultFatalExitCode(exitCode) {
+    this.fatalExitCode = exitCode;
   }
 
   setExternalLogStream(logFH) {
@@ -101,16 +107,12 @@ class Logger
     }
   }
 
-  fatal(message, data={}, context="general", exitCode=17) {
+  fatal(message, data={}, context="general", exitCode=0) {
+    exitCode = exitCode || this.fatalExitCode;
     this.logAsJSON(`${message}. Quitting`, data, context, "fatal");
 
-    async function markFailedAndEnd(crawlState) {
-      await crawlState.setStatus("failed");
-      await crawlState.setEndTime();
-    }
-
     if (this.crawlState) {
-      markFailedAndEnd(this.crawlState).finally(process.exit(exitCode));
+      this.crawlState.setStatus("failed").finally(process.exit(exitCode));
     } else {
       process.exit(exitCode);
     }


### PR DESCRIPTION
Follow-up to #378, supersedes #405.

Removing start/end time count from the crawler itself.

Instead, adding 'isCrawlCanceled()` which, if true, will immediately exit the process.

Also checking isCrawlCanceled() on interrupts, to allow immediate shutdown when crawl is canceled.

When in 'restart on exit' mode, have fatal() return a 0 exit code. This then tells k8s to not restart the pod (the actual failure state is set in redis), while a non-zero exit code will result in a restart.