### PR TITLE
Raise size limit for large HTML pages

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -25,7 +25,7 @@ import { RedisCrawlState, WorkerId } from "./state.js";
 import { CDPSession, Protocol } from "puppeteer-core";
 import { Crawler } from "../crawler.js";
 
-const MAX_BROWSER_DEFAULT_FETCH_SIZE = 2_500_000;
+const MAX_BROWSER_DEFAULT_FETCH_SIZE = 5_000_000;
 const MAX_BROWSER_TEXT_FETCH_SIZE = 25_000_000;
 
 const MAX_NETWORK_LOAD_SIZE = 200_000_000;

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -469,10 +469,9 @@ export class Recorder {
     const contentType = this._getContentType(responseHeaders);
 
     // set max fetch size higher for HTML responses for current page
-    const matchFetchSize =
-      this.allowLargeContent(contentType) && this.pageUrl === url
-        ? MAX_BROWSER_TEXT_FETCH_SIZE
-        : MAX_BROWSER_DEFAULT_FETCH_SIZE;
+    const matchFetchSize = this.allowLargeContent(contentType)
+      ? MAX_BROWSER_TEXT_FETCH_SIZE
+      : MAX_BROWSER_DEFAULT_FETCH_SIZE;
 
     if (contentLen < 0 || contentLen > matchFetchSize) {
       const opts = {

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -88,7 +88,7 @@ export class Recorder {
     workerid: WorkerId;
     collDir: string;
     // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     crawler: Crawler;
   }) {
     this.workerid = workerid;
@@ -469,10 +469,22 @@ export class Recorder {
     const contentType = this._getContentType(responseHeaders);
 
     // set max fetch size higher for HTML responses for current page
-    const matchFetchSize = this.allowLargeContent(contentType) && this.pageUrl === url ? MAX_BROWSER_TEXT_FETCH_SIZE : MAX_BROWSER_DEFAULT_FETCH_SIZE;
+    const matchFetchSize =
+      this.allowLargeContent(contentType) && this.pageUrl === url
+        ? MAX_BROWSER_TEXT_FETCH_SIZE
+        : MAX_BROWSER_DEFAULT_FETCH_SIZE;
 
     if (contentLen < 0 || contentLen > matchFetchSize) {
-      const opts = {tempdir: this.tempdir, reqresp, expectedSize: contentLen, recorder: this, networkId, cdp, requestId, matchFetchSize};
+      const opts = {
+        tempdir: this.tempdir,
+        reqresp,
+        expectedSize: contentLen,
+        recorder: this,
+        networkId,
+        cdp,
+        requestId,
+        matchFetchSize,
+      };
 
       // fetching using response stream, await here and then either call fulFill, or if not started, return false
       if (contentLen < 0) {
@@ -698,7 +710,10 @@ export class Recorder {
     return false;
   }
 
-  async rewriteResponse(reqresp: RequestResponseInfo, contentType: string | null) {
+  async rewriteResponse(
+    reqresp: RequestResponseInfo,
+    contentType: string | null,
+  ) {
     const { url, extraOpts, payload } = reqresp;
 
     if (!payload || !payload.length) {
@@ -709,25 +724,8 @@ export class Recorder {
     let string = null;
 
     switch (contentType) {
-    case "application/x-mpegURL":
-    case "application/vnd.apple.mpegurl":
-      string = payload.toString();
-      newString = rewriteHLS(string, {save: extraOpts});
-      break;
-
-    case "application/dash+xml":
-      string = payload.toString();
-      newString = rewriteDASH(string, {save: extraOpts});
-      break;
-
-    case "text/html":
-    case "application/json":
-    case "text/javascript":
-    case "application/javascript":
-    case "application/x-javascript": {
-      const rw = baseDSRules.getRewriter(url);
-
-      if (rw !== baseDSRules.defaultRewriter) {
+      case "application/x-mpegURL":
+      case "application/vnd.apple.mpegurl":
         string = payload.toString();
         newString = rewriteHLS(string, { save: extraOpts });
         break;
@@ -778,13 +776,15 @@ export class Recorder {
       "application/json",
       "text/javascript",
       "application/javascript",
-      "application/x-javascript"
+      "application/x-javascript",
     ];
 
     return allowLargeCTs.includes(contentType || "");
   }
 
-  _getContentType(headers? : Protocol.Fetch.HeaderEntry[] | {name: string, value: string}[]) {
+  _getContentType(
+    headers?: Protocol.Fetch.HeaderEntry[] | { name: string; value: string }[],
+  ) {
     if (!headers) {
       return null;
     }
@@ -946,10 +946,25 @@ class AsyncFetcher {
   tempdir: string;
   filename: string;
 
-  constructor({tempdir, reqresp, expectedSize = -1, recorder, networkId, filter = undefined, ignoreDupe = false,
-              maxFetchSize = MAX_BROWSER_DEFAULT_FETCH_SIZE} :
-              {tempdir: string, reqresp: RequestResponseInfo, expectedSize?: number, recorder: Recorder, 
-              networkId: string, filter?: (resp: Response) => boolean, ignoreDupe?: boolean, maxFetchSize?: number }) {
+  constructor({
+    tempdir,
+    reqresp,
+    expectedSize = -1,
+    recorder,
+    networkId,
+    filter = undefined,
+    ignoreDupe = false,
+    maxFetchSize = MAX_BROWSER_DEFAULT_FETCH_SIZE,
+  }: {
+    tempdir: string;
+    reqresp: RequestResponseInfo;
+    expectedSize?: number;
+    recorder: Recorder;
+    networkId: string;
+    filter?: (resp: Response) => boolean;
+    ignoreDupe?: boolean;
+    maxFetchSize?: number;
+  }) {
     this.reqresp = reqresp;
     this.reqresp.expectedSize = expectedSize;
     this.reqresp.asyncLoading = true;
@@ -961,7 +976,10 @@ class AsyncFetcher {
     this.recorder = recorder;
 
     this.tempdir = tempdir;
-    this.filename = path.join(this.tempdir, `${timestampNow()}-${uuidv4()}.data`);
+    this.filename = path.join(
+      this.tempdir,
+      `${timestampNow()}-${uuidv4()}.data`,
+    );
 
     this.maxFetchSize = maxFetchSize;
   }
@@ -992,7 +1010,10 @@ class AsyncFetcher {
       const responseRecord = createResponse(reqresp, pageid, body);
       const requestRecord = createRequest(reqresp, responseRecord, pageid);
 
-      const serializer = new WARCSerializer(responseRecord, {gzip, maxMemSize: this.maxFetchSize});
+      const serializer = new WARCSerializer(responseRecord, {
+        gzip,
+        maxMemSize: this.maxFetchSize,
+      });
 
       try {
         let readSize = await serializer.digestRecord();

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -63,28 +63,16 @@ export class RequestResponseInfo {
     this.requestId = requestId;
   }
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fillRequest(params: Record<string, any>) {
+  fillFetchRequestPaused(params: Protocol.Fetch.RequestPausedEvent) {
     this.url = params.request.url;
     this.method = params.request.method;
     if (!this.requestHeaders) {
       this.requestHeaders = params.request.headers;
     }
     this.postData = params.request.postData;
-    this.hasPostData = params.request.hasPostData;
+    this.hasPostData = params.request.hasPostData || false;
 
-    if (params.type) {
-      this.resourceType = params.type;
-    }
-  }
-
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fillFetchRequestPaused(params: Record<string, any>) {
-    this.fillRequest(params);
-
-    this.status = params.responseStatusCode;
+    this.status = params.responseStatusCode || 0;
     this.statusText = params.responseStatusText || getStatusText(this.status);
 
     this.responseHeadersList = params.responseHeaders;
@@ -153,7 +141,9 @@ export class RequestResponseInfo {
     }
   }
 
-  fillResponseReceivedExtraInfo(params: Record<string, string>) {
+  fillResponseReceivedExtraInfo(
+    params: Protocol.Network.ResponseReceivedExtraInfoEvent,
+  ) {
     // this.responseHeaders = params.headers;
     // if (params.headersText) {
     //   this.responseHeadersText = params.headersText;
@@ -161,17 +151,15 @@ export class RequestResponseInfo {
     this.extraOpts.ipType = params.resourceIPAddressSpace;
   }
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fillFetchResponse(response: Record<string, any>) {
+  fillFetchResponse(response: Response) {
     this.responseHeaders = Object.fromEntries(response.headers);
     this.status = response.status;
     this.statusText = response.statusText || getStatusText(this.status);
   }
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fillRequestExtraInfo(params: Record<string, any>) {
+  fillRequestExtraInfo(
+    params: Protocol.Network.RequestWillBeSentExtraInfoEvent,
+  ) {
     this.requestHeaders = params.headers;
   }
 


### PR DESCRIPTION
Currently, the recorder will stream response >2MB to disk and not return a response to browser. This generally works, however, if an HTML page is very large, will result in no HTML being loaded.

This PR raises the limit, and also adds a separate limit for HTML pages (html content that is also the current page).

Also includes some more type fixing.