### PR TITLE
detect invalid custom behaviors on load:

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -305,6 +305,19 @@ export class Browser {
     return page.evaluateOnNewDocument(script);
   }
 
+  async checkScript(cdp: CDPSession, filename: string, script: string) {
+    const { exceptionDetails } = await cdp.send("Runtime.evaluate", {
+      expression: script,
+    });
+    if (exceptionDetails) {
+      logger.fatal(
+        "Custom behavior load error, aborting",
+        { filename, ...exceptionDetails },
+        "behavior",
+      );
+    }
+  }
+
   async _init(
     launchOpts: PuppeteerLaunchOptions,
     // eslint-disable-next-line @typescript-eslint/ban-types

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -7,7 +7,7 @@ export function collectAllFileSources(
   fileOrDir: string,
   ext?: string,
   depth = 0,
-): string[] {
+): { path: string; contents: string }[] {
   const resolvedPath = path.resolve(fileOrDir);
 
   if (depth >= MAX_DEPTH) {
@@ -21,15 +21,23 @@ export function collectAllFileSources(
 
   if (stat.isFile() && (ext === null || path.extname(resolvedPath) === ext)) {
     const contents = fs.readFileSync(resolvedPath);
-    return [`/* src: ${resolvedPath} */\n\n${contents}`];
+    return [
+      {
+        path: resolvedPath,
+        contents: `/* src: ${resolvedPath} */\n\n${contents}`,
+      },
+    ];
   }
 
   if (stat.isDirectory()) {
     const files = fs.readdirSync(resolvedPath);
-    return files.reduce((acc: string[], next: string) => {
-      const nextPath = path.join(fileOrDir, next);
-      return [...acc, ...collectAllFileSources(nextPath, ext, depth + 1)];
-    }, []);
+    return files.reduce(
+      (acc: { path: string; contents: string }[], next: string) => {
+        const nextPath = path.join(fileOrDir, next);
+        return [...acc, ...collectAllFileSources(nextPath, ext, depth + 1)];
+      },
+      [],
+    );
   }
 
   if (depth === 0) {

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -34,3 +34,18 @@ test("test custom behaviors", async () => {
     ) > 0,
   ).toBe(true);
 });
+
+test("test invalid behavior exit", async () => {
+  let status = 0;
+
+  try {
+    child_process.execSync(
+      "docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/invalid-behaviors/:/custom-behaviors/ webrecorder/browsertrix-crawler crawl --url https://example.com/ --url https://example.org/ --url https://webrecorder.net/ --customBehaviors /custom-behaviors/invalid-export.js --scopeType page",
+    );
+  } catch (e) {
+    status = e.status;
+  }
+
+  // logger fatal exit code
+  expect(status).toBe(17);
+});

--- a/tests/invalid-behaviors/invalid-export.js
+++ b/tests/invalid-behaviors/invalid-export.js
@@ -1,0 +1,20 @@
+export class TestBehavior {
+  static init() {
+    return {
+      state: {},
+    };
+  }
+
+  static get id() {
+    return "TestBehavior";
+  }
+
+  static isMatch() {
+    return window.location.origin === "https://example.com";
+  }
+
+  async *run(ctx) {
+    ctx.log("In Test Behavior!");
+    yield ctx.Lib.getState(ctx, "test-stat");
+  }
+}


### PR DESCRIPTION
- on first page, attempt to evaluate the behavior class to ensure it compiles
- if fails to compile, log exception with fatal and exit
- update behavior gathering code to keep track of behavior filename
- tests: add test for invalid behavior which causes crawl to exit with fatal exit code (17)