### PR TITLE
Use RFC2606 invalid domain names

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -593,8 +593,8 @@ export const defaultArgs = [
   "--no-service-autorun",
   "--export-tagged-pdf",
   "--apps-keep-chrome-alive-in-tests",
-  "--apps-gallery-url=https://invalid.webstore.example.com/",
-  "--apps-gallery-update-url=https://invalid.webstore.example.com/",
-  //"--component-updater=url-source=http://invalid.dev/",
-  "--brave-stats-updater-server=url-source=http://invalid.dev/",
+  "--apps-gallery-url=https://gallery.invalid/",
+  "--apps-gallery-update-url=https://gallery-update.invalid/",
+  //"--component-updater=url-source=http://updater.invalid/",
+  "--brave-stats-updater-server=url-source=http://stats-updater.invalid/",
 ];


### PR DESCRIPTION
`invalid.dev` can potentially be registered and used. `.invalid` is guaranteed to never be valid. See also: https://www.rfc-editor.org/rfc/rfc2606.html