### PR TITLE
Ensure links added via behaviors also get processed

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@novnc/novnc": "^1.4.0",
     "@webrecorder/wabac": "^2.16.12",
-    "browsertrix-behaviors": "^0.5.2",
+    "browsertrix-behaviors": "^0.5.3",
     "crc": "^4.3.2",
     "get-folder-size": "^4.0.0",
     "husky": "^8.0.3",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -805,10 +805,6 @@ self.__bx_behaviors.selectMainBehavior();
           "behavior",
         );
 
-        if (data.callbacks.flushLinks) {
-          await data.callbacks.flushLinks();
-        }
-
         await this.netIdle(page, logDetails);
 
         if (res) {
@@ -1729,31 +1725,8 @@ self.__bx_behaviors.selectMainBehavior();
   ) {
     const { seedId, depth, extraHops = 0, filteredFrames, callbacks } = data;
 
-    let links: string[] = [];
-    let promiseList: Promise<void>[] = [];
-
-    callbacks.addLink = (url: string) => {
-      links.push(url);
-      if (links.length == 500) {
-        promiseList.push(
-          this.queueInScopeUrls(seedId, links, depth, extraHops, logDetails),
-        );
-        links = [];
-      }
-    };
-
-    callbacks.flushLinks = async () => {
-      if (links.length) {
-        promiseList.push(
-          this.queueInScopeUrls(seedId, links, depth, extraHops, logDetails),
-        );
-        links = [];
-      }
-
-      if (promiseList.length) {
-        await Promise.allSettled(promiseList);
-        promiseList = [];
-      }
+    callbacks.addLink = async (url: string) => {
+      await this.queueInScopeUrls(seedId, [url], depth, extraHops, logDetails);
     };
 
     const loadLinks = (options: {
@@ -1822,8 +1795,6 @@ self.__bx_behaviors.selectMainBehavior();
     } catch (e) {
       logger.warn("Link Extraction failed", e, "links");
     }
-
-    await callbacks.flushLinks();
   }
 
   async queueInScopeUrls(

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -36,8 +36,7 @@ export type QueueEntry = {
 
 // ============================================================================
 export type PageCallbacks = {
-  addLink?: (url: string) => void;
-  flushLinks?: () => Promise<void>;
+  addLink?: (url: string) => Promise<void>;
 };
 
 // ============================================================================

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -37,6 +37,7 @@ export type QueueEntry = {
 // ============================================================================
 export type PageCallbacks = {
   addLink?: (url: string) => void;
+  flushLinks?: () => Promise<void>;
 };
 
 // ============================================================================

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,10 +1425,10 @@ browserslist@^4.21.3:
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.9"
 
-browsertrix-behaviors@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.5.2.tgz#d2fe1d6ff08815ff0dd68a05fe1a3cdc4bbec8ca"
-  integrity sha512-8nhpnzY8OM1mxQ+mZ+m10dpGgMuhCnKUV5YUlitDpMyEfKlEybUmTz5sroVQH8e//NcJox7W6QYjaU2Y/ygxww==
+browsertrix-behaviors@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.5.3.tgz#f987075790b0fd970814f57195e8525277ddd2a0"
+  integrity sha512-NiVdV42xvj4DvX/z0Dxqzqsa+5e57/M7hIyK3fl41BxzOJqCgSMu0MpkrWuKpbRVo+89ZnBmzh2z6D18Vmn1LA==
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Requires webrecorder/browsertrix-behaviors#69 / browsertrix-behaviors 0.5.3, which will add support for behaviors to add links.

Simplify adding links by simply adding the links directly, instead of batching to 500 links. Errors are already being logged in queueing a new URL fails.