### PR TITLE
Add types + validation for log context options

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -31,7 +31,7 @@ import { ScreenCaster, WSTransport } from "./util/screencaster.js";
 import { Screenshots } from "./util/screenshots.js";
 import { parseArgs } from "./util/argParser.js";
 import { initRedis } from "./util/redis.js";
-import { logger, errJSON } from "./util/logger.js";
+import { logger, formatErr } from "./util/logger.js";
 import { WorkerOpts, WorkerState, runWorkers } from "./util/worker.js";
 import { sleep, timedRun, secondsElapsed } from "./util/timing.js";
 import { collectAllFileSources } from "./util/file_reader.js";
@@ -591,7 +591,7 @@ export class Crawler {
       page.on("pageerror", (e) => {
         logger.warn(
           "Page Error",
-          { ...errJSON(e), page: page.url(), workerid },
+          { ...formatErr(e), page: page.url(), workerid },
           "jsError",
         );
       });
@@ -899,7 +899,7 @@ self.__bx_behaviors.selectMainBehavior();
     } catch (e) {
       logger.warn(
         "Behavior run failed",
-        { ...errJSON(e), ...logDetails },
+        { ...formatErr(e), ...logDetails },
         "behavior",
       );
       return false;
@@ -1958,7 +1958,7 @@ self.__bx_behaviors.selectMainBehavior();
       return this.isHTMLContentType(resp.headers.get("Content-Type"));
     } catch (e) {
       // can't confirm not html, so try in browser
-      logger.debug("HEAD request failed", { ...errJSON(e), ...logDetails });
+      logger.debug("HEAD request failed", { ...formatErr(e), ...logDetails });
       return true;
     }
   }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -192,7 +192,7 @@ export class Crawler {
       logger.setDefaultFatalExitCode(0);
     }
 
-    logger.debug("Writing log to: " + this.logFilename, {}, "init");
+    logger.debug("Writing log to: " + this.logFilename, {}, "general");
 
     this.headers = {};
 
@@ -407,8 +407,7 @@ export class Crawler {
       logger.debug(`Clearing ${this.collDir} before starting`);
       try {
         fs.rmSync(this.collDir, { recursive: true, force: true });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (e: any) {
+      } catch (e) {
         logger.error(`Unable to clear ${this.collDir}`, e);
       }
     }
@@ -477,8 +476,7 @@ export class Crawler {
           exitCode = 11;
         }
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
+    } catch (e) {
       logger.error("Crawl failed", e);
       exitCode = 9;
       status = "failing";
@@ -1099,8 +1097,7 @@ self.__bx_behaviors.selectMainBehavior();
     try {
       const driverUrl = new URL(this.params.driver, import.meta.url);
       this.driver = (await import(driverUrl.href)).default;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
+    } catch (e) {
       logger.warn(`Error importing driver ${this.params.driver}`, e);
       return;
     }
@@ -1287,8 +1284,7 @@ self.__bx_behaviors.selectMainBehavior();
         );
         try {
           fs.rmSync(this.collDir, { recursive: true, force: true });
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (e: any) {
+        } catch (e) {
           logger.warn(`Unable to clear ${this.collDir} before exit`, e);
         }
       }
@@ -1460,7 +1456,7 @@ self.__bx_behaviors.selectMainBehavior();
         maxHeapTotal: this.maxHeapTotal,
         ...memUsage,
       },
-      "memory",
+      "memoryStatus",
     );
   }
 
@@ -1493,8 +1489,7 @@ self.__bx_behaviors.selectMainBehavior();
           this.params.statsFilename,
           JSON.stringify(stats, null, 2),
         );
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (err: any) {
+      } catch (err) {
         logger.warn("Stats output failed", err);
       }
     }
@@ -1563,8 +1558,10 @@ self.__bx_behaviors.selectMainBehavior();
       const contentType = resp.headers()["content-type"];
 
       isHTMLPage = this.isHTMLContentType(contentType);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
+    } catch (e) {
+      if (!(e instanceof Error)) {
+        throw e;
+      }
       const msg = e.message || "";
       if (!msg.startsWith("net::ERR_ABORTED") || !ignoreAbort) {
         // if timeout error, and at least got to content loaded, continue on
@@ -1750,9 +1747,8 @@ self.__bx_behaviors.selectMainBehavior();
           }
         }
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      logger.warn("Link Extraction failed", e);
+    } catch (e) {
+      logger.warn("Link Extraction failed", e, "links");
     }
 
     if (links.length) {
@@ -1799,9 +1795,8 @@ self.__bx_behaviors.selectMainBehavior();
           );
         }
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      logger.error("Queuing Error", e);
+    } catch (e) {
+      logger.error("Queuing Error", e, "links");
     }
   }
 
@@ -1899,8 +1894,7 @@ self.__bx_behaviors.selectMainBehavior();
         const header_formatted = JSON.stringify(header).concat("\n");
         await this.pagesFH.writeFile(header_formatted);
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err) {
       logger.error("pages/pages.jsonl creation failed", err);
     }
   }
@@ -1936,8 +1930,7 @@ self.__bx_behaviors.selectMainBehavior();
     const processedRow = JSON.stringify(row) + "\n";
     try {
       await this.pagesFH!.writeFile(processedRow);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err) {
       logger.warn("pages/pages.jsonl append failed", err);
     }
   }
@@ -2016,8 +2009,7 @@ self.__bx_behaviors.selectMainBehavior();
       const { sites } = await sitemapper.fetch();
       logger.info("Sitemap Urls Found", { urls: sites.length }, "sitemap");
       await this.queueInScopeUrls(seedId, sites, 0);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
+    } catch (e) {
       logger.warn("Error fetching sites from sitemap", e, "sitemap");
     }
   }
@@ -2169,8 +2161,7 @@ self.__bx_behaviors.selectMainBehavior();
     try {
       logger.info(`Saving crawl state to: ${filename}`);
       await fsp.writeFile(filename, res);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
+    } catch (e) {
       logger.error(`Failed to write save state file: ${filename}`, e);
       return;
     }

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -15,7 +15,7 @@ import {
 import { ScopedSeed } from "./seeds.js";
 import { interpolateFilename } from "./storage.js";
 import { screenshotTypes } from "./screenshots.js";
-import { logger } from "./logger.js";
+import { LOG_CONTEXT_TYPES, logger } from "./logger.js";
 
 // ============================================================================
 class ArgParser {
@@ -217,9 +217,11 @@ class ArgParser {
       },
 
       context: {
+        alias: "logContext",
         describe: "Comma-separated list of contexts to include in logs",
         type: "array",
         default: [],
+        choices: LOG_CONTEXT_TYPES,
         coerce,
       },
 

--- a/src/util/blockrules.ts
+++ b/src/util/blockrules.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 
-import { logger, errJSON } from "./logger.js";
+import { logger, formatErr } from "./logger.js";
 import { HTTPRequest, Page } from "puppeteer-core";
 import { Browser } from "./browser.js";
 
@@ -97,7 +97,7 @@ export class BlockRules {
       } catch (e) {
         logger.warn(
           "Error handling request",
-          { ...errJSON(e), ...logDetails },
+          { ...formatErr(e), ...logDetails },
           "blocking",
         );
       }
@@ -122,7 +122,7 @@ export class BlockRules {
     } catch (e) {
       logger.debug(
         `Block: (${blockState}) Failed On: ${url}`,
-        { ...errJSON(e), ...logDetails },
+        { ...formatErr(e), ...logDetails },
         "blocking",
       );
     }
@@ -276,7 +276,7 @@ export class BlockRules {
     } catch (e) {
       logger.debug(
         "Error determining text match",
-        { ...errJSON(e), ...logDetails },
+        { ...formatErr(e), ...logDetails },
         "blocking",
       );
     }

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -6,7 +6,7 @@ import { Readable } from "node:stream";
 import os from "os";
 import path from "path";
 
-import { logger } from "./logger.js";
+import { LogContext, logger } from "./logger.js";
 import { initStorage } from "./storage.js";
 
 import puppeteer, {
@@ -123,7 +123,7 @@ export class Browser {
       logger.info(
         `Downloading ${profileFilename} to ${targetFilename}`,
         {},
-        "browserProfile",
+        "browser",
       );
 
       const resp = await fetch(profileFilename);
@@ -237,7 +237,7 @@ export class Browser {
     cdpContextId: number,
     funcString: string,
     logData: Record<string, string>,
-    contextName: string,
+    contextName: LogContext,
   ) {
     const frameUrl = frame.url();
     // TODO: Fix this the next time the file is edited.
@@ -468,7 +468,7 @@ export class Browser {
     funcString: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     logData: Record<string, any>,
-    contextName: string,
+    contextName: LogContext,
   ) {
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -11,7 +11,7 @@ Object.defineProperty(RegExp.prototype, "toJSON", {
 
 // ===========================================================================
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function errJSON(e: unknown): Record<string, any> {
+export function formatErr(e: unknown): Record<string, any> {
   if (e instanceof Error) {
     return { type: "exception", message: e.message, stack: e.stack || "" };
   } else if (typeof e === "object") {
@@ -34,7 +34,7 @@ export const LOG_CONTEXT_TYPES = [
   "exclusion",
   "screenshots",
   "screencast",
-  "originoverride",
+  "originOverride",
   "healthcheck",
   "browser",
   "blocking",
@@ -96,7 +96,7 @@ class Logger {
     logLevel = "info",
   ) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: Record<string, any> = errJSON(dataUnknown);
+    const data: Record<string, any> = formatErr(dataUnknown);
 
     if (this.logLevels.length) {
       if (this.logLevels.indexOf(logLevel) < 0) {

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -10,15 +10,46 @@ Object.defineProperty(RegExp.prototype, "toJSON", {
 });
 
 // ===========================================================================
-// TODO: Fix this the next time the file is edited.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function errJSON(e: any) {
+export function errJSON(e: unknown): Record<string, any> {
   if (e instanceof Error) {
-    return { type: "exception", message: e.message, stack: e.stack };
+    return { type: "exception", message: e.message, stack: e.stack || "" };
+  } else if (typeof e === "object") {
+    return e || {};
   } else {
-    return { message: e.toString() };
+    return { message: (e as object).toString() };
   }
 }
+
+// ===========================================================================
+export const LOG_CONTEXT_TYPES = [
+  "general",
+  "worker",
+  "recorder",
+  "writer",
+  "state",
+  "redis",
+  "storage",
+  "text",
+  "exclusion",
+  "screenshots",
+  "screencast",
+  "originoverride",
+  "healthcheck",
+  "browser",
+  "blocking",
+  "behavior",
+  "behaviorScript",
+  "jsError",
+  "fetch",
+  "pageStatus",
+  "memoryStatus",
+  "crawlStatus",
+  "links",
+  "sitemap",
+] as const;
+
+export type LogContext = (typeof LOG_CONTEXT_TYPES)[number];
 
 // ===========================================================================
 class Logger {
@@ -58,20 +89,14 @@ class Logger {
     this.crawlState = crawlState;
   }
 
-  // TODO: Fix this the next time the file is edited.
-
   logAsJSON(
     message: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data: Record<string, string> | Error | any,
+    dataUnknown: unknown,
     context: string,
     logLevel = "info",
   ) {
-    if (data instanceof Error) {
-      data = errJSON(data);
-    } else if (typeof data !== "object") {
-      data = { message: data.toString() };
-    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: Record<string, any> = errJSON(dataUnknown);
 
     if (this.logLevels.length) {
       if (this.logLevels.indexOf(logLevel) < 0) {
@@ -90,7 +115,7 @@ class Logger {
       logLevel: logLevel,
       context: context,
       message: message,
-      details: data ? data : {},
+      details: data,
     };
     const string = JSON.stringify(dataToLog);
     console.log(string);
@@ -108,25 +133,30 @@ class Logger {
     }
   }
 
-  info(message: string, data = {}, context = "general") {
+  info(message: string, data: unknown = {}, context: LogContext = "general") {
     this.logAsJSON(message, data, context);
   }
 
-  error(message: string, data = {}, context = "general") {
+  error(message: string, data: unknown = {}, context: LogContext = "general") {
     this.logAsJSON(message, data, context, "error");
   }
 
-  warn(message: string, data = {}, context = "general") {
+  warn(message: string, data: unknown = {}, context: LogContext = "general") {
     this.logAsJSON(message, data, context, "warn");
   }
 
-  debug(message: string, data = {}, context = "general") {
+  debug(message: string, data: unknown = {}, context: LogContext = "general") {
     if (this.debugLogging) {
       this.logAsJSON(message, data, context, "debug");
     }
   }
 
-  fatal(message: string, data = {}, context = "general", exitCode = 0) {
+  fatal(
+    message: string,
+    data = {},
+    context: LogContext = "general",
+    exitCode = 0,
+  ) {
     exitCode = exitCode || this.fatalExitCode;
     this.logAsJSON(`${message}. Quitting`, data, context, "fatal");
 

--- a/src/util/originoverride.ts
+++ b/src/util/originoverride.ts
@@ -1,5 +1,5 @@
 import { HTTPRequest, Page } from "puppeteer-core";
-import { errJSON, logger } from "./logger.js";
+import { formatErr, logger } from "./logger.js";
 import { Browser } from "./browser.js";
 
 export class OriginOverride {
@@ -52,15 +52,15 @@ export class OriginOverride {
         logger.debug(
           "Origin overridden",
           { orig: url, dest: newUrl, status, body: body.length },
-          "originoverride",
+          "originOverride",
         );
 
         request.respond({ body, headers: respHeaders, status }, -1);
       } catch (e) {
         logger.warn(
           "Error overriding origin",
-          { ...errJSON(e), url: page.url() },
-          "originoverride",
+          { ...formatErr(e), url: page.url() },
+          "originOverride",
         );
         request.continue({}, -1);
       }

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import PQueue from "p-queue";
 
-import { logger, errJSON } from "./logger.js";
+import { logger, formatErr } from "./logger.js";
 import { sleep, timestampNow } from "./timing.js";
 import { RequestResponseInfo } from "./reqresp.js";
 
@@ -376,7 +376,7 @@ export class Recorder {
     } catch (e) {
       logger.error(
         "Error handling response, probably skipping URL",
-        { url, ...errJSON(e), ...this.logDetails },
+        { url, ...formatErr(e), ...this.logDetails },
         "recorder",
       );
     }
@@ -387,7 +387,7 @@ export class Recorder {
       } catch (e) {
         logger.debug(
           "continueResponse failed",
-          { requestId, networkId, url, ...errJSON(e), ...this.logDetails },
+          { requestId, networkId, url, ...formatErr(e), ...this.logDetails },
           "recorder",
         );
       }
@@ -526,7 +526,7 @@ export class Recorder {
       } catch (e) {
         logger.warn(
           "Failed to load response body",
-          { url, networkId, ...errJSON(e), ...this.logDetails },
+          { url, networkId, ...formatErr(e), ...this.logDetails },
           "recorder",
         );
         return false;
@@ -995,7 +995,7 @@ class AsyncFetcher {
       } catch (e) {
         logger.error(
           "Error reading + digesting payload",
-          { url, filename, ...errJSON(e), ...logDetails },
+          { url, filename, ...formatErr(e), ...logDetails },
           "recorder",
         );
       }
@@ -1059,7 +1059,7 @@ class AsyncFetcher {
     } catch (e) {
       logger.error(
         "Streaming Fetch Error",
-        { url, networkId, filename, ...errJSON(e), ...logDetails },
+        { url, networkId, filename, ...formatErr(e), ...logDetails },
         "recorder",
       );
       await crawlState.removeDupe(ASYNC_FETCH_DUPE_KEY, url!);
@@ -1132,7 +1132,7 @@ class AsyncFetcher {
     } catch (e) {
       logger.warn(
         "takeReader interrupted",
-        { ...errJSON(e), url: this.reqresp.url, ...this.recorder.logDetails },
+        { ...formatErr(e), url: this.reqresp.url, ...this.recorder.logDetails },
         "recorder",
       );
       this.reqresp.truncated = "disconnect";
@@ -1156,7 +1156,7 @@ class AsyncFetcher {
     } catch (e) {
       logger.warn(
         "takeStream interrupted",
-        { ...errJSON(e), url: this.reqresp.url, ...this.recorder.logDetails },
+        { ...formatErr(e), url: this.reqresp.url, ...this.recorder.logDetails },
         "recorder",
       );
       this.reqresp.truncated = "disconnect";
@@ -1219,7 +1219,7 @@ class NetworkLoadStreamAsyncFetcher extends AsyncFetcher {
     } catch (e) {
       logger.debug(
         "Network.loadNetworkResource failed, attempting node fetch",
-        { url, ...errJSON(e), ...this.recorder.logDetails },
+        { url, ...formatErr(e), ...this.recorder.logDetails },
         "recorder",
       );
       return await super._doFetch();

--- a/src/util/screenshots.ts
+++ b/src/util/screenshots.ts
@@ -1,7 +1,7 @@
 import sharp from "sharp";
 
 import { WARCResourceWriter } from "./warcresourcewriter.js";
-import { logger, errJSON } from "./logger.js";
+import { logger, formatErr } from "./logger.js";
 import { Browser } from "./browser.js";
 
 // ============================================================================
@@ -65,7 +65,7 @@ export class Screenshots extends WARCResourceWriter {
     } catch (e) {
       logger.error(
         "Taking screenshot failed",
-        { page: this.url, type: screenshotType, ...errJSON(e) },
+        { page: this.url, type: screenshotType, ...formatErr(e) },
         "screenshots",
       );
     }
@@ -96,7 +96,7 @@ export class Screenshots extends WARCResourceWriter {
     } catch (e) {
       logger.error(
         "Taking screenshot failed",
-        { page: this.url, type: screenshotType, ...errJSON(e) },
+        { page: this.url, type: screenshotType, ...formatErr(e) },
         "screenshots",
       );
     }

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -371,10 +371,8 @@ return 0;
             }
             break;
         }
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (e: any) {
-        logger.warn("Error processing message", e, "redisMessage");
+      } catch (e) {
+        logger.warn("Error processing message", e, "redis");
       }
     }
   }
@@ -473,7 +471,7 @@ return 0;
     try {
       data = JSON.parse(json);
     } catch (e) {
-      logger.error("Invalid queued json", json);
+      logger.error("Invalid queued json", json, "redis");
       return null;
     }
 
@@ -648,9 +646,7 @@ return 0;
       for (const url of pendingUrls) {
         await this.redis.unlockpending(this.pkey + ":" + url, this.uid);
       }
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
+    } catch (e) {
       logger.error("Redis Del Pending Failed", e, "state");
     }
   }
@@ -668,11 +664,11 @@ return 0;
       );
       switch (res) {
         case 1:
-          logger.info(`Requeued: ${url}`);
+          logger.info(`Requeued: ${url}`, {}, "state");
           break;
 
         case 2:
-          logger.info(`Not requeuing anymore: ${url}`);
+          logger.info(`Not requeuing anymore: ${url}`, {}, "state");
           break;
       }
     }

--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -85,7 +85,7 @@ export class S3StorageSync {
       prefix: this.objectPrefix,
       targetFilename,
     };
-    logger.info("S3 file upload information", fileUploadInfo, "s3Upload");
+    logger.info("S3 file upload information", fileUploadInfo, "storage");
 
     await this.client.fPutObject(
       this.bucketName,
@@ -119,7 +119,7 @@ export class S3StorageSync {
     logger.info(
       "WACZ S3 file upload resource",
       { targetFilename, resource },
-      "s3Upload",
+      "storage",
     );
 
     if (this.webhookUrl) {
@@ -149,6 +149,8 @@ export class S3StorageSync {
         if (parts.length !== 5) {
           logger.fatal(
             "redis webhook url must be in format: redis://<host>:<port>/<db>/<key>",
+            {},
+            "redis",
           );
         }
         const redis = await initRedis(parts.slice(0, 4).join("/"));
@@ -189,7 +191,7 @@ export async function getFileSize(filename: string) {
 export async function getDirSize(dir: string) {
   const { size, errors } = await getFolderSize(dir);
   if (errors && errors.length) {
-    logger.warn("Size check errors", { errors }, "sizecheck");
+    logger.warn("Size check errors", { errors }, "storage");
   }
   return size;
 }

--- a/src/util/textextract.ts
+++ b/src/util/textextract.ts
@@ -45,9 +45,7 @@ export abstract class BaseTextExtract extends WARCResourceWriter {
 
       this.lastText = text;
       return { changed: true, text };
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
+    } catch (e) {
       logger.debug("Error extracting text", e, "text");
       return { changed: false, text: null };
     }

--- a/src/util/timing.ts
+++ b/src/util/timing.ts
@@ -1,4 +1,4 @@
-import { logger } from "./logger.js";
+import { LogContext, logger } from "./logger.js";
 
 export function sleep(seconds: number) {
   return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
@@ -12,7 +12,7 @@ export function timedRun(
   seconds: number,
   message = "Promise timed out",
   logDetails = {},
-  context = "general",
+  context: LogContext = "general",
   isWarn = false,
 ) {
   // return Promise return value or log error if timeout is reached first

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 import { CDXIndexer } from "warcio";
 import { WARCSerializer } from "warcio/node";
-import { logger, errJSON } from "./logger.js";
+import { logger, formatErr } from "./logger.js";
 import type { IndexerOffsetLength, WARCRecord } from "warcio";
 
 // =================================================================
@@ -107,7 +107,7 @@ export class WARCWriter implements IndexerOffsetLength {
       } catch (e) {
         logger.error(
           "Error writing to WARC, corruption possible",
-          { ...errJSON(e), url, ...this.logDetails },
+          { ...formatErr(e), url, ...this.logDetails },
           "writer",
         );
       }

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -2,7 +2,7 @@ import os from "os";
 
 import { v4 as uuidv4 } from "uuid";
 
-import { logger, errJSON } from "./logger.js";
+import { logger, formatErr } from "./logger.js";
 import { sleep, timedRun } from "./timing.js";
 import { Recorder } from "./recorder.js";
 import { rxEscape } from "./seeds.js";
@@ -247,7 +247,7 @@ export class PageWorker {
           if (this.page === page) {
             logger.error(
               "Page Crashed",
-              { ...errJSON(err), ...this.logDetails },
+              { ...formatErr(err), ...this.logDetails },
               "worker",
             );
             this.crashed = true;
@@ -263,7 +263,7 @@ export class PageWorker {
       } catch (err) {
         logger.warn(
           "Error getting new page",
-          { workerid: this.id, ...errJSON(err) },
+          { workerid: this.id, ...formatErr(err) },
           "worker",
         );
         retry++;
@@ -332,7 +332,7 @@ export class PageWorker {
       if (e instanceof Error && e.message !== "logged" && !this.crashed) {
         logger.error(
           "Worker Exception",
-          { ...errJSON(e), ...this.logDetails },
+          { ...formatErr(e), ...this.logDetails },
           "worker",
         );
       }
@@ -360,7 +360,7 @@ export class PageWorker {
     } catch (e) {
       logger.error(
         "Worker error, exiting",
-        { ...errJSON(e), workerid: this.id },
+        { ...formatErr(e), workerid: this.id },
         "worker",
       );
     } finally {


### PR DESCRIPTION
- add LogContext type and enumerate all log contexts
- also add LOG_CONTEXT_TYPES array to validate --context arg
- make errJSON() convert unknown to proper type
- make logger info/error/debug accept unknown as well, to avoid explicit 'any' typing in all catch handlers