### PR TITLE
Fail on status code option + requeue fix

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1586,20 +1586,30 @@ self.__bx_behaviors.selectMainBehavior();
         });
       }
 
-      // Handle 4xx or 5xx response as a page load error
       const status = resp.status();
       data.status = status;
-      if (isChromeError) {
+
+      let failed = isChromeError;
+
+      if (this.params.failOnInvalidStatus && status >= 400) {
+        // Handle 4xx or 5xx response as a page load error
+        failed = true;
+      }
+
+      if (failed) {
         if (failCrawlOnError) {
           logger.fatal("Seed Page Load Error, failing crawl", {
             status,
             ...logDetails,
           });
         } else {
-          logger.error("Page Crashed on Load", {
-            status,
-            ...logDetails,
-          });
+          logger.error(
+            isChromeError ? "Page Crashed on Load" : "Page Invalid Status",
+            {
+              status,
+              ...logDetails,
+            },
+          );
           throw new Error("logged");
         }
       }

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -484,6 +484,14 @@ class ArgParser {
         default: 0,
       },
 
+      failOnInvalidStatus: {
+        describe:
+          "If set, will treat pages with non-200 response as failures. When combined with --failOnFailedLimit or --failOnFailedSeed" +
+          "may result in crawl failing due to non-200 responses",
+        type: "boolean",
+        default: false,
+      },
+
       customBehaviors: {
         describe:
           "injects a custom behavior file or set of behavior files in a directory",


### PR DESCRIPTION
Add fail on status code option, --failOnInvalidStatus to treat non-200 responses as failures. Can be useful especially when combined with --failOnFailedSeed or --failOnFailedLimit

requeue: ensure requeued urls are requeued with same depth/priority, not 0