### PR TITLE
WARC filename prefix + rollover size + improved 'livestream' / truncated response support.

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1225,8 +1225,6 @@ self.__bx_behaviors.selectMainBehavior();
 
     await this.serializeConfig(true);
 
-    await this.browser.close();
-
     if (this.pagesFH) {
       await this.pagesFH.sync();
       await this.pagesFH.close();

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -489,6 +489,13 @@ class ArgParser {
           "if set, runs internal redis without protected mode to allow external access (for debugging)",
         type: "boolean",
       },
+
+      warcPrefix: {
+        describe:
+          "prefix for WARC files generated, including WARCs added to WACZ",
+        type: "string",
+        default: "rec",
+      },
     };
   }
 

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -102,7 +102,7 @@ export class Recorder {
     this.collDir = collDir;
 
     this.archivesDir = path.join(this.collDir, "archive");
-    this.tempdir = path.join(this.collDir, "tmp-dl");
+    this.tempdir = path.join(os.tmpdir(), "tmp-dl");
     this.tempCdxDir = path.join(this.collDir, "tmp-cdx");
 
     fs.mkdirSync(this.tempdir, { recursive: true });

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -89,8 +89,6 @@ export class Recorder {
   }: {
     workerid: WorkerId;
     collDir: string;
-    // TODO: Fix this the next time the file is edited.
-
     crawler: Crawler;
   }) {
     this.workerid = workerid;
@@ -111,13 +109,17 @@ export class Recorder {
     fs.mkdirSync(this.archivesDir, { recursive: true });
     fs.mkdirSync(this.tempCdxDir, { recursive: true });
 
+    const prefix = crawler.params.warcPrefix || "rec";
     const crawlId = process.env.CRAWL_ID || os.hostname();
-    const filename = `rec-${crawlId}-${timestampNow()}-${this.workerid}.warc`;
+    const filenameTemplate = `${prefix}-${crawlId}-$ts-${this.workerid}.warc${
+      this.gzip ? ".gz" : ""
+    }`;
 
     this.writer = new WARCWriter({
       archivesDir: this.archivesDir,
       tempCdxDir: this.tempCdxDir,
-      filename,
+      filenameTemplate,
+      rolloverSize: crawler.params.rolloverSize,
       gzip: this.gzip,
       logDetails: this.logDetails,
     });

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -17,6 +17,7 @@ export class WARCWriter implements IndexerOffsetLength {
 
   offset = 0;
   recordLength = 0;
+  done = false;
 
   indexer?: CDXIndexer;
 
@@ -50,7 +51,7 @@ export class WARCWriter implements IndexerOffsetLength {
     }
   }
 
-  async initFH() {
+  private async initFH() {
     if (!this.fh) {
       this.fh = fs.createWriteStream(
         path.join(this.archivesDir, this.filename),
@@ -68,6 +69,15 @@ export class WARCWriter implements IndexerOffsetLength {
     requestRecord: WARCRecord,
     responseSerializer: WARCSerializer | undefined = undefined,
   ) {
+    if (this.done) {
+      logger.warn(
+        "Writer closed, not writing records",
+        this.logDetails,
+        "writer",
+      );
+      return;
+    }
+
     const opts = { gzip: this.gzip };
 
     if (!responseSerializer) {
@@ -140,6 +150,8 @@ export class WARCWriter implements IndexerOffsetLength {
       await streamFinish(this.cdxFH);
       this.cdxFH = null;
     }
+
+    this.done = true;
   }
 }
 

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -70,8 +70,12 @@ export class WARCWriter implements IndexerOffsetLength {
   private async initFH() {
     if (this.offset >= this.rolloverSize) {
       logger.info(
-        `Rollover size exceeded ${this.offset} >= ${this.rolloverSize}, create new WARC`,
-        this.logDetails,
+        `Rollover size exceeded, creating new WARC`,
+        {
+          rolloverSize: this.rolloverSize,
+          size: this.offset,
+          ...this.logDetails,
+        },
         "writer",
       );
       this.filename = this._initNewFile();

--- a/tests/basic_crawl.test.js
+++ b/tests/basic_crawl.test.js
@@ -5,7 +5,7 @@ import md5 from "md5";
 
 test("ensure basic crawl run with docker run passes", async () => {
   child_process.execSync(
-    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://www.example.com/ --generateWACZ  --text --collection wr-net --combineWARC --rolloverSize 10000 --workers 2 --title "test title" --description "test description"',
+    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://example.com/ --generateWACZ  --text --collection wr-net --combineWARC --rolloverSize 10000 --workers 2 --title "test title" --description "test description" --warcPrefix custom-prefix',
   );
 
   child_process.execSync(
@@ -15,6 +15,20 @@ test("ensure basic crawl run with docker run passes", async () => {
   child_process.execSync(
     "unzip test-crawls/collections/wr-net/wr-net.wacz -d test-crawls/collections/wr-net/wacz",
   );
+});
+
+test("check that individual WARCs have correct prefix and are under rollover size", () => {
+  const archiveWarcLists = fs.readdirSync(
+    "test-crawls/collections/wr-net/archive",
+  );
+
+  archiveWarcLists.forEach((filename) => {
+    expect(filename.startsWith("custom-prefix-")).toEqual(true);
+    const size = fs.statSync(
+      path.join("test-crawls/collections/wr-net/archive", filename),
+    ).size;
+    expect(size < 10000).toEqual(true);
+  });
 });
 
 test("check that a combined warc file exists in the archive folder", () => {


### PR DESCRIPTION
Support for rollover size and custom WARC prefix templates:
- reenable --rolloverSize (default to 1GB) for when a new WARC is created
- support custom WARC prefix via --warcPrefix, prepended to new WARC filename
- filename template for new files is: `${prefix}-${crawlId}-$ts-${this.workerid}.warc${his.gzip ? ".gz" : ""}` with `$ts` replaced at new file creation time with current timestamp

Improved support for long (non-terminating) responses, such as from live-streaming:
  - add a size to CDP takeStream to ensure data is streamed in fixed chunks, defaulting to 64k
  - change shutdown order: first close browser, then finish writing all WARCs to ensure any truncated responses can be captured.
  - ensure WARC is not rewritten after it is done, skip writing records if stream already flushed
  - add timeout to final fetch tasks to avoid never hanging on finish
  - fix adding `WARC-Truncated` header, need to set after stream is finished to determine if its been truncated
  - move temp download `tmp-dl` dir to main temp folder, outside of collection (no need to be there).
