### PR TITLE
qa/replay crawl loading improvements

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1804,9 +1804,9 @@ self.__bx_behaviors.selectMainBehavior();
 
     if (this.params.postLoadDelay) {
       logger.info("Awaiting post load delay", {
-        seconds: this.params.pagePostLoadDelay,
+        seconds: this.params.postLoadDelay,
       });
-      await sleep(this.params.pagePostLoadDelay);
+      await sleep(this.params.postLoadDelay);
     }
 
     // skip extraction if at max depth

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -268,7 +268,7 @@ export class ReplayCrawler extends Crawler {
       if (this.limitHit) {
         break;
       }
-      this._addPageIfInScope(entry, depth++);
+      await this._addPageIfInScope(entry, depth++);
     }
   }
 

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -329,7 +329,7 @@ export class ReplayCrawler extends Crawler {
             try {
               frame.evaluate("window.location.reload();");
             } catch (e) {
-              logger.error("RWP Reload failed, retrying", e, "replay");
+              logger.error("RWP Reload failed", e, "replay");
             }
           }, 10000);
           this.reloadTimeouts.set(page, timeoutid);

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -538,10 +538,12 @@ export class ReplayCrawler extends Crawler {
         path.join(dir, `${counter}-${workerid}-${pageid}-replay.png`),
         PNG.sync.write(replay),
       );
-      await fsp.writeFile(
-        path.join(dir, `${counter}-${workerid}-${pageid}-vdiff.png`),
-        PNG.sync.write(diff),
-      );
+      if (res && matchPercent < 1) {
+        await fsp.writeFile(
+          path.join(dir, `${counter}-${workerid}-${pageid}-vdiff.png`),
+          PNG.sync.write(diff),
+        );
+      }
     }
 
     const pageInfo = this.pageInfos.get(page);

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -500,26 +500,25 @@ export class ReplayCrawler extends Crawler {
     const replay = PNG.sync.read(screenshotView);
 
     const { width, height } = replay;
-    const diff = new PNG({ width, height });
+    const diffImage = new PNG({ width, height });
 
-    const res = pixelmatch(crawl.data, replay.data, diff.data, width, height, {
-      threshold: 0.1,
-      alpha: 0,
-    });
+    const diff = pixelmatch(
+      crawl.data,
+      replay.data,
+      diffImage.data,
+      width,
+      height,
+      {
+        threshold: 0.1,
+        alpha: 0,
+      },
+    );
 
     const total = width * height;
 
-    const matchPercent = (total - res) / total;
+    const matchPercent = (total - diff) / total;
 
-    logger.info(
-      "Screenshot Diff",
-      {
-        url,
-        diff: res,
-        matchPercent,
-      },
-      "replay",
-    );
+    logger.info("Screenshot Diff", { url, diff, matchPercent }, "replay");
 
     if (this.params.qaDebugImageDiff) {
       const dir = path.join(this.collDir, "screenshots");
@@ -538,10 +537,10 @@ export class ReplayCrawler extends Crawler {
         path.join(dir, `${counter}-${workerid}-${pageid}-replay.png`),
         PNG.sync.write(replay),
       );
-      if (res && matchPercent < 1) {
+      if (diff && matchPercent < 1) {
         await fsp.writeFile(
           path.join(dir, `${counter}-${workerid}-${pageid}-vdiff.png`),
-          PNG.sync.write(diff),
+          PNG.sync.write(diffImage),
         );
       }
     }

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -560,8 +560,13 @@ class ArgParser {
   parseArgs(argvParams?: string[], isQA = false) {
     let argv = argvParams || process.argv;
 
-    if (process.env.CRAWL_ARGS) {
-      argv = argv.concat(this.splitCrawlArgsQuoteSafe(process.env.CRAWL_ARGS));
+    const envArgs =
+      isQA && process.env.QA_ARGS
+        ? process.env.QA_ARGS
+        : process.env.CRAWL_ARGS;
+
+    if (envArgs) {
+      argv = argv.concat(this.splitCrawlArgsQuoteSafe(envArgs));
     }
 
     let origConfig = {};
@@ -609,6 +614,7 @@ class ArgParser {
     const behaviorOpts: { [key: string]: string | boolean } = {};
     argv.behaviors.forEach((x: string) => (behaviorOpts[x] = true));
     behaviorOpts.log = BEHAVIOR_LOG_FUNC;
+    behaviorOpts.startEarly = true;
     argv.behaviorOpts = JSON.stringify(behaviorOpts);
 
     argv.text = argv.text || [];

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -49,8 +49,8 @@ export class ScopedSeed {
       throw new Error("Invalid URL");
     }
     this.url = parsedUrl.href;
-    this.include = this.parseRx(include);
-    this.exclude = this.parseRx(exclude);
+    this.include = parseRx(include);
+    this.exclude = parseRx(exclude);
     this.scopeType = scopeType;
 
     this._includeStr = include;
@@ -79,16 +79,6 @@ export class ScopedSeed {
     this.allowHash = allowHash;
     this.maxExtraHops = extraHops;
     this.maxDepth = depth < 0 ? MAX_DEPTH : depth;
-  }
-
-  parseRx(value: string[] | RegExp[] | string | null | undefined) {
-    if (value === null || value === undefined || value === "") {
-      return [];
-    } else if (!(value instanceof Array)) {
-      return [new RegExp(value)];
-    } else {
-      return value.map((e) => (e instanceof RegExp ? e : new RegExp(e)));
-    }
   }
 
   newScopedSeed(url: string) {
@@ -287,4 +277,16 @@ export function rxEscape(string: string) {
 
 export function urlRxEscape(url: string, parsedUrl: URL) {
   return rxEscape(url).replace(parsedUrl.protocol, "https?:");
+}
+
+export function parseRx(
+  value: string[] | RegExp[] | string | null | undefined,
+) {
+  if (value === null || value === undefined || value === "") {
+    return [];
+  } else if (!(value instanceof Array)) {
+    return [new RegExp(value)];
+  } else {
+    return value.map((e) => (e instanceof RegExp ? e : new RegExp(e)));
+  }
 }


### PR DESCRIPTION
- use frame.load() to load RWP frame directly instead of waiting for navigation messages
- retry loading RWP if replay frame is missing
- support --postLoadDelay in replay crawl
- support --include / --exclude options in replay crawler, allow excluding and including pages to QA via regex
- improve --qaDebugImageDiff debug image saving, save images to same dir, using ${counter}-${workerid}-${pageid}-{crawl,replay,vdiff}.png for better sorting
- when running QA crawl, check and use QA_ARGS instead of CRAWL_ARGS if provided
- ensure info.warc.gz is closed in closeFiles()

misc:
- fix typo in --postLoadDelay check!
- enable 'startEarly' mode for behaviors (autofetch, autoplay)