### PR TITLE
Fix for --rolloverSize for individual WARCs in 1.x

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -454,7 +454,7 @@ export class Crawler {
     await fsp.mkdir(this.tempdir, { recursive: true });
     await fsp.mkdir(this.tempCdxDir, { recursive: true });
 
-    this.logFH = fs.createWriteStream(this.logFilename);
+    this.logFH = fs.createWriteStream(this.logFilename, { flags: "a" });
     logger.setExternalLogStream(this.logFH);
 
     this.infoString = await getInfoString();
@@ -2484,7 +2484,7 @@ self.__bx_behaviors.selectMainBehavior();
   }
 
   createExtraResourceWarcWriter(resourceName: string, gzip = true) {
-    const filenameBase = `${this.getWarcPrefix()}${resourceName}`;
+    const filenameBase = `${this.getWarcPrefix()}${resourceName}-$ts`;
 
     return this.createWarcWriter(filenameBase, gzip, { resourceName });
   }

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -85,14 +85,15 @@ export class WARCWriter implements IndexerOffsetLength {
   private async initFH() {
     if (this.filename && this.offset >= this.rolloverSize) {
       const oldFilename = this.filename;
+      const size = this.offset;
       this.filename = this._initNewFile();
       logger.info(
         `Rollover size exceeded, creating new WARC`,
         {
+          size,
           oldFilename,
           newFilename: this.filename,
           rolloverSize: this.rolloverSize,
-          size: this.offset,
           ...this.logDetails,
         },
         "writer",

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -83,18 +83,21 @@ export class WARCWriter implements IndexerOffsetLength {
   }
 
   private async initFH() {
-    if (this.offset >= this.rolloverSize) {
+    if (this.filename && this.offset >= this.rolloverSize) {
+      const oldFilename = this.filename;
+      this.filename = this._initNewFile();
       logger.info(
         `Rollover size exceeded, creating new WARC`,
         {
+          oldFilename,
+          newFilename: this.filename,
           rolloverSize: this.rolloverSize,
           size: this.offset,
           ...this.logDetails,
         },
         "writer",
       );
-      this.filename = this._initNewFile();
-      this.cdxFH = null;
+      await this._close();
     } else if (!this.filename) {
       this.filename = this._initNewFile();
     }
@@ -102,11 +105,14 @@ export class WARCWriter implements IndexerOffsetLength {
     let fh = this.fh;
 
     if (!fh) {
-      fh = fs.createWriteStream(path.join(this.archivesDir, this.filename));
+      fh = fs.createWriteStream(path.join(this.archivesDir, this.filename), {
+        flags: "a",
+      });
     }
     if (!this.cdxFH && this.tempCdxDir) {
       this.cdxFH = fs.createWriteStream(
         path.join(this.tempCdxDir, this.filename + ".cdx"),
+        { flags: "a" },
       );
     }
 
@@ -243,7 +249,7 @@ export class WARCWriter implements IndexerOffsetLength {
     let total = 0;
     const url = record.warcTargetURI;
 
-    if (!this.fh) {
+    if (!this.fh || this.offset >= this.rolloverSize) {
       this.fh = await this.initFH();
     }
 
@@ -280,9 +286,7 @@ export class WARCWriter implements IndexerOffsetLength {
     this.offset += this.recordLength;
   }
 
-  async flush() {
-    await this.warcQ.onIdle();
-
+  private async _close() {
     if (this.fh) {
       await streamFinish(this.fh);
       this.fh = null;
@@ -294,6 +298,12 @@ export class WARCWriter implements IndexerOffsetLength {
       await streamFinish(this.cdxFH);
       this.cdxFH = null;
     }
+  }
+
+  async flush() {
+    await this.warcQ.onIdle();
+
+    await this._close();
 
     this.done = true;
   }

--- a/tests/rollover-writer.test.js
+++ b/tests/rollover-writer.test.js
@@ -1,0 +1,30 @@
+import child_process from "child_process";
+import fs from "fs";
+
+test("set rollover to 500K and ensure individual WARCs rollover, including screenshots", async () => {
+  child_process.execSync(
+    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --limit 5 --collection rollover-500K --rolloverSize 500000 --screenshot view"
+  );
+
+  const warcLists = fs.readdirSync("test-crawls/collections/rollover-500K/archive");
+
+  let main = 0;
+  let screenshots = 0;
+
+  console.log(warcLists);
+
+  for (const name of warcLists) {
+    if (name.startsWith("rec-")) {
+      main++;
+    } else if (name.startsWith("screenshots-")) {
+      screenshots++;
+    }
+  }
+
+  // expect at least 6 main WARCs
+  expect(main).toBeGreaterThan(5);
+
+  // expect at least 2 screenshot WARCs
+  expect(screenshots).toBeGreaterThan(1);
+
+});

--- a/tests/screenshot.test.js
+++ b/tests/screenshot.test.js
@@ -3,17 +3,27 @@ import fs from "fs";
 
 // screenshot
 
+function screenshotWarcExists(name) {
+  const warcList = fs.readdirSync(`test-crawls/collections/${name}/archive/`);
+
+  for (const warc of warcList) {
+    if (warc.startsWith("screenshots-")) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
 test("ensure basic crawl run with --screenshot passes", async () => {
   child_process.execSync(
-    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection test --url http://www.example.com/ --screenshot view --workers 2",
+    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection test-with-screenshots --url http://www.example.com/ --screenshot view --workers 2",
   );
 });
 
 test("check that a screenshots warc file exists in the test collection", () => {
-  const screenshotWarcExists = fs.existsSync(
-    "test-crawls/collections/test/archive/screenshots.warc.gz",
-  );
-  expect(screenshotWarcExists).toBe(true);
+  expect(screenshotWarcExists("test-with-screenshots")).toBe(true);
 });
 
 // fullPageScreenshot
@@ -25,10 +35,7 @@ test("ensure basic crawl run with --fullPageScreenshot passes", async () => {
 });
 
 test("check that a screenshots warc file exists in the fullpage collection", () => {
-  const screenshotWarcExists = fs.existsSync(
-    "test-crawls/collections/fullpage/archive/screenshots.warc.gz",
-  );
-  expect(screenshotWarcExists).toBe(true);
+  expect(screenshotWarcExists("fullpage")).toBe(true);
 });
 
 // thumbnail
@@ -40,10 +47,7 @@ test("ensure basic crawl run with --thumbnail passes", async () => {
 });
 
 test("check that a screenshots warc file exists in the thumbnail collection", () => {
-  const screenshotWarcExists = fs.existsSync(
-    "test-crawls/collections/thumbnail/archive/screenshots.warc.gz",
-  );
-  expect(screenshotWarcExists).toBe(true);
+  expect(screenshotWarcExists("thumbnail")).toBe(true);
 });
 
 // combination
@@ -55,10 +59,7 @@ test("ensure basic crawl run with multiple screenshot types and --generateWACZ p
 });
 
 test("check that a screenshots warc file exists in the combined collection", () => {
-  const screenshotWarcExists = fs.existsSync(
-    "test-crawls/collections/combined/archive/screenshots.warc.gz",
-  );
-  expect(screenshotWarcExists).toBe(true);
+  expect(screenshotWarcExists("combined")).toBe(true);
 });
 
 test("check that a wacz file exists in the combined collection", () => {


### PR DESCRIPTION
Fixes #533 

Fixes rollover in WARCWriter, separate from combined WARC rollover size:
- check rolloverSize and close previous WARCs when size exceeds
- add timestamp to resource WARC filenames to support rollover, eg. screenshots-{ts}.warc.gz
- use append mode for all write streams, just in case
- tests: add test for rollover of individual WARCs with 500K size limit
- tests: update screenshot tests to account for WARCs now being named screenshots-{ts}.warc.gz instead of just screenshots.warc.gz