### PR TITLE
Fix Save/Load State

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -353,9 +353,9 @@ export class Crawler {
   async initExtraSeeds() {
     const extraSeeds = await this.crawlState.getExtraSeeds();
 
-    for (const { seedId, url } of extraSeeds) {
-      const seed = this.params.scopedSeeds[seedId];
-      this.params.scopedSeeds.push(seed.newScopedSeed(url));
+    for (const { origSeedId, newUrl } of extraSeeds) {
+      const seed = this.params.scopedSeeds[origSeedId];
+      this.params.scopedSeeds.push(seed.newScopedSeed(newUrl));
     }
   }
 
@@ -1588,13 +1588,11 @@ self.__bx_behaviors.selectMainBehavior();
       const isChromeError = page.url().startsWith("chrome-error://");
 
       if (depth === 0 && !isChromeError && respUrl !== url) {
-        const seed = this.params.scopedSeeds[data.seedId];
-        this.params.scopedSeeds.push(seed.newScopedSeed(respUrl));
-        data.seedId = this.params.scopedSeeds.length - 1;
-        await this.crawlState.addExtraSeed({
-          seedId: data.seedId,
-          url: respUrl,
-        });
+        data.seedId = await this.crawlState.addExtraSeed(
+          this.params.scopedSeeds,
+          data.seedId,
+          respUrl,
+        );
         logger.info("Seed page redirected, adding redirected seed", {
           origUrl: url,
           newUrl: respUrl,

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -329,7 +329,17 @@ export class Crawler {
       os.hostname(),
     );
 
-    await this.initExtraSeeds();
+    // load full state from config
+    if (this.params.state) {
+      await this.crawlState.load(
+        this.params.state,
+        this.params.scopedSeeds,
+        true,
+      );
+      // otherwise, just load extra seeds
+    } else {
+      await this.loadExtraSeeds();
+    }
 
     // clear any pending URLs from this instance
     await this.crawlState.clearOwnPendingLocks();
@@ -350,7 +360,7 @@ export class Crawler {
     return this.crawlState;
   }
 
-  async initExtraSeeds() {
+  async loadExtraSeeds() {
     const extraSeeds = await this.crawlState.getExtraSeeds();
 
     for (const { origSeedId, newUrl } of extraSeeds) {
@@ -1200,14 +1210,6 @@ self.__bx_behaviors.selectMainBehavior();
     }
 
     await this.crawlState.setStatus("running");
-
-    if (this.params.state) {
-      await this.crawlState.load(
-        this.params.state,
-        this.params.scopedSeeds,
-        true,
-      );
-    }
 
     await this.initPages();
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -329,6 +329,8 @@ export class Crawler {
       os.hostname(),
     );
 
+    await this.initExtraSeeds();
+
     // clear any pending URLs from this instance
     await this.crawlState.clearOwnPendingLocks();
 
@@ -346,6 +348,15 @@ export class Crawler {
     }
 
     return this.crawlState;
+  }
+
+  async initExtraSeeds() {
+    const extraSeeds = await this.crawlState.getExtraSeeds();
+
+    for (const { seedId, url } of extraSeeds) {
+      const seed = this.params.scopedSeeds[seedId];
+      this.params.scopedSeeds.push(seed.newScopedSeed(url));
+    }
   }
 
   initScreenCaster() {
@@ -1580,6 +1591,10 @@ self.__bx_behaviors.selectMainBehavior();
         const seed = this.params.scopedSeeds[data.seedId];
         this.params.scopedSeeds.push(seed.newScopedSeed(respUrl));
         data.seedId = this.params.scopedSeeds.length - 1;
+        await this.crawlState.addExtraSeed({
+          seedId: data.seedId,
+          url: respUrl,
+        });
         logger.info("Seed page redirected, adding redirected seed", {
           origUrl: url,
           newUrl: respUrl,

--- a/tests/saved-state.test.js
+++ b/tests/saved-state.test.js
@@ -95,6 +95,11 @@ test("check parsing saved state + page done + queue present", () => {
   expect(numQueued > 0).toEqual(true);
   expect(numDone + numQueued).toEqual(10);
 
+  // ensure extra seeds also set
+  expect(state.extraSeeds).toEqual([
+    `{"origSeedId":0,"newUrl":"https://www.iana.org/"}`,
+  ]);
+
   finished = state.finished;
 });
 

--- a/tests/saved-state.test.js
+++ b/tests/saved-state.test.js
@@ -43,7 +43,7 @@ test("check crawl interrupted + saved state written", async () => {
 
   try {
     containerId = execSync(
-      "docker run -d -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection int-state-test --url https://iana.org/ --limit 10",
+      "docker run -d -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection int-state-test --url https://www.webrecorder.net/ --limit 10",
       { encoding: "utf-8" },
       //wait.callback,
     );
@@ -108,7 +108,7 @@ test("check parsing saved state + page done + queue present", () => {
 
   // ensure extra seeds also set
   expect(state.extraSeeds).toEqual([
-    `{"origSeedId":0,"newUrl":"https://www.iana.org/"}`,
+    `{"origSeedId":0,"newUrl":"https://webrecorder.net/"}`,
   ]);
 
   finished = state.finished;


### PR DESCRIPTION
- Fixes state serialization, which was missing the done list. Instead, adds a 'finished' list computed from the seen list, minus failed and queued URLs.
- Also adds serialization support for 'extraSeeds', seeds added dynamically from a redirect (via #475). Extra seeds are added to Redis and also included in the serialization.

Fixes #491

