### PR TITLE
add timeout to final awaitPendingClear()

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -898,8 +898,14 @@ self.__bx_behaviors.selectMainBehavior();
 
     await this.writeStats();
 
-    // extra wait for all resources to land into WARCs
-    await this.awaitPendingClear();
+    // extra wait with timeout for all resources to land into WARCs
+    await timedRun(
+      this.awaitPendingClear(),
+      this.maxPageTime * this.params.workers,
+      "Waiting for pending resources timed out",
+      {timeout: this.maxPageTime * this.params.workers},
+      "general"
+    );
 
     // if crawl has been stopped, mark as final exit for post-crawl tasks
     if (await this.crawlState.isCrawlStopped()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",


### PR DESCRIPTION
Ensure the final pending wait also have a timeout. Set it to max page timeout x num workers.
Could also set higher, but needs to have a timeout, eg. in case of downloading live stream that never terminates.
Fixes #348 in the 0.12.x line.

bump to 0.12.3