### PR TITLE
Better tracking of failed requests + logging context exclude 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -189,7 +189,8 @@ export class Crawler {
     const debugLogging = this.params.logging.includes("debug");
     logger.setDebugLogging(debugLogging);
     logger.setLogLevel(this.params.logLevel);
-    logger.setContext(this.params.context);
+    logger.setContext(this.params.logContext);
+    logger.setExcludeContext(this.params.logExcludeContext);
 
     // if automatically restarts on error exit code,
     // exit with 0 from fatal by default, to avoid unnecessary restart

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -15,7 +15,11 @@ import {
 import { ScopedSeed } from "./seeds.js";
 import { interpolateFilename } from "./storage.js";
 import { screenshotTypes } from "./screenshots.js";
-import { LOG_CONTEXT_TYPES, logger } from "./logger.js";
+import {
+  DEFAULT_EXCLUDE_LOG_CONTEXTS,
+  LOG_CONTEXT_TYPES,
+  logger,
+} from "./logger.js";
 
 // ============================================================================
 class ArgParser {
@@ -221,6 +225,14 @@ class ArgParser {
         describe: "Comma-separated list of contexts to include in logs",
         type: "array",
         default: [],
+        choices: LOG_CONTEXT_TYPES,
+        coerce,
+      },
+
+      logExcludeContext: {
+        describe: "Comma-separated list of contexts to NOT include in logs",
+        type: "array",
+        default: DEFAULT_EXCLUDE_LOG_CONTEXTS,
         choices: LOG_CONTEXT_TYPES,
         coerce,
       },

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -44,11 +44,11 @@ export class RequestResponseInfo {
   payload?: Uint8Array;
 
   // misc
-  fromServiceWorker: boolean = false;
+  fromServiceWorker = false;
 
   frameId?: string;
 
-  fetch: boolean = false;
+  fetch = false;
 
   resourceType?: string;
 
@@ -71,13 +71,7 @@ export class RequestResponseInfo {
   }
 
   fillFetchRequestPaused(params: Protocol.Fetch.RequestPausedEvent) {
-    this.url = params.request.url;
-    this.method = params.request.method;
-    if (!this.requestHeaders) {
-      this.requestHeaders = params.request.headers;
-    }
-    this.postData = params.request.postData;
-    this.hasPostData = params.request.hasPostData || false;
+    this.fillRequest(params.request, params.resourceType);
 
     this.status = params.responseStatusCode || 0;
     this.statusText = params.responseStatusText || getStatusText(this.status);
@@ -86,14 +80,24 @@ export class RequestResponseInfo {
 
     this.fetch = true;
 
-    if (params.resourceType) {
-      this.resourceType = params.resourceType.toLowerCase();
-    }
-
     this.frameId = params.frameId;
   }
 
-  fillResponse(response: Protocol.Network.Response, type?: string) {
+  fillRequest(request: Protocol.Network.Request, resourceType?: string) {
+    this.url = request.url;
+    this.method = request.method;
+    if (!this.requestHeaders) {
+      this.requestHeaders = request.headers;
+    }
+    this.postData = request.postData;
+    this.hasPostData = request.hasPostData || false;
+
+    if (resourceType) {
+      this.resourceType = resourceType.toLowerCase();
+    }
+  }
+
+  fillResponse(response: Protocol.Network.Response, resourceType?: string) {
     // if initial fetch was a 200, but now replacing with 304, don't!
     if (
       response.status == 304 &&
@@ -111,8 +115,8 @@ export class RequestResponseInfo {
 
     this.protocol = response.protocol;
 
-    if (type) {
-      this.resourceType = type.toLowerCase();
+    if (resourceType) {
+      this.resourceType = resourceType.toLowerCase();
     }
 
     if (response.requestHeaders) {

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -298,7 +298,7 @@ export class PageWorker {
   async crawlPage(opts: WorkerState) {
     const res = await this.crawler.crawlPage(opts);
     if (this.recorder) {
-      opts.data.ts = await this.recorder.finishPage();
+      await this.recorder.awaitPageResources();
     }
     return res;
   }
@@ -339,7 +339,21 @@ export class PageWorker {
           "worker",
         );
       }
+
+      await this.closePage();
     } finally {
+      try {
+        if (this.recorder) {
+          opts.data.ts = await this.recorder.writePageInfoRecord();
+        }
+      } catch (e) {
+        logger.error(
+          "Error writing pageinfo recorder",
+          { ...formatErr(e), ...this.logDetails },
+          "recorder",
+        );
+      }
+
       await timedRun(
         this.crawler.pageFinished(data),
         FINISHED_TIMEOUT,


### PR DESCRIPTION
- add --logExcludeContext for log contexts that should be excluded (while --logContext specifies which are to be included)
- enable 'recorderNetwork' logging for debugging CDP network
- create default log context exclude list (containing: screencast, recorderNetwork, jsErrors), customizable via --logExcludeContext

recorder: Track failed requests and include in pageinfo records with status code 0
- cleanup cdp handler methods
- intercept requestWillBeSent to track requests that started (but may not complete)
- fix shouldSkip() still working if no url is provided (eg. check only headers)
- set status to 0 for async fetch failures
- remove responseServedFromCache interception, as response data generally not available then, and responseReceived is still called
- pageinfo: include page requests that failed with status code 0
- ensure page is closed on failure
- ensure pageinfo still written even if nothing else is crawled for a page

tests: add pageinfo test for crawling invalid URL, which should still result in pageinfo record with status code 0

bump to 1.0.0-beta.7