### PR TITLE
disable component updates by setting --component-updater to invalid URL

### DIFF
--- a/util/browser.js
+++ b/util/browser.js
@@ -359,5 +359,6 @@ export const defaultArgs = [
   "--use-mock-keychain",
   // See https://chromium-review.googlesource.com/c/chromium/src/+/2436773
   "--no-service-autorun",
-  "--export-tagged-pdf"
+  "--export-tagged-pdf",
+  "--component-updater=url-source=http://invalid.dev/",
 ];


### PR DESCRIPTION
Currently, Brave will attempt an automatic update of components on launch. This should prevent that.