### PR TITLE
improved handling of requests from workers:

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -504,14 +504,14 @@ export class Browser {
           recorder.swFrameIds.add(frameId);
         }
 
-        if (recorder.swFrameIds && recorder.swFrameIds.has(frameId)) {
+        if (recorder.hasFrame(frameId)) {
           foundRecorder = recorder;
           break;
         }
       }
 
       if (!foundRecorder) {
-        logger.debug(
+        logger.warn(
           "Skipping URL from unknown frame",
           { url: request.url, frameId },
           "recorder",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -117,6 +117,8 @@ export class Recorder {
   pageUrl!: string;
   pageid!: string;
 
+  frameIdToExecId: Map<string, number> | null;
+
   constructor({
     workerid,
     writer,
@@ -137,9 +139,19 @@ export class Recorder {
     this.tempdir = tempdir;
 
     this.fetcherQ = new PQueue({ concurrency: 1 });
+
+    this.frameIdToExecId = null;
   }
 
-  async onCreatePage({ cdp }: { cdp: CDPSession }) {
+  async onCreatePage({
+    cdp,
+    frameIdToExecId,
+  }: {
+    cdp: CDPSession;
+    frameIdToExecId: Map<string, number>;
+  }) {
+    this.frameIdToExecId = frameIdToExecId;
+
     // Fetch
     cdp.on("Fetch.requestPaused", async (params) => {
       this.handleRequestPaused(params, cdp);
@@ -217,6 +229,10 @@ export class Recorder {
     });
 
     await cdp.send("Console.enable");
+  }
+
+  hasFrame(frameId: string) {
+    return this.swFrameIds.has(frameId) || this.frameIdToExecId?.has(frameId);
   }
 
   handleResponseReceived(params: Protocol.Network.ResponseReceivedEvent) {
@@ -783,6 +799,7 @@ export class Recorder {
 
   async onClosePage() {
     // Any page-specific handling before page is closed.
+    this.frameIdToExecId = null;
   }
 
   async onDone(timeout: number) {


### PR DESCRIPTION
on sites with regular workers, requests from workers were being skipped as there was no match for the worker frameId
- add recorder.hasFrame() frameId to match not just service-worker frameIds but also other frame ids already tracked in the in frameIdToExecId map

Tests:
Fixes 'Skipping URL from unknown frame' on sites such as https://www.stadttunnel-zug-nein.ch/
Without this fix, many URLs result in this error, and this should eliminate that.