### PR TITLE
warcinfo: fix version to 1.1 to avoid confusion (part of #553)

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1090,12 +1090,12 @@ self.__bx_behaviors.selectMainBehavior();
   }
 
   async createWARCInfo(filename: string) {
-    const warcVersion = "WARC/1.0";
+    const warcVersion = "WARC/1.1";
     const type = "warcinfo";
 
     const info = {
       software: this.infoString,
-      format: "WARC File Format 1.0",
+      format: "WARC File Format 1.1",
     };
 
     const warcInfo = { ...info, ...this.params.warcInfo };

--- a/tests/warcinfo.test.js
+++ b/tests/warcinfo.test.js
@@ -28,5 +28,5 @@ test("check that the warcinfo file works as expected on the command line", async
   expect(
     string.match(/Browsertrix-Crawler \d[\w.-]+ \(with warcio.js \d[\w.-]+\)/),
   ).not.toEqual(null);
-  expect(string.indexOf("format: WARC File Format 1.0")).toBeGreaterThan(-1);
+  expect(string.indexOf("format: WARC File Format 1.1")).toBeGreaterThan(-1);
 });


### PR DESCRIPTION
Ensure warcinfo record is also WARC/1.1

Initial fix, follow up fix will be in #556 to add warcinfo for all WARCs