### PR TITLE
Docs: Minor fixes to edit link & clarifications

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,7 +10,7 @@ Welcome to the Browsertrix Crawler official documentation.
 
 Browsertrix Crawler is a simplified browser-based high-fidelity crawling system, designed to run a complex, customizable browser-based crawl in a single Docker container. Browsertrix Crawler uses [Puppeteer](https://github.com/puppeteer/puppeteer) to control one or more [Brave Browser](https://brave.com/) browser windows in parallel. Data is captured through the [Chrome Devtools Protocol (CDP)](https://chromedevtools.github.io/devtools-protocol/) in the browser.
 
-Browsertrix Crawler is a command line application responsible for the core features of [Browsertrix](https://browsertrix.com), Webrecorder's cloud-based web archiving service. You can find the documentation for Browsertrix — the cloud platform — [here](https://docs.browsertrix.cloud)!
+Browsertrix Crawler is a command line application responsible for the core features of [Browsertrix](https://browsertrix.com), Webrecorder's cloud-based web archiving service. See the [Browsertrix documentation] for more information about Browsertrix, the cloud platform.
 
 !!! note
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,14 +10,13 @@ Welcome to the Browsertrix Crawler official documentation.
 
 Browsertrix Crawler is a simplified browser-based high-fidelity crawling system, designed to run a complex, customizable browser-based crawl in a single Docker container. Browsertrix Crawler uses [Puppeteer](https://github.com/puppeteer/puppeteer) to control one or more [Brave Browser](https://brave.com/) browser windows in parallel. Data is captured through the [Chrome Devtools Protocol (CDP)](https://chromedevtools.github.io/devtools-protocol/) in the browser.
 
+Browsertrix Crawler is a command line application responsible for the core features of [Browsertrix](https://browsertrix.com), Webrecorder's cloud-based web archiving service. You can find the documentation for Browsertrix — the cloud platform — [here](https://docs.browsertrix.cloud)!
 
 !!! note
 
     This documentation applies to Browsertrix Crawler versions 1.0.0 and above. Documentation for earlier versions of the crawler is available in the [Browsertrix Crawler Github repository](https://github.com/webrecorder/browsertrix-crawler)'s README file in older commits.
 
-
 ## Features
-
 
 - Single-container, browser based crawling with a headless/headful browser running pages in multiple windows.
 - Support for custom browser behaviors, using [Browsertrix Behaviors](https://github.com/webrecorder/browsertrix-behaviors) including autoscroll, video autoplay, and site-specific behaviors.

--- a/docs/docs/user-guide/index.md
+++ b/docs/docs/user-guide/index.md
@@ -1,6 +1,6 @@
 # Browsertrix Crawler User Guide
 
-Welcome to the Browsertrix User Guide. This page covers the basics of using Browsertrix Crawler, Webrecorder's browser-based high-fidelity crawling system, designed to run a complex, customizable browser-based crawl in a single Docker container.
+Welcome to the Browsertrix Crawler User Guide. This page covers the basics of using Browsertrix Crawler, Webrecorder's browser-based high-fidelity crawling system, designed to run a complex, customizable, browser-based crawl in a single Docker container.
 
 ## Getting Started
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Browsertrix Crawler Docs
 repo_url: https://github.com/webrecorder/browsertrix-crawler/
 repo_name: Browsertrix Crawler
-edit_uri: edit/main/docs/
+edit_uri: edit/main/docs/docs/
 extra_css:
   - stylesheets/extra.css
 theme:


### PR DESCRIPTION
### Changes
- Fixes docs edit link GitHub path, unlike Browsertrix everything lives in a separate /docs directory here!
- Adds a note directing people to Browsertrix — the cloud platform — and its documentation to the homepage