### PR TITLE
Support site-specific wait via browsertrix-behaviors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@novnc/novnc": "^1.4.0",
     "@types/sax": "^1.2.7",
     "@webrecorder/wabac": "^2.16.12",
-    "browsertrix-behaviors": "^0.5.3",
+    "browsertrix-behaviors": "^0.6.0",
     "crc": "^4.3.2",
     "get-folder-size": "^4.0.0",
     "husky": "^8.0.3",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1835,6 +1835,17 @@ self.__bx_behaviors.selectMainBehavior();
 
     await this.netIdle(page, logDetails);
 
+    logger.debug(
+      "Waiting for custom page load via behavior",
+      logDetails,
+      "behavior",
+    );
+    try {
+      await page.evaluate("self.__bx_behaviors.initialPageLoad();");
+    } catch (e) {
+      logger.warn("Waiting for custom page load failed", e, "behavior");
+    }
+
     if (this.params.postLoadDelay) {
       logger.info("Awaiting post load delay", {
         seconds: this.params.postLoadDelay,

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1835,23 +1835,7 @@ self.__bx_behaviors.selectMainBehavior();
 
     await this.netIdle(page, logDetails);
 
-    logger.debug(
-      "Waiting for custom page load via behavior",
-      logDetails,
-      "behavior",
-    );
-    try {
-      await page.evaluate("self.__bx_behaviors.initialPageLoad();");
-    } catch (e) {
-      logger.warn("Waiting for custom page load failed", e, "behavior");
-    }
-
-    if (this.params.postLoadDelay) {
-      logger.info("Awaiting post load delay", {
-        seconds: this.params.postLoadDelay,
-      });
-      await sleep(this.params.postLoadDelay);
-    }
+    await this.awaitPageLoad(page.mainFrame(), logDetails);
 
     // skip extraction if at max depth
     if (seed.isAtMaxDepth(depth) || !selectorOptsList) {
@@ -1879,6 +1863,26 @@ self.__bx_behaviors.selectMainBehavior();
     } catch (e) {
       logger.debug("waitForNetworkIdle timed out, ignoring", details);
       // ignore, continue
+    }
+  }
+
+  async awaitPageLoad(frame: Frame, logDetails: LogDetails) {
+    logger.debug(
+      "Waiting for custom page load via behavior",
+      logDetails,
+      "behavior",
+    );
+    try {
+      await frame.evaluate("self.__bx_behaviors.awaitPageLoad();");
+    } catch (e) {
+      logger.warn("Waiting for custom page load failed", e, "behavior");
+    }
+
+    if (this.params.postLoadDelay) {
+      logger.info("Awaiting post load delay", {
+        seconds: this.params.postLoadDelay,
+      });
+      await sleep(this.params.postLoadDelay);
     }
   }
 

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -438,27 +438,10 @@ export class ReplayCrawler extends Crawler {
       );
     }
 
-    logger.debug(
-      "Waiting for custom page load via behavior",
-      logDetails,
-      "behavior",
-    );
-    try {
-      await replayFrame.evaluate("self.__bx_behaviors.initialPageLoad();");
-    } catch (e) {
-      logger.warn("Waiting for custom page load failed", e, "behavior");
-    }
-
     // optionally reload (todo: reevaluate if this is needed)
     // await page.reload();
 
-    if (this.params.postLoadDelay) {
-      logger.info("Awaiting post load delay", {
-        ...logDetails,
-        seconds: this.params.postLoadDelay,
-      });
-      await sleep(this.params.postLoadDelay);
-    }
+    await this.awaitPageLoad(replayFrame, logDetails);
 
     data.isHTMLPage = true;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,10 +1663,10 @@ browserslist@^4.22.2:
     node-releases "^2.0.14"
     update-browserslist-db "^1.0.13"
 
-browsertrix-behaviors@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.5.3.tgz#f987075790b0fd970814f57195e8525277ddd2a0"
-  integrity sha512-NiVdV42xvj4DvX/z0Dxqzqsa+5e57/M7hIyK3fl41BxzOJqCgSMu0MpkrWuKpbRVo+89ZnBmzh2z6D18Vmn1LA==
+browsertrix-behaviors@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.6.0.tgz#e16345e4b414b18e6441548d517d01b4316f744e"
+  integrity sha512-BdfEPHmDjhEIFrn80UKnwGT6HRgnmq2shNybu8BEfAHJQsqZdvP/VVKWvNGnWML1jjUKiwtvtkdFhtHedFQkzA==
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
The 0.6.0 release of Browsertrix Behaviors / webrecorder/browsertrix-behaviors#70 introduces support for site-specific behaviors to implement an `awaitPageLoad()` function which allows for waiting for specific resources on the page load.

This PR just adds a call to this function directly after page load. This is to support custom loading for Instagram, and other sites in the future.


Testing:
- Build browsertrix-behaviors from branch / use `dist/behaviors.js` from PR
- Copy to behaviors.js
- Uncomment the COPY behaviors line in Dockerfile
- Build
- Run crawl with an instagram page.