### PR TITLE
logging: don't log filtered out direct fetch attempt as error

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -703,7 +703,12 @@ self.__bx_behaviors.selectMainBehavior();
           return true;
         }
       } catch (e) {
-        // ignore failed direct fetch attempt, do browser-based capture
+        // filtered out direct fetch
+        logger.debug(
+          "Direct fetch response not accepted, continuing with browser fetch",
+          logDetails,
+          "fetch",
+        );
       }
     }
 


### PR DESCRIPTION
When calling directFetchCapture, and aborting the response via an exception, throw `new Error("response-filtered-out");`
so that it can be ignored. This exception is only used for direct capture, and should not be logged as an error -- will continue loading in the browser