### PR TITLE
refactor handling of max size for html/js/css

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -606,7 +606,7 @@ export class Recorder {
       : MAX_BROWSER_DEFAULT_FETCH_SIZE;
 
     if (contentLen < 0 || contentLen > maxFetchSize) {
-      logger.warn(
+      logger.debug(
         "Large/unknown resource fetch",
         { url, contentLen, contentType, resourceType },
         "recorder",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -326,7 +326,7 @@ export class Recorder {
       if (!this.shouldSkip(headers, url, method, type)) {
         const reqresp = this.pendingReqResp(requestId);
         if (reqresp) {
-          reqresp.fillRequest(request);
+          reqresp.fillRequest(request, type || "");
         }
       }
     }

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -86,7 +86,7 @@ export class RequestResponseInfo {
     this.frameId = params.frameId;
   }
 
-  fillRequest(request: Protocol.Network.Request, resourceType?: string) {
+  fillRequest(request: Protocol.Network.Request, resourceType: string) {
     this.url = request.url;
     this.method = request.method;
     if (!this.requestHeaders) {


### PR DESCRIPTION
- due to a typo (and lack of type-checking!) incorrectly passed in matchFetchSize instead of maxFetchSize, resulting in text/css/js for >5MB instead of >25MB not properly streamed back to the browser
- add type checking to AsyncFetcherOptions to avoid this in the future.
- refactor to avoid checking size altogether for 'essential resources', html(document), js and css, instead always fetch them fully and continue in the browser. Only apply rewriting if <25MB.
- fixes #522