### PR TITLE
Set mime type for html pages

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1754,7 +1754,7 @@ self.__bx_behaviors.selectMainBehavior();
 
       isHTMLPage = this.isHTMLContentType(contentType);
 
-      if (!isHTMLPage) {
+      if (contentType) {
         data.mime = contentType.split(";")[0];
       }
     } catch (e) {


### PR DESCRIPTION
Fixes #544 

As long as the response has a content-type header, we should use it to set MIME type for the page.