### PR TITLE
Better logging of all queue WARCWriter operations

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -31,7 +31,7 @@ import {
 import { ScreenCaster, WSTransport } from "./util/screencaster.js";
 import { Screenshots } from "./util/screenshots.js";
 import { initRedis } from "./util/redis.js";
-import { logger, formatErr } from "./util/logger.js";
+import { logger, formatErr, LogDetails } from "./util/logger.js";
 import {
   WorkerOpts,
   WorkerState,
@@ -88,9 +88,6 @@ const POST_CRAWL_STATES = [
   "generate-cdx",
   "generate-warc",
 ];
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type LogDetails = Record<string, any>;
 
 type PageEntry = {
   id: string;

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -756,6 +756,7 @@ export class ReplayCrawler extends Crawler {
           url: pageInfo.url,
         },
         { type: "pageinfo", url: pageInfo.url },
+        "replay",
       );
 
       this.pageInfos.delete(page);

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -748,12 +748,15 @@ export class ReplayCrawler extends Crawler {
         (state as ComparisonPageState).comparison = comparison;
       }
 
-      this.infoWriter?.writeNewResourceRecord({
-        buffer: new TextEncoder().encode(JSON.stringify(pageInfo, null, 2)),
-        resourceType: "pageinfo",
-        contentType: "application/json",
-        url: pageInfo.url,
-      });
+      this.infoWriter?.writeNewResourceRecord(
+        {
+          buffer: new TextEncoder().encode(JSON.stringify(pageInfo, null, 2)),
+          resourceType: "pageinfo",
+          contentType: "application/json",
+          url: pageInfo.url,
+        },
+        { type: "pageinfo", url: pageInfo.url },
+      );
 
       this.pageInfos.delete(page);
     }

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -9,6 +9,9 @@ Object.defineProperty(RegExp.prototype, "toJSON", {
   value: RegExp.prototype.toString,
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type LogDetails = Record<string, any>;
+
 // ===========================================================================
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function formatErr(e: unknown): Record<string, any> {

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -733,6 +733,7 @@ export class Recorder {
         url,
       },
       { type: "pageinfo", url },
+      "recorder",
     );
 
     return this.pageInfo.ts;

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -725,12 +725,15 @@ export class Recorder {
 
     const url = this.pageUrl;
 
-    this.writer.writeNewResourceRecord({
-      buffer: new TextEncoder().encode(text),
-      resourceType: "pageinfo",
-      contentType: "application/json",
-      url,
-    });
+    this.writer.writeNewResourceRecord(
+      {
+        buffer: new TextEncoder().encode(text),
+        resourceType: "pageinfo",
+        contentType: "application/json",
+        url,
+      },
+      { type: "pageinfo", url },
+    );
 
     return this.pageInfo.ts;
   }

--- a/src/util/screenshots.ts
+++ b/src/util/screenshots.ts
@@ -81,7 +81,13 @@ export class Screenshots {
           contentType: "image/" + options.type,
           url: this.url,
         },
-        { type: screenshotType, url: this.url, filename: this.writer.filename },
+        {
+          resource: "screenshot",
+          type: screenshotType,
+          url: this.url,
+          filename: this.writer.filename,
+        },
+        "screenshots",
       );
       // logger.info(
       //   `Screenshot (type: ${screenshotType}) for ${this.url} written to ${this.writer.filename}`,
@@ -116,11 +122,14 @@ export class Screenshots {
           contentType: "image/" + options.type,
           url: this.url,
         },
-        { type: screenshotType, url: this.url, filename: this.writer.filename },
+        {
+          resource: "screenshot",
+          type: screenshotType,
+          url: this.url,
+          filename: this.writer.filename,
+        },
+        "screenshots",
       );
-      // logger.info(
-      //   `Screenshot (type: thumbnail) for ${this.url} written to ${this.writer.filename}`,
-      // );
     } catch (e) {
       logger.error(
         "Taking screenshot failed",

--- a/src/util/screenshots.ts
+++ b/src/util/screenshots.ts
@@ -74,15 +74,18 @@ export class Screenshots {
       if (state && screenshotType === "view") {
         state.screenshotView = screenshotBuffer;
       }
-      this.writer.writeNewResourceRecord({
-        buffer: screenshotBuffer,
-        resourceType: screenshotType,
-        contentType: "image/" + options.type,
-        url: this.url,
-      });
-      logger.info(
-        `Screenshot (type: ${screenshotType}) for ${this.url} written to ${this.writer.filename}`,
+      this.writer.writeNewResourceRecord(
+        {
+          buffer: screenshotBuffer,
+          resourceType: screenshotType,
+          contentType: "image/" + options.type,
+          url: this.url,
+        },
+        { type: screenshotType, url: this.url, filename: this.writer.filename },
       );
+      // logger.info(
+      //   `Screenshot (type: ${screenshotType}) for ${this.url} written to ${this.writer.filename}`,
+      // );
     } catch (e) {
       logger.error(
         "Taking screenshot failed",
@@ -106,15 +109,18 @@ export class Screenshots {
         // 16:9 thumbnail
         .resize(640, 360)
         .toBuffer();
-      this.writer.writeNewResourceRecord({
-        buffer: thumbnailBuffer,
-        resourceType: screenshotType,
-        contentType: "image/" + options.type,
-        url: this.url,
-      });
-      logger.info(
-        `Screenshot (type: thumbnail) for ${this.url} written to ${this.writer.filename}`,
+      this.writer.writeNewResourceRecord(
+        {
+          buffer: thumbnailBuffer,
+          resourceType: screenshotType,
+          contentType: "image/" + options.type,
+          url: this.url,
+        },
+        { type: screenshotType, url: this.url, filename: this.writer.filename },
       );
+      // logger.info(
+      //   `Screenshot (type: thumbnail) for ${this.url} written to ${this.writer.filename}`,
+      // );
     } catch (e) {
       logger.error(
         "Taking screenshot failed",

--- a/src/util/textextract.ts
+++ b/src/util/textextract.ts
@@ -43,15 +43,18 @@ export abstract class BaseTextExtract {
         return { changed: false, text };
       }
       if (saveToWarc) {
-        this.writer.writeNewResourceRecord({
-          buffer: new TextEncoder().encode(text),
-          resourceType,
-          contentType: "text/plain",
-          url: this.url,
-        });
-        logger.debug(
-          `Text Extracted (type: ${resourceType}) for ${this.url} written to ${this.writer.filename}`,
+        this.writer.writeNewResourceRecord(
+          {
+            buffer: new TextEncoder().encode(text),
+            resourceType,
+            contentType: "text/plain",
+            url: this.url,
+          },
+          { type: resourceType, url: this.url, filename: this.writer.filename },
         );
+        // logger.debug(
+        //   `Text Extracted (type: ${resourceType}) for ${this.url} written to ${this.writer.filename}`,
+        // );
       }
 
       this.lastText = text;

--- a/src/util/textextract.ts
+++ b/src/util/textextract.ts
@@ -50,11 +50,14 @@ export abstract class BaseTextExtract {
             contentType: "text/plain",
             url: this.url,
           },
-          { type: resourceType, url: this.url, filename: this.writer.filename },
+          {
+            resource: "text",
+            type: resourceType,
+            url: this.url,
+            filename: this.writer.filename,
+          },
+          "text",
         );
-        // logger.debug(
-        //   `Text Extracted (type: ${resourceType}) for ${this.url} written to ${this.writer.filename}`,
-        // );
       }
 
       this.lastText = text;

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -118,7 +118,7 @@ export class WARCWriter implements IndexerOffsetLength {
     requestRecord: WARCRecord,
     responseSerializer: WARCSerializer | undefined = undefined,
   ) {
-    this.addToQueue(
+    this.addToQueue(() =>
       this._writeRecordPair(responseRecord, requestRecord, responseSerializer),
     );
   }
@@ -151,12 +151,12 @@ export class WARCWriter implements IndexerOffsetLength {
   }
 
   private addToQueue(
-    promise: Promise<void>,
+    func: () => Promise<void>,
     details: LogDetails | null = null,
   ) {
     this.warcQ.add(async () => {
       try {
-        await promise;
+        await func();
         if (details) {
           logger.debug("WARC Record Written", details, "writer");
         }
@@ -171,7 +171,7 @@ export class WARCWriter implements IndexerOffsetLength {
   }
 
   writeSingleRecord(record: WARCRecord) {
-    this.addToQueue(this._writeSingleRecord(record));
+    this.addToQueue(() => this._writeSingleRecord(record));
   }
 
   private async _writeSingleRecord(record: WARCRecord) {
@@ -185,7 +185,7 @@ export class WARCWriter implements IndexerOffsetLength {
   }
 
   writeNewResourceRecord(record: ResourceRecordData, details: LogDetails) {
-    this.addToQueue(this._writeNewResourceRecord(record), details);
+    this.addToQueue(() => this._writeNewResourceRecord(record), details);
   }
 
   private async _writeNewResourceRecord({


### PR DESCRIPTION
warcwriter operations result in a write promise being put on a queue, and handled one-at-a-time.

This PR wraps that promise in an async function that awaits the actual write and logs any rejections.
If an additional logdetails is provided, successful writes are also logged
for now, including success logging for resource records (text, screenshot, pageinfo)
