### PR TITLE
Separate writing pages to pages.jsonl + extraPages.jsonl to use with new py-wacz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-#wacz>=0.4.9
-git+https://github.com/webrecorder/py-wacz@copy-pages-files
+wacz>=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-wacz>=0.4.9
+#wacz>=0.4.9
+git+https://github.com/webrecorder/py-wacz@copy-pages-files

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1281,8 +1281,11 @@ self.__bx_behaviors.selectMainBehavior();
 
     await this.crawlState.setStatus("running");
 
-    this.pagesFH = await this.initPages(true);
-    this.extraPagesFH = await this.initPages(false);
+    this.pagesFH = await this.initPages(this.seedPagesFile, "Seed Pages");
+    this.extraPagesFH = await this.initPages(
+      this.otherPagesFile,
+      "Non-Seed Pages",
+    );
 
     this.adBlockRules = new AdBlockRules(
       this.captureBasePrefix,
@@ -1517,12 +1520,12 @@ self.__bx_behaviors.selectMainBehavior();
 
     const createArgs = [
       "create",
-      "--split-seeds",
+      //"--split-seeds",
       "-o",
       waczPath,
       "--pages",
       this.seedPagesFile,
-      "--extraPages",
+      "--extra-pages",
       this.otherPagesFile,
       "--copy-pages",
       "--log-directory",
@@ -2057,8 +2060,7 @@ self.__bx_behaviors.selectMainBehavior();
     return false;
   }
 
-  async initPages(seedPages: boolean) {
-    const filename = seedPages ? this.seedPagesFile : this.otherPagesFile;
+  async initPages(filename: string, title: string) {
     let fh = null;
 
     try {
@@ -2072,7 +2074,7 @@ self.__bx_behaviors.selectMainBehavior();
         const header: Record<string, string> = {
           format: "json-pages-1.0",
           id: "pages",
-          title: seedPages ? "Seed Pages" : "Non-Seed Pages",
+          title,
         };
         header.hasText = this.params.text.includes("to-pages");
         if (this.params.text.length) {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1520,7 +1520,6 @@ self.__bx_behaviors.selectMainBehavior();
 
     const createArgs = [
       "create",
-      //"--split-seeds",
       "-o",
       waczPath,
       "--pages",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2115,7 +2115,11 @@ self.__bx_behaviors.selectMainBehavior();
     let { ts } = state;
     if (!ts) {
       ts = new Date();
-      logger.warn("Page date missing, setting to now", { url, ts });
+      logger.warn(
+        "Page date missing, setting to now",
+        { url, ts },
+        "pageStatus",
+      );
     }
 
     row.ts = ts.toISOString();
@@ -2151,14 +2155,18 @@ self.__bx_behaviors.selectMainBehavior();
     const pagesFH = depth > 0 ? this.extraPagesFH : this.pagesFH;
 
     if (!pagesFH) {
-      logger.error("Can't write pages, missing stream");
+      logger.error("Can't write pages, missing stream", {}, "pageStatus");
       return;
     }
 
     try {
       await pagesFH.write(processedRow);
     } catch (err) {
-      logger.warn("pages/pages.jsonl append failed");
+      logger.warn(
+        "Page append failed",
+        { pagesFile: depth > 0 ? this.otherPagesFile : this.seedPagesFile },
+        "pageStatus",
+      );
     }
   }
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1521,7 +1521,10 @@ self.__bx_behaviors.selectMainBehavior();
       "-o",
       waczPath,
       "--pages",
-      this.pagesFile,
+      this.seedPagesFile,
+      "--extraPages",
+      this.otherPagesFile,
+      "--copy-pages",
       "--log-directory",
       this.logDir,
     ];

--- a/tests/custom_driver.test.js
+++ b/tests/custom_driver.test.js
@@ -24,13 +24,29 @@ test("ensure custom driver with custom selector crawls JS files as pages", async
     pages.add(url);
   }
 
-  console.log(pages);
+  const crawledExtraPages = fs.readFileSync(
+    "test-crawls/collections/custom-driver-1/pages/extraPages.jsonl",
+    "utf8",
+  );
+  const extraPages = new Set();
+
+  for (const line of crawledExtraPages.trim().split("\n")) {
+    const url = JSON.parse(line).url;
+    if (!url) {
+      continue;
+    }
+    extraPages.add(url);
+  }
 
   const expectedPages = new Set([
     "https://www.iana.org/",
+  ]);
+
+  const expectedExtraPages = new Set([
     "https://www.iana.org/_js/jquery.js",
     "https://www.iana.org/_js/iana.js",
   ]);
 
   expect(pages).toEqual(expectedPages);
+  expect(extraPages).toEqual(expectedExtraPages);
 });

--- a/tests/extra_hops_depth.test.js
+++ b/tests/extra_hops_depth.test.js
@@ -24,8 +24,17 @@ test(
     );
     const crawledPagesArray = crawledPages.trim().split("\n");
 
+    const crawledExtraPages = fs.readFileSync(
+      "test-crawls/collections/extra-hops-beyond/pages/extraPages.jsonl",
+      "utf8",
+    );
+    const crawledExtraPagesArray = crawledExtraPages.trim().split("\n");
+
     const expectedPages = [
       "https://webrecorder.net/",
+    ];
+
+    const expectedExtraPages = [
       "https://webrecorder.net/blog",
       "https://webrecorder.net/tools",
       "https://webrecorder.net/community",
@@ -36,6 +45,7 @@ test(
 
     // first line is the header, not page, so adding -1
     expect(crawledPagesArray.length - 1).toEqual(expectedPages.length);
+    expect(crawledExtraPagesArray.length - 1).toEqual(expectedExtraPages.length);
 
     for (const page of crawledPagesArray) {
       const url = JSON.parse(page).url;
@@ -43,6 +53,14 @@ test(
         continue;
       }
       expect(expectedPages.indexOf(url) >= 0).toBe(true);
+    }
+
+    for (const page of crawledExtraPagesArray) {
+      const url = JSON.parse(page).url;
+      if (!url) {
+        continue;
+      }
+      expect(expectedExtraPages.indexOf(url) >= 0).toBe(true);
     }
   },
   extraHopsTimeout,

--- a/tests/saved-state.test.js
+++ b/tests/saved-state.test.js
@@ -6,6 +6,7 @@ import Redis from "ioredis";
 
 
 const pagesFile = "test-crawls/collections/int-state-test/pages/pages.jsonl";
+const extraPagesFile = "test-crawls/collections/int-state-test/pages/extraPages.jsonl";
 
 
 function sleep(ms) {
@@ -159,12 +160,20 @@ test("check crawl restarted with saved state", async () => {
   }
 });
 
-test("ensure correct number of pages was written", () => {
+test("ensure correct number of pages was written to pages + extraPages", () => {
   const pages = fs
     .readFileSync(pagesFile, { encoding: "utf-8" })
     .trim()
     .split("\n");
 
   // first line is the header
-  expect(pages.length).toBe(10 + 1);
+  expect(pages.length).toBe(2);
+
+  const extraPages = fs
+    .readFileSync(extraPagesFile, { encoding: "utf-8" })
+    .trim()
+    .split("\n");
+
+  // first line is the header
+  expect(extraPages.length).toBe(10);
 });

--- a/tests/sitemap-parse.test.js
+++ b/tests/sitemap-parse.test.js
@@ -64,7 +64,7 @@ async function runCrawl(numExpected, url, sitemap="", limit=0, numExpectedLessTh
 }
 
 test("test sitemap fully finish", async () => {
-  await runCrawl(8036, "https://www.mozilla.org/", "", 0);
+  await runCrawl(7000, "https://www.mozilla.org/", "", 0);
 });
 
 test("test sitemap with limit", async () => {


### PR DESCRIPTION
Cherry-picked from the use-js-wacz branch, now implementing separate writing of pages.jsonl / extraPages.jsonl to be used with py-wacz and new `--copy-page-files` flag.

Dependent on webrecorder/py-wacz#43