### PR TITLE
load saved state fixes + redis tests

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -266,7 +266,12 @@ export class Crawler {
 
     const subprocesses = [];
 
-    subprocesses.push(child_process.spawn("redis-server", {cwd: "/tmp/", stdio: redisStdio}));
+    let redisArgs = [];
+    if (this.params.debugAccessRedis) {
+      redisArgs = ["--protected-mode", "no"];
+    }
+
+    subprocesses.push(child_process.spawn("redis-server", redisArgs, {cwd: "/tmp/", stdio: redisStdio}));
 
     opts.env = {
       ...process.env,

--- a/tests/add-exclusion.test.js
+++ b/tests/add-exclusion.test.js
@@ -1,0 +1,47 @@
+import { exec } from "child_process";
+import Redis from "ioredis";
+
+test("dynamically add exclusion while crawl is running", async () => {
+  let callback = null;
+
+  const p = new Promise((resolve) => {
+    callback = (error, stdout, stderr) => {
+      resolve({error, stdout, stderr});
+    };
+  });
+
+  try {
+    exec("docker run -p 36379:6379 -e CRAWL_ID=test -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection add-exclusion --url https://webrecorder.net/ --scopeType prefix --limit 20 --logging debug --debugAccessRedis", {"shell": "/bin/bash"}, callback);
+  } catch (error) {
+    console.log(error);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  
+  const redis = new Redis("redis://127.0.0.1:36379/0", {lazyConnect: true});
+
+  await redis.connect({maxRetriesPerRequest: 50});
+
+  while (true) {
+    if (Number(await redis.zcard("test:q")) > 1) {
+      break;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  const uids = await redis.hkeys("test:status");
+
+  // exclude all pages containing 'webrecorder', should clear out the queue and end the crawl
+  await redis.rpush(`${uids[0]}:msg`, JSON.stringify({type: "addExclusion", regex: "webrecorder"}));
+
+  // ensure 'Add Exclusion is contained in the debug logs
+  const { stdout } = await p;
+
+  expect(stdout.indexOf("Add Exclusion") > 0).toBe(true);
+
+  expect(stdout.indexOf("Removing excluded URL") > 0).toBe(true);
+
+  await redis.disconnect();
+});
+  

--- a/tests/saved-state.test.js
+++ b/tests/saved-state.test.js
@@ -1,0 +1,126 @@
+import { exec } from "child_process";
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+import Redis from "ioredis";
+
+function waitForProcess() {
+  let callback = null;
+  const p = new Promise((resolve) => {
+    callback = (/*error, stdout, stderr*/) => {
+      //console.log(stdout);
+      resolve();
+    };
+  });
+
+  return {p, callback};
+}
+
+var savedStateFile;
+var state;
+var numDone;
+
+test("check crawl interrupted + saved state written", async () => {
+  let proc = null;
+
+  const wait = waitForProcess();
+
+  try {
+    proc = exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection int-state-test --url https://webrecorder.net/ --limit 20", wait.callback);
+  }
+  catch (error) {
+    console.log(error);
+  }
+
+  const pagesFile = "test-crawls/collections/int-state-test/pages/pages.jsonl";
+
+  // remove existing pagesFile to support reentrancy
+  try {
+    fs.unlinkSync(pagesFile);
+  } catch (e) {
+    // ignore
+  }
+
+  while (true) {
+    try {
+      const pages = fs.readFileSync(pagesFile, {encoding: "utf-8"}).trim().split("\n");
+
+      if (pages.length >= 2) {
+        break;
+      }
+    } catch(e) {
+      // ignore
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  proc.kill("SIGINT");
+
+  await wait.p;
+
+  const savedStates = fs.readdirSync("test-crawls/collections/int-state-test/crawls");
+  expect(savedStates.length > 0).toEqual(true);
+
+  savedStateFile = savedStates[savedStates.length - 1];
+});
+
+
+test("check parsing saved state + page done + queue present", () => {
+  const savedState = fs.readFileSync(path.join("test-crawls/collections/int-state-test/crawls", savedStateFile), "utf-8");
+  
+  const saved = yaml.load(savedState);
+
+  expect(!!saved.state).toBe(true);
+  state = saved.state;
+
+  numDone = state.done;
+
+  expect(state.done > 0).toEqual(true);
+  expect(state.queued.length > 0).toEqual(true);
+
+});
+
+
+test("check crawl restarted with saved state", async () => {
+  let proc = null;
+
+  const wait = waitForProcess();
+
+  try {
+    proc = exec(`docker run -p 36379:6379 -e CRAWL_ID=test -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection int-state-test --url https://webrecorder.net/ --config /crawls/collections/int-state-test/crawls/${savedStateFile} --debugAccessRedis`, wait.callback);
+  }
+  catch (error) {
+    console.log(error);
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  const redis = new Redis("redis://127.0.0.1:36379/0", {lazyConnect: true});
+
+  try {
+    for (let i = 0; i < 10; i++) {
+      try {
+        await redis.connect();
+        break;
+      } catch (e) {
+        console.log("awaiting redis");
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+
+    expect(await redis.get("test:d")).toBe(numDone + "");
+
+    await redis.disconnect();
+
+  } finally {
+
+    proc.kill("SIGINT");
+
+    await wait.p;
+
+    await redis.disconnect();
+  }
+
+});
+

--- a/tests/saved-state.test.js
+++ b/tests/saved-state.test.js
@@ -19,6 +19,7 @@ function waitForProcess() {
 var savedStateFile;
 var state;
 var numDone;
+var redis;
 
 test("check crawl interrupted + saved state written", async () => {
   let proc = null;
@@ -98,7 +99,7 @@ test("check crawl restarted with saved state", async () => {
 
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
-  const redis = new Redis("redis://127.0.0.1:36379/0", {lazyConnect: true});
+  redis = new Redis("redis://127.0.0.1:36379/0", {lazyConnect: true});
 
   try {
     for (let i = 0; i < 10; i++) {
@@ -113,15 +114,7 @@ test("check crawl restarted with saved state", async () => {
 
     expect(await redis.get("test:d")).toBe(numDone + "");
 
-    await redis.disconnect();
-
   } finally {
-
-    try {
-      await redis.disconnect();
-    } catch (e) {
-      // ignore
-    }
 
     proc.kill("SIGINT");
 
@@ -130,5 +123,11 @@ test("check crawl restarted with saved state", async () => {
     expect(res).toBe(0);
   }
 
+});
+
+afterAll(async () => {
+  if (redis) {
+    await redis.quit();
+  }
 });
 

--- a/util/argParser.js
+++ b/util/argParser.js
@@ -408,6 +408,11 @@ class ArgParser {
         describe: "injects a custom behavior file or set of behavior files in a directory",
         type: ["string"]
       },
+
+      "debugAccessRedis": {
+        describe: "if set, runs internal redis without protected mode to allow external access (for debugging)",
+        type: "boolean",
+      }
     };
   }
 

--- a/util/state.js
+++ b/util/state.js
@@ -427,15 +427,20 @@ return 0;
       seen.push(data.url);
     }
 
-    // retained in modified form for backwards compatibility
-    for (const json of state.done) {
-      const data = JSON.parse(json);
-      if (data.failed) {
-        await this.redis.zadd(this.qkey, this._getScore(data), json);
-      } else {
-        await this.redis.incr(this.dkey);
+    if (typeof(state.done) === "number") {
+      // done key is just an int counter
+      await this.redis.set(this.dkey, state.done);
+    } else if (state.done instanceof Array) {
+      // for backwards compatibility with old save states
+      for (const json of state.done) {
+        const data = JSON.parse(json);
+        if (data.failed) {
+          await this.redis.zadd(this.qkey, this._getScore(data), json);
+        } else {
+          await this.redis.incr(this.dkey);
+        }
+        seen.push(data.url);
       }
-      seen.push(data.url);
     }
 
     for (const json of state.failed) {


### PR DESCRIPTION
- set done key correctly, just an int now
- also check if array for old-style save states (for backwards compatibility)
- fixes #411
- tests: includes tests using redis: tests save state + dynamically adding exclusions (follow up to #408)
- adds `--debugAccessRedis` flag to allow accessing local redis outside container