### PR TITLE
ensure all warcwriter write operations go through a queue.

### DIFF
--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -675,7 +675,7 @@ export class ReplayCrawler extends Crawler {
         (state as ComparisonPageState).comparison = comparison;
       }
 
-      await this.infoWriter?.writeNewResourceRecord({
+      this.infoWriter?.writeNewResourceRecord({
         buffer: new TextEncoder().encode(JSON.stringify(pageInfo, null, 2)),
         resourceType: "pageinfo",
         contentType: "application/json",

--- a/src/util/screenshots.ts
+++ b/src/util/screenshots.ts
@@ -74,7 +74,7 @@ export class Screenshots {
       if (state && screenshotType === "view") {
         state.screenshotView = screenshotBuffer;
       }
-      await this.writer.writeNewResourceRecord({
+      this.writer.writeNewResourceRecord({
         buffer: screenshotBuffer,
         resourceType: screenshotType,
         contentType: "image/" + options.type,
@@ -106,7 +106,7 @@ export class Screenshots {
         // 16:9 thumbnail
         .resize(640, 360)
         .toBuffer();
-      await this.writer.writeNewResourceRecord({
+      this.writer.writeNewResourceRecord({
         buffer: thumbnailBuffer,
         resourceType: screenshotType,
         contentType: "image/" + options.type,

--- a/src/util/textextract.ts
+++ b/src/util/textextract.ts
@@ -43,7 +43,7 @@ export abstract class BaseTextExtract {
         return { changed: false, text };
       }
       if (saveToWarc) {
-        await this.writer.writeNewResourceRecord({
+        this.writer.writeNewResourceRecord({
           buffer: new TextEncoder().encode(text),
           resourceType,
           contentType: "text/plain",


### PR DESCRIPTION
Currently, only the recorder's WARCWriter writes records through a queue, resulting in other WARCs potentially suffering from concurrent write attempts. This fixes that by:
- adding the concurrent queue to WARCWriter itself
- all writeRecord, writeRecordPair, writeNewResourceRecord calls are first added to the PQueue, which ensures writes happen in order and one-at-a-time
- flush() also ensures queue is empty/idle
- should avoid any issues with concurrent writes to any WARC