### PR TITLE
Temporarily disable tmp-cdx creation

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -130,7 +130,7 @@ export class Recorder {
 
     fs.mkdirSync(this.tempdir, { recursive: true });
     fs.mkdirSync(this.archivesDir, { recursive: true });
-    fs.mkdirSync(this.tempCdxDir, { recursive: true });
+    // fs.mkdirSync(this.tempCdxDir, { recursive: true });
 
     const prefix =
       process.env.WARC_PREFIX || crawler.params.warcPrefix || "rec";
@@ -141,7 +141,7 @@ export class Recorder {
 
     this.writer = new WARCWriter({
       archivesDir: this.archivesDir,
-      tempCdxDir: this.tempCdxDir,
+      // tempCdxDir: this.tempCdxDir,
       filenameTemplate,
       rolloverSize: crawler.params.rolloverSize,
       gzip: this.gzip,

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -13,7 +13,7 @@ const DEFAULT_ROLLOVER_SIZE = 1_000_000_000;
 // =================================================================
 export class WARCWriter implements IndexerOffsetLength {
   archivesDir: string;
-  tempCdxDir: string;
+  tempCdxDir?: string;
   filenameTemplate: string;
   filename?: string;
   gzip: boolean;
@@ -39,7 +39,7 @@ export class WARCWriter implements IndexerOffsetLength {
     logDetails,
   }: {
     archivesDir: string;
-    tempCdxDir: string;
+    tempCdxDir?: string;
     filenameTemplate: string;
     rolloverSize?: number;
     gzip: boolean;


### PR DESCRIPTION
Fixes #498 

To revert after 1.0.0 when we make changes that allow for using the temp CDX in WACZ creation.