### PR TITLE
replay counts: don't filter out URLs with __wb_method to avoid dispar…

### DIFF
--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -648,9 +648,6 @@ export class ReplayCrawler extends Crawler {
       if (!url.startsWith("http")) {
         continue;
       }
-      if (url.indexOf("__wb_method") !== -1) {
-        continue;
-      }
       if (status >= 400) {
         bad++;
       } else {


### PR DESCRIPTION
…ity in replay/crawl counts, since

non-GET crawl requests are not filtered out