### PR TITLE
Make /app world-readable to better support non-root usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,8 @@ WORKDIR /crawls
 # enable to test custom behaviors build (from browsertrix-behaviors)
 # COPY behaviors.js /app/node_modules/browsertrix-behaviors/dist/behaviors.js
 
+RUN chmod o=rX -R /app
+
 ADD docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 


### PR DESCRIPTION
I suspect https://github.com/webrecorder/browsertrix-cloud/pull/1625 is failing in CI because browsertrix-crawler sometimes needs to read from `/app` after launching. This causes errors with the non-root deployment.