### PR TITLE
tests: disable ad-block tests: seeing inconsistent ci behavior

### DIFF
--- a/tests/adblockrules.test.js
+++ b/tests/adblockrules.test.js
@@ -24,6 +24,8 @@ function doesCDXContain(coll, value) {
   return data.indexOf(value) >= 0;
 }
 
+// Test Disabled for Brave -- should always be blocked, but seeing inconsistent ci behavior
+/*
 test("test crawl without ad block for specific URL", () => {
   const config = {
     "url": "https://www.mozilla.org/en-US/firefox/",
@@ -35,6 +37,7 @@ test("test crawl without ad block for specific URL", () => {
   // without ad blocking, URL with googletagmanager is included
   expect(doesCDXContain("adblock-no-block", "www.googletagmanager.com")).toBe(true);
 });
+*/
 
 test("testcrawl with ad block for specific URL", () => {
   const config = {

--- a/tests/blockrules.test.js
+++ b/tests/blockrules.test.js
@@ -24,6 +24,8 @@ function doesCDXContain(coll, value) {
   return data.indexOf(value) >= 0;
 }
 
+// Test Disabled for Brave -- should always be blocked, but seeing inconsistent ci behavior
+/*
 test("test crawl without block for specific URL", () => {
   const config = {
     "url": "https://www.iana.org/",
@@ -35,6 +37,7 @@ test("test crawl without block for specific URL", () => {
   // without blocks, URL with add sense is included
   expect(doesCDXContain("block-1-no-block", "https://cse.google.com/adsense/search/async-ads.js")).toBe(true);
 });
+*/
 
 
 test("test block rule on specific URL", () => {


### PR DESCRIPTION
Disable these tests until we get consistent repro of the issues.
They seem to be failing sporadically, though the content does appear to be blocked in Brave on manual testing.