### PR TITLE
skipping resources: ensure HEAD, OPTIONS, 204, 206, and 304 response/request pairs are not written to WARC

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -912,8 +912,14 @@ export class Recorder {
   }
 
   async serializeToWARC(reqresp: RequestResponseInfo) {
-    if (!reqresp.payload) {
-      logNetwork("Not writing, no payload", { url: reqresp.url });
+    if (reqresp.shouldSkip()) {
+      const { url, method, status, payload } = reqresp;
+      logNetwork("Skipping request/response", {
+        url,
+        method,
+        status,
+        payloadLength: payload && payload.length,
+      });
       return;
     }
 

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -912,7 +912,7 @@ export class Recorder {
   }
 
   async serializeToWARC(reqresp: RequestResponseInfo) {
-    if (reqresp.shouldSkip()) {
+    if (reqresp.shouldSkipSave()) {
       const { url, method, status, payload } = reqresp;
       logNetwork("Skipping request/response", {
         url,

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -270,12 +270,12 @@ export class RequestResponseInfo {
     return true;
   }
 
-  shouldSkip() {
-    // skip OPTIONS/HEAD responses, and 304, 204 or 206 responses
+  shouldSkipSave() {
+    // skip OPTIONS/HEAD responses, and 304 or 206 responses
     if (
       !this.payload ||
       (this.method && ["OPTIONS", "HEAD"].includes(this.method)) ||
-      [204, 206, 304].includes(this.status)
+      [206, 304].includes(this.status)
     ) {
       return true;
     }

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -270,6 +270,19 @@ export class RequestResponseInfo {
     return true;
   }
 
+  shouldSkip() {
+    // skip OPTIONS/HEAD responses, and 304, 204 or 206 responses
+    if (
+      !this.payload ||
+      (this.method && ["OPTIONS", "HEAD"].includes(this.method)) ||
+      [204, 206, 304].includes(this.status)
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   getCanonURL(): string {
     if (!this.method || this.method === "GET") {
       return this.url;


### PR DESCRIPTION
Allows for skipping network traffic that doesn't need to be stored, as it is not necessary/will result in incorrect replay (eg. 304 instead of a 200).