### PR TITLE
Include WARC prefix for screenshots and text WARCs

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -263,7 +263,7 @@ export class Crawler {
 
     this.browser = new Browser();
 
-    this.warcPrefix = process.env.WARC_PREFIX || this.params.warcPrefix;
+    this.warcPrefix = process.env.WARC_PREFIX || this.params.warcPrefix || "";
     if (this.warcPrefix) {
       this.warcPrefix += "-";
     }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -266,9 +266,8 @@ export class Crawler {
     this.warcPrefix = process.env.WARC_PREFIX || this.params.warcPrefix || "";
 
     if (this.warcPrefix) {
-      this.warcPrefix += "-";
+      this.warcPrefix += "-" + this.crawlId + "-";
     }
-    this.warcPrefix += this.crawlId + "-";
   }
 
   configureUA() {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -264,9 +264,11 @@ export class Crawler {
     this.browser = new Browser();
 
     this.warcPrefix = process.env.WARC_PREFIX || this.params.warcPrefix || "";
+
     if (this.warcPrefix) {
       this.warcPrefix += "-";
     }
+    this.warcPrefix += this.crawlId + "-";
   }
 
   configureUA() {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -159,6 +159,8 @@ export class Crawler {
   maxHeapUsed = 0;
   maxHeapTotal = 0;
 
+  warcPrefix: string;
+
   driver!: (opts: {
     page: Page;
     data: PageState;
@@ -260,6 +262,11 @@ export class Crawler {
     this.customBehaviors = "";
 
     this.browser = new Browser();
+
+    this.warcPrefix = process.env.WARC_PREFIX || this.params.warcPrefix;
+    if (this.warcPrefix) {
+      this.warcPrefix += "-";
+    }
   }
 
   configureUA() {
@@ -741,6 +748,7 @@ self.__bx_behaviors.selectMainBehavior();
         logger.debug("Skipping screenshots for non-HTML page", logDetails);
       }
       const screenshots = new Screenshots({
+        warcPrefix: this.warcPrefix,
         browser: this.browser,
         page,
         url,
@@ -761,6 +769,7 @@ self.__bx_behaviors.selectMainBehavior();
 
     if (data.isHTMLPage) {
       textextract = new TextExtractViaSnapshot(cdp, {
+        warcPrefix: this.warcPrefix,
         url,
         directory: archiveDir,
       });

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -500,7 +500,6 @@ class ArgParser {
         describe:
           "prefix for WARC files generated, including WARCs added to WACZ",
         type: "string",
-        default: "rec",
       },
     };
   }

--- a/src/util/warcresourcewriter.ts
+++ b/src/util/warcresourcewriter.ts
@@ -15,16 +15,18 @@ export class WARCResourceWriter {
     url,
     directory,
     date,
+    warcPrefix,
     warcName,
   }: {
     url: string;
     directory: string;
     date: Date;
+    warcPrefix: string;
     warcName: string;
   }) {
     this.url = url;
     this.directory = directory;
-    this.warcName = path.join(this.directory, warcName);
+    this.warcName = path.join(this.directory, warcPrefix + warcName);
     this.date = date ? date : new Date();
   }
 


### PR DESCRIPTION
Ensure the env var / cli warc prefix is also applied to `screenshots.warc.gz` and `text.warc.gz`