### PR TITLE
Include resource type + mime type in page resources list

### DIFF
--- a/tests/pageinfo-records.test.js
+++ b/tests/pageinfo-records.test.js
@@ -52,22 +52,71 @@ function validateResourcesIndex(json) {
   expect(json).toHaveProperty("ts");
   expect(json).toHaveProperty("urls");
   expect(json.urls).toEqual({
-    "https://webrecorder.net/": 200,
-    "https://webrecorder.net/assets/main.css": 200,
-    "https://webrecorder.net/assets/tools/awp-icon.png": 200,
-    "https://webrecorder.net/assets/wr-logo.svg": 200,
-    "https://webrecorder.net/assets/tools/browsertrixcrawler.png": 200,
-    "https://webrecorder.net/assets/tools/logo-pywb.png": 200,
-    "https://webrecorder.net/assets/images/btrix-cloud.png": 200,
-    "https://webrecorder.net/assets/tools/rwp-icon.png": 200,
-    "https://webrecorder.net/assets/fontawesome/all.css": 200,
-    "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@700;900&display=swap": 200,
-    "https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro&display=swap": 200,
-    "https://stats.browsertrix.com/js/script.js": 200,
-    "https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3ig4vwlxdu.woff2": 200,
-    "https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qOK7l.woff2": 200,
-    "https://webrecorder.net/assets/favicon.ico": 200,
-    "https://stats.browsertrix.com/api/event?__wb_method=POST&n=pageview&u=https%3A%2F%2Fwebrecorder.net%2F&d=webrecorder.net": 202,
+    "https://webrecorder.net/": {
+      status: 200,
+      mime: "text/html",
+      type: "Document",
+    },
+    "https://webrecorder.net/assets/fontawesome/all.css": {
+      status: 200,
+      mime: "text/css",
+      type: "Stylesheet",
+    },
+    "https://webrecorder.net/assets/wr-logo.svg": {
+      status: 200,
+      mime: "image/svg+xml",
+      type: "Image",
+    },
+    "https://webrecorder.net/assets/tools/awp-icon.png": {
+      status: 200,
+      mime: "image/png",
+      type: "Image",
+    },
+    "https://webrecorder.net/assets/tools/logo-pywb.png": {
+      status: 200,
+      mime: "image/png",
+      type: "Image",
+    },
+    "https://webrecorder.net/assets/tools/browsertrixcrawler.png": {
+      status: 200,
+      mime: "image/png",
+      type: "Image",
+    },
+    "https://webrecorder.net/assets/tools/rwp-icon.png": {
+      status: 200,
+      mime: "image/png",
+      type: "Image",
+    },
+    "https://webrecorder.net/assets/images/btrix-cloud.png": {
+      status: 200,
+      mime: "image/png",
+      type: "Image",
+    },
+    "https://webrecorder.net/assets/main.css": {
+      status: 200,
+      mime: "text/css",
+      type: "Stylesheet",
+    },
+    "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@700;900&display=swap":
+      { status: 200, mime: "text/css", type: "Stylesheet" },
+    "https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro&display=swap":
+      { status: 200, mime: "text/css", type: "Stylesheet" },
+    "https://stats.browsertrix.com/js/script.js": {
+      status: 200,
+      mime: "application/javascript",
+      type: "Script",
+    },
+    "https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qOK7l.woff2":
+      { status: 200, mime: "font/woff2", type: "Font" },
+    "https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3ig4vwlxdu.woff2":
+      { status: 200, mime: "font/woff2", type: "Font" },
+    "https://webrecorder.net/assets/favicon.ico": {
+      status: 200,
+      mime: "image/vnd.microsoft.icon",
+      type: "Other",
+    },
+    "https://stats.browsertrix.com/api/event?__wb_method=POST&n=pageview&u=https%3A%2F%2Fwebrecorder.net%2F&d=webrecorder.net":
+      { status: 202, mime: "text/plain", type: "XHR" },
   });
 }
 
@@ -77,16 +126,38 @@ function validateResourcesAbout(json) {
   expect(json).toHaveProperty("ts");
   expect(json).toHaveProperty("urls");
   expect(json.urls).toEqual({
-    "https://webrecorder.net/about": 200,
-    "https://webrecorder.net/assets/main.css": 200,
-    "https://webrecorder.net/assets/fontawesome/all.css": 200,
-    "https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro&display=swap": 200,
-    "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@700;900&display=swap": 200,
-    "https://stats.browsertrix.com/js/script.js": 200,
-    "https://webrecorder.net/assets/wr-logo.svg": 200,
-    "https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qOK7l.woff2": 200,
-    "https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3ig4vwlxdu.woff2": 200,
-    //"https://webrecorder.net/assets/favicon.ico": 200,
-    //"https://stats.browsertrix.com/api/event?__wb_method=POST&n=pageview&u=https%3A%2F%2Fwebrecorder.net%2Fabout&d=webrecorder.net": 202,
+    "https://webrecorder.net/about": {
+      status: 200,
+      mime: "text/html",
+      type: "Document",
+    },
+    "https://webrecorder.net/assets/main.css": {
+      status: 200,
+      mime: "text/css",
+      type: "Stylesheet",
+    },
+    "https://webrecorder.net/assets/fontawesome/all.css": {
+      status: 200,
+      mime: "text/css",
+      type: "Stylesheet",
+    },
+    "https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro&display=swap":
+      { status: 200, mime: "text/css", type: "Stylesheet" },
+    "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@700;900&display=swap":
+      { status: 200, mime: "text/css", type: "Stylesheet" },
+    "https://stats.browsertrix.com/js/script.js": {
+      status: 200,
+      mime: "application/javascript",
+      type: "Script",
+    },
+    "https://webrecorder.net/assets/wr-logo.svg": {
+      status: 200,
+      mime: "image/svg+xml",
+      type: "Image",
+    },
+    "https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qOK7l.woff2":
+      { status: 200, mime: "font/woff2", type: "Font" },
+    "https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3ig4vwlxdu.woff2":
+      { status: 200, mime: "font/woff2", type: "Font" },
   });
 }


### PR DESCRIPTION
The `:pageinfo:<url>` record now includes the mime type + resource type (from Chrome) along with status code for each resource, for better filtering / comparison.