### PR TITLE
service worker capture fix: disable by default for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -758,6 +758,7 @@ self.__bx_behaviors.selectMainBehavior();
             data.mime = mime;
           }
           data.status = 200;
+          data.ts = new Date();
           logger.info(
             "Direct fetch successful",
             { url, ...logDetails },
@@ -1256,6 +1257,7 @@ self.__bx_behaviors.selectMainBehavior();
       profileUrl: this.params.profile,
       headless: this.params.headless,
       emulateDevice: this.emulateDevice,
+      swOpt: this.params.serviceWorker,
       chromeOptions: {
         proxy: false,
         userAgent: this.emulateDevice.userAgent,
@@ -1980,9 +1982,12 @@ self.__bx_behaviors.selectMainBehavior();
   }: PageState) {
     const row: PageEntry = { id: pageid!, url, title, loadState };
 
-    if (ts) {
-      row.ts = ts.toISOString();
+    if (!ts) {
+      ts = new Date();
+      logger.warn("Page date missing, setting to now", { url, ts });
     }
+
+    row.ts = ts.toISOString();
 
     if (mime) {
       row.mime = mime;
@@ -2000,11 +2005,11 @@ self.__bx_behaviors.selectMainBehavior();
       row.seed = true;
     }
 
-    if (text !== null) {
+    if (text) {
       row.text = text;
     }
 
-    if (favicon !== null) {
+    if (favicon) {
       row.favIconUrl = favicon;
     }
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -11,6 +11,7 @@ import {
   BEHAVIOR_LOG_FUNC,
   WAIT_UNTIL_OPTS,
   EXTRACT_TEXT_TYPES,
+  SERVICE_WORKER_OPTS,
 } from "./constants.js";
 import { ScopedSeed } from "./seeds.js";
 import { interpolateFilename } from "./storage.js";
@@ -526,6 +527,14 @@ class ArgParser {
         describe:
           "prefix for WARC files generated, including WARCs added to WACZ",
         type: "string",
+      },
+
+      serviceWorker: {
+        alias: "sw",
+        describe:
+          "service worker handling: disabled, enabled, or disabled with custom profile",
+        choices: SERVICE_WORKER_OPTS,
+        default: "disabled",
       },
     };
   }

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -114,23 +114,25 @@ export class Browser {
       'Object.defineProperty(navigator, "webdriver", {value: false});',
     );
 
-    if (this.customProfile) {
-      logger.info("Disabling Service Workers for profile", {}, "browser");
-    }
-
     switch (this.swOpt) {
       case "disabled":
+        logger.info("Service Workers: always disabled", {}, "browser");
         await page.setBypassServiceWorker(true);
         break;
 
       case "disabled-if-profile":
         if (this.customProfile) {
+          logger.info(
+            "Service Workers: disabled since using profile",
+            {},
+            "browser",
+          );
           await page.setBypassServiceWorker(true);
         }
         break;
 
       case "enabled":
-        // do nothing
+        logger.info("Service Workers: always enabled", {}, "browser");
         break;
     }
   }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -10,6 +10,14 @@ export const WAIT_UNTIL_OPTS = [
   "networkidle2",
 ];
 
+export const SERVICE_WORKER_OPTS = [
+  "disabled",
+  "disabled-if-profile",
+  "enabled",
+] as const;
+
+export type ServiceWorkerOpt = (typeof SERVICE_WORKER_OPTS)[number];
+
 export const DETECT_SITEMAP = "<detect>";
 
 export const EXTRACT_TEXT_TYPES = ["to-pages", "to-warc", "final-to-warc"];


### PR DESCRIPTION
Due to issues with capturing top-level pages, make bypassing service workers the default for now. Previously, it was only disabled when using profiles. (This is also consistent with ArchiveWeb.page behavior).
Includes:
- add --serviceWorker option which can be `disabled`, disabled-if-profile (previous default) and `enabled`
- ensure page timestamp is set for direct fetch
- warn if page timestamp is missing on serialization, then set to now before serializing

bump version to 1.0.2