### PR TITLE
allow minio to connect to other regions

### DIFF
--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -65,6 +65,7 @@ export class S3StorageSync {
       accessKey,
       secretKey,
       partSize: 100 * 1024 * 1024,
+      region: "auto",
     });
 
     this.bucketName = url.pathname.slice(1).split("/")[0];


### PR DESCRIPTION
This should address the issue of connecting to buckets stored outside us-east-1 (https://github.com/webrecorder/browsertrix-crawler/issues/515) while the switch from Minio client to AWS SDK is being worked on (https://github.com/webrecorder/browsertrix-crawler/issues/479)