### PR TITLE
Always add warcinfo records to all WARCs

### DIFF
--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -119,7 +119,7 @@ export class WARCWriter implements IndexerOffsetLength {
       );
     }
 
-    fh.write(createWARCInfo(this.filename));
+    fh.write(await createWARCInfo(this.filename));
 
     return fh;
   }

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -11,6 +11,8 @@ import PQueue from "p-queue";
 
 const DEFAULT_ROLLOVER_SIZE = 1_000_000_000;
 
+let warcInfo = {};
+
 export type ResourceRecordData = {
   buffer: Uint8Array;
   resourceType: string;
@@ -116,6 +118,8 @@ export class WARCWriter implements IndexerOffsetLength {
         { flags: "a" },
       );
     }
+
+    fh.write(createWARCInfo(this.filename));
 
     return fh;
   }
@@ -308,6 +312,33 @@ export class WARCWriter implements IndexerOffsetLength {
 
     this.done = true;
   }
+}
+
+// =================================================================
+export function setWARCInfo(
+  software: string,
+  otherParams?: Record<string, string>,
+) {
+  warcInfo = {
+    software,
+    format: "WARC File Format 1.1",
+    ...otherParams,
+  };
+}
+
+// =================================================================
+export async function createWARCInfo(filename: string) {
+  const warcVersion = "WARC/1.1";
+  const type = "warcinfo";
+
+  const record = await WARCRecord.createWARCInfo(
+    { filename, type, warcVersion },
+    warcInfo,
+  );
+  const buffer = await WARCSerializer.serialize(record, {
+    gzip: true,
+  });
+  return buffer;
 }
 
 // =================================================================

--- a/tests/warcinfo.test.js
+++ b/tests/warcinfo.test.js
@@ -1,8 +1,11 @@
 import fs from "fs";
 import zlib from "zlib";
+import path from "path";
 import child_process from "child_process";
 
-test("check that the warcinfo file works as expected on the command line", async () => {
+test("run crawl", async() => {
+  let success = false;
+
   try {
     const configYaml = fs.readFileSync("tests/fixtures/crawl-2.yaml", "utf8");
     const proc = child_process.execSync(
@@ -11,10 +14,42 @@ test("check that the warcinfo file works as expected on the command line", async
     );
 
     console.log(proc);
+    success = true;
   } catch (error) {
     console.log(error);
   }
 
+  expect(success).toBe(true);
+});
+
+test("check that the warcinfo for individual WARC is as expected", async () => {
+
+  const warcs = fs.readdirSync("test-crawls/collections/warcinfo/archive/");
+
+  let filename = "";
+
+  for (const name of warcs) {
+    if (name.startsWith("rec-")) {
+      filename = path.join("test-crawls/collections/warcinfo/archive/", name);
+      break;
+    }
+  }
+
+  const warcData = fs.readFileSync(filename);
+
+  const data = zlib.gunzipSync(warcData);
+
+  const string = data.toString("utf8");
+
+  expect(string.indexOf("operator: test")).toBeGreaterThan(-1);
+  expect(string.indexOf("host: hostname")).toBeGreaterThan(-1);
+  expect(
+    string.match(/Browsertrix-Crawler \d[\w.-]+ \(with warcio.js \d[\w.-]+\)/),
+  ).not.toEqual(null);
+  expect(string.indexOf("format: WARC File Format 1.1")).toBeGreaterThan(-1);
+});
+
+test("check that the warcinfo for combined WARC file is as expected", async () => {
   const warcData = fs.readFileSync(
     "test-crawls/collections/warcinfo/warcinfo_0.warc.gz",
   );
@@ -28,5 +63,5 @@ test("check that the warcinfo file works as expected on the command line", async
   expect(
     string.match(/Browsertrix-Crawler \d[\w.-]+ \(with warcio.js \d[\w.-]+\)/),
   ).not.toEqual(null);
-  expect(string.indexOf("format: WARC File Format 1.0")).toBeGreaterThan(-1);
+  expect(string.indexOf("format: WARC File Format 1.1")).toBeGreaterThan(-1);
 });


### PR DESCRIPTION
Fixes #553 

Includes `warcinfo` records at the beginning of new WARCs, as well as the combined WARC.
Makes the warcinfo record also WARC/1.1 to match the rest of the WARC records.