### PR TITLE
Set warc prefix via WARC_PREFIX env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -128,7 +128,8 @@ export class Recorder {
     fs.mkdirSync(this.archivesDir, { recursive: true });
     fs.mkdirSync(this.tempCdxDir, { recursive: true });
 
-    const prefix = crawler.params.warcPrefix || "rec";
+    const prefix =
+      process.env.WARC_PREFIX || crawler.params.warcPrefix || "rec";
     const crawlId = process.env.CRAWL_ID || os.hostname();
     const filenameTemplate = `${prefix}-${crawlId}-$ts-${this.workerid}.warc${
       this.gzip ? ".gz" : ""


### PR DESCRIPTION
In addition to `--warcPrefix` flag, also support WARC_PREFIX env var, which takes precedence.
Bump to 1.0.0-beta.4