### PR TITLE
Fix potential for pending list never being processed

### DIFF
--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -117,7 +117,6 @@ declare module "ioredis" {
 export class RedisCrawlState {
   redis: Redis;
   maxRetryPending = 1;
-  _lastSize = 0;
 
   uid: string;
   key: string;
@@ -621,7 +620,7 @@ return 0;
     const res = await this.redis.hlen(this.pkey);
 
     // reset pendings
-    if (res > 0 && !this._lastSize) {
+    if (res > 0 && !(await this.queueSize())) {
       await this.resetPendings();
     }
 
@@ -679,8 +678,7 @@ return 0;
   }
 
   async queueSize() {
-    this._lastSize = await this.redis.zcard(this.qkey);
-    return this._lastSize;
+    return await this.redis.zcard(this.qkey);
   }
 
   async addIfNoDupe(key: string, value: string) {


### PR DESCRIPTION
Due to an optimization, numPending() call assumed that queueSize() would be called to update cached queue size. However, in the current worker code, this is not the case. Remove cacheing queue size and just check queue size in numPending(), to ensure pending list is always processed.

Perhaps want to port this to a 0.12.2 release, as this addresses an edge case after exclusions where pending URLs remain but are not reprocessed.