### PR TITLE
profiles: ensure all page.goto() promises have at least catch block/a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",


### PR DESCRIPTION
…re awaited, to handle possibly interruptions

(user closing browser, committing profile, etc..) without causing a crash.

In particular, an API call to /navigate starts, but doesn't wait for a page load to finish, since user can choose to close the profile browser at any time. This ensure that it doesn't cause the browser to crash if its interrupted while navigating.

bump to 1.1.1