### PR TITLE
Additional type fixes, follow-up to #488

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -33,7 +33,7 @@ import { Screenshots } from "./util/screenshots.js";
 import { parseArgs } from "./util/argParser.js";
 import { initRedis } from "./util/redis.js";
 import { logger, formatErr } from "./util/logger.js";
-import { WorkerState, runWorkers } from "./util/worker.js";
+import { WorkerOpts, WorkerState, runWorkers } from "./util/worker.js";
 import { sleep, timedRun, secondsElapsed } from "./util/timing.js";
 import { collectAllFileSources } from "./util/file_reader.js";
 
@@ -869,7 +869,7 @@ self.__bx_behaviors.selectMainBehavior();
     await this.checkLimits();
   }
 
-  async teardownPage({ workerid }: WorkerState) {
+  async teardownPage({ workerid }: WorkerOpts) {
     if (this.screencaster) {
       await this.screencaster.stopById(workerid);
     }

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -52,7 +52,7 @@ export async function runWorkers(
 }
 
 // ===========================================================================
-type WorkerOpts = {
+export type WorkerOpts = {
   page: Page;
   cdp: CDPSession;
   workerid: WorkerId;
@@ -71,9 +71,8 @@ export type WorkerState = WorkerOpts & {
 // ===========================================================================
 export class PageWorker {
   id: WorkerId;
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  crawler: any;
+
+  crawler: Crawler;
   maxPageTime: number;
 
   reuseCount = 0;
@@ -97,9 +96,7 @@ export class PageWorker {
 
   constructor(
     id: WorkerId,
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    crawler: any,
+    crawler: Crawler,
     maxPageTime: number,
     collDir: string,
   ) {
@@ -127,7 +124,7 @@ export class PageWorker {
       await this.recorder.onClosePage();
     }
 
-    if (!this.crashed) {
+    if (!this.crashed && this.opts) {
       try {
         await timedRun(
           this.crawler.teardownPage(this.opts),


### PR DESCRIPTION
More type safety (keep using WorkerOpts when needed)
follow-up to changes in #488 
