### PR TITLE
Support adding/removing exclusions without restarting the crawler

### DIFF
--- a/util/seeds.js
+++ b/util/seeds.js
@@ -45,6 +45,25 @@ export class ScopedSeed
     }
   }
 
+  addExclusion(value) {
+    if (!value) {
+      return;
+    }
+    if (!(value instanceof RegExp)) {
+      value = new RegExp(value);
+    }
+    this.exclude.push(value);
+  }
+
+  removeExclusion(value) {
+    for (let i = 0; i < this.exclude.length; i++) {
+      if (this.exclude[i].toString() == value.toString()) {
+        this.exclude.splice(i, 1);
+        return true;
+      }
+    }
+  }
+
   parseUrl(url, logDetails = {}) {
     let parsedUrl = null;
     try {

--- a/util/worker.js
+++ b/util/worker.js
@@ -237,6 +237,8 @@ export class PageWorker
     let loggedWaiting = false;
 
     while (await this.crawler.isCrawlRunning()) {
+      await crawlState.processMessage(this.crawler.params.scopedSeeds);
+
       const data = await crawlState.nextFromQueue();
 
       // see if any work data in the queue


### PR DESCRIPTION
Part of work for webrecorder/browsertrix-cloud#1216:
- support adding/removing exclusions dynamically via a Redis message list
- add processMessage() which checks <uid>:msg list for any messages
- handle addExclusion / removeExclusion messages to add / remove exclusions for each seed
- also add filterQueue() which filters queue, one URL at a time, async when a new exclusion is added