### PR TITLE
qa: filter out non-html pages

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1756,6 +1756,10 @@ self.__bx_behaviors.selectMainBehavior();
       const contentType = resp.headers()["content-type"];
 
       isHTMLPage = this.isHTMLContentType(contentType);
+
+      if (!isHTMLPage) {
+        data.mime = contentType.split(";")[0];
+      }
     } catch (e) {
       if (!(e instanceof Error)) {
         throw e;

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -41,6 +41,7 @@ type ReplayPage = {
   url: string;
   ts: number;
   id: string;
+  mime?: string;
 };
 
 type ComparisonData = {
@@ -234,7 +235,12 @@ export class ReplayCrawler extends Crawler {
     }
   }
 
-  async _addPageIfInScope({ url, ts, id }: ReplayPage, depth: number) {
+  async _addPageIfInScope({ url, ts, id, mime }: ReplayPage, depth: number) {
+    if (mime && mime !== "text/html") {
+      logger.info("Skipping non-HTML page", { url, mime }, "replay");
+      return;
+    }
+
     if (this.includeRx.length) {
       let inScope = false;
       for (const s of this.includeRx) {


### PR DESCRIPTION
Fixes #540 

Also ensure mime type is set on page for non-html pages when loaded through browser, already being set for direct fetch path.

Testing: Can test with a WACZ of a site with non-HTML pages