### PR TITLE
Adblock support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,10 @@ ADD config/ /app/
 
 ADD html/ /app/html/
 
-ARG RWP_VERSION=1.8.15
+ARG RWP_VERSION=2.0.0
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/ui.js /app/html/rwp/
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/sw.js /app/html/rwp/
+ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/adblock/adblock.gz /app/html/rwp/adblock.gz
 
 RUN chmod a+x /app/dist/main.js /app/dist/create-login-profile.js && chmod a+r /app/html/rwp/*
 

--- a/html/replay.html
+++ b/html/replay.html
@@ -33,6 +33,7 @@
       url="about:blank"
       ts=""
       coll="replay"
+      useAdblock
     >
     </replay-web-page>
   </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.1.0-beta.4",
+  "version": "1.1.0-beta.5",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/util/replayserver.ts
+++ b/src/util/replayserver.ts
@@ -16,6 +16,11 @@ const uiJS = fs.readFileSync(new URL("../../html/rwp/ui.js", import.meta.url), {
   encoding: "utf8",
 });
 
+const adblockGZ = fs.readFileSync(
+  new URL("../../html/rwp/adblock.gz", import.meta.url),
+  {},
+);
+
 // ============================================================================
 const PORT = 9990;
 
@@ -76,9 +81,7 @@ export class ReplayServer {
         return;
 
       case "/sw.js":
-      case "/sw.js?serveIndex=1":
       case "/replay/sw.js":
-      case "/replay/sw.js?serveIndex=1":
         response.writeHead(200, { "Content-Type": "application/javascript" });
         response.end(swJS);
         return;
@@ -86,6 +89,11 @@ export class ReplayServer {
       case "/ui.js":
         response.writeHead(200, { "Content-Type": "application/javascript" });
         response.end(uiJS);
+        return;
+
+      case "/replay/adblock/adblock.gz":
+        response.writeHead(200, { "Content-Type": "application/gzip" });
+        response.end(adblockGZ);
         return;
 
       case this.sourceUrl:


### PR DESCRIPTION
Now that RWP 2.0.0 with adblock support has been released (webrecorder/replayweb.page#307), this enables adblock on the QA mode RWP embed, to get more accurate screenshots.
Fetches the adblock.gz directly from RWP (though could also fetch it separately from Easylist)
Updates to 1.1.0-beta.5

To test: QA a crawl that was crawled with ad-blocking (eg. a site like cnn.com) and verify that ads are being blocked in screenshots / via screencasting.