### PR TITLE
Generate urn:pageinfo:<page url> records

### DIFF
--- a/src/util/warcresourcewriter.ts
+++ b/src/util/warcresourcewriter.ts
@@ -33,26 +33,38 @@ export class WARCResourceWriter {
     resourceType: string,
     contentType: string,
   ) {
-    const warcRecord = await this.wrap(contents, resourceType, contentType);
+    const warcRecord = await WARCResourceWriter.createResourceRecord(
+      contents,
+      resourceType,
+      contentType,
+      this.url,
+      this.date,
+    );
     const warcRecordBuffer = await warcio.WARCSerializer.serialize(warcRecord, {
       gzip: true,
     });
     fs.appendFileSync(this.warcName, warcRecordBuffer);
   }
 
-  async wrap(buffer: Uint8Array, resourceType: string, contentType: string) {
+  static async createResourceRecord(
+    buffer: Uint8Array,
+    resourceType: string,
+    contentType: string,
+    url: string,
+    date: Date,
+  ) {
     const warcVersion = "WARC/1.1";
     const warcRecordType = "resource";
     const warcHeaders = { "Content-Type": contentType };
     async function* content() {
       yield buffer;
     }
-    const resourceUrl = `urn:${resourceType}:${this.url}`;
+    const resourceUrl = `urn:${resourceType}:${url}`;
 
     return warcio.WARCRecord.create(
       {
         url: resourceUrl,
-        date: this.date.toISOString(),
+        date: date.toISOString(),
         type: warcRecordType,
         warcVersion,
         warcHeaders,

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -135,6 +135,15 @@ export class WARCWriter implements IndexerOffsetLength {
     this._writeCDX(requestRecord);
   }
 
+  async writeSingleRecord(record: WARCRecord) {
+    const opts = { gzip: this.gzip };
+
+    const requestSerializer = new WARCSerializer(record, opts);
+    this.recordLength = await this._writeRecord(record, requestSerializer);
+
+    this._writeCDX(record);
+  }
+
   async _writeRecord(record: WARCRecord, serializer: WARCSerializer) {
     let total = 0;
     const url = record.warcTargetURI;


### PR DESCRIPTION
Generate records for each page, containing a list of resources and their status codes, to aid in future diffing/comparison.

Generates a `urn:pageinfo:<page url>` record for each page
- Adds POST / non-GET request canonicalization from warcio to handle non-GET requests
- Adds `writeSingleRecord` to WARCWriter

Fixes #457 