### PR TITLE
Adding support for HTTP Basic Auth

### DIFF
--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -144,6 +144,11 @@ Options:
                                             age behavior will run on each page.
                                             If 0, a behavior can run until finis
                                             h.            [number] [default: 90]
+      --postLoadDelay                       If >0, amount of time to sleep (in s
+                                            econds) after page has loaded, befor
+                                            e taking screenshots / getting text
+                                            / running behaviors
+                                                           [number] [default: 0]
       --pageExtraDelay, --delay             If >0, amount of time to sleep (in s
                                             econds) after behaviors before movin
                                             g on to next page
@@ -255,6 +260,10 @@ Options:
       --qaDebugImageDiff                    if specified, will write crawl.png,
                                             replay.png and diff.png for each pag
                                             e where they're different  [boolean]
+      --httpBasicAuth                       The colon separated username and pas
+                                            sword to use when prompted for HTTP
+                                            Basic Authentication credentials, e.
+                                            g. jane:abc123              [string]
       --config                              Path to YAML config file
 ```
 
@@ -269,7 +278,8 @@ Options:
                      ted
   --password         The password for the login. If not specified, will be promp
                      ted (recommended)
-  --filename         The filename for the profile tarball
+  --filename         The filename for the profile tarball, stored within /crawls
+                     /profiles if absolute path not provided
                                     [default: "/crawls/profiles/profile.tar.gz"]
   --debugScreenshot  If specified, take a screenshot after login and save as thi
                      s filename

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -319,6 +319,10 @@ export class Crawler {
       this.emulateDevice.userAgent += " " + this.params.userAgentSuffix;
     }
 
+    if (this.params.httpBasicAuth) {
+      this.emulateDevice.httpBasicAuth = this.params.httpBasicAuth;
+    }
+
     return this.emulateDevice.userAgent;
   }
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -554,6 +554,12 @@ class ArgParser {
           "if specified, will write crawl.png, replay.png and diff.png for each page where they're different",
         type: "boolean",
       },
+
+      httpBasicAuth: {
+        describe:
+          "The colon separated username and password to use when prompted for HTTP Basic Authentication credentials, e.g. jane:abc123",
+        type: "string",
+      },
     };
   }
 

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -465,6 +465,13 @@ export class Browser {
       } else if (device.userAgent) {
         await page.setUserAgent(device.userAgent);
       }
+
+      if (device.httpBasicAuth) {
+        // ideally we'd use page.authenticate here but it doesn't seem to work?
+        page.setExtraHTTPHeaders({
+          Authorization: "Basic " + btoa(device.httpBasicAuth),
+        });
+      }
     }
 
     const cdp = await target.createCDPSession();

--- a/tests/http_basicauth.test.js
+++ b/tests/http_basicauth.test.js
@@ -1,0 +1,15 @@
+import child_process from "child_process";
+import fs from "fs";
+
+test("test that http basic auth works", async () => {
+  child_process.execSync(
+    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://httpbin.org/basic-auth/foo/bar --httpBasicAuth foo:bar --collection basicauth-test --statsFilename stats.json',
+  );
+});
+
+test("check that the page didn't fail", () => {
+  const data = fs.readFileSync("test-crawls/stats.json", "utf8");
+  const dataJSON = JSON.parse(data);
+  expect(dataJSON.crawled).toEqual(1);
+  expect(dataJSON.failed).toEqual(0);
+});

--- a/tests/http_basicauth.test.js
+++ b/tests/http_basicauth.test.js
@@ -1,15 +1,29 @@
 import child_process from "child_process";
 import fs from "fs";
+import http from 'http';
 
-test("test that http basic auth works", async () => {
-  child_process.execSync(
-    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://httpbin.org/basic-auth/foo/bar --httpBasicAuth foo:bar --collection basicauth-test --statsFilename stats.json',
-  );
+const server = http.createServer((req, res) => {
+  res.writeHead(200);
+  res.write("Hi!");
+  res.end();
 });
 
-test("check that the page didn't fail", () => {
+beforeAll(() => {
+  server.listen(9998, '0.0.0.0');
+});
+
+test("test that http basic auth works", async () => {
+
+  child_process.execSync(
+    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://host.docker.internal:9998/ --httpBasicAuth foo:bar --collection basicauth-test --statsFilename stats.json",
+  );
+
   const data = fs.readFileSync("test-crawls/stats.json", "utf8");
   const dataJSON = JSON.parse(data);
   expect(dataJSON.crawled).toEqual(1);
   expect(dataJSON.failed).toEqual(0);
 });
+
+afterAll(() => {
+  server.close();
+})

--- a/tests/http_basicauth.test.js
+++ b/tests/http_basicauth.test.js
@@ -15,7 +15,7 @@ beforeAll(() => {
 test("test that http basic auth works", async () => {
 
   child_process.execSync(
-    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://host.docker.internal:9998/ --httpBasicAuth foo:bar --collection basicauth-test --statsFilename stats.json",
+    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://host.docker.internal:9998 --httpBasicAuth foo:bar --collection basicauth-test --statsFilename stats.json",
   );
 
   const data = fs.readFileSync("test-crawls/stats.json", "utf8");


### PR DESCRIPTION
You can use the `--httpBasicAuth` flag to pass colon separated username and password credentials to the browser used for crawling.

For some reason I couldn't get `page.authenticate()` to work as advertised in the puppeteer docs. I could get it to work outside of browsertrix-crawler's browser, so maybe there's some interference from another setting? But setting the Authenticate header directly worked nicely. Thanks for the tip @vnznznz!

Fixes #168
