### PR TITLE
PDF loading status code fix

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1697,7 +1697,7 @@ self.__bx_behaviors.selectMainBehavior();
     // Detect if ERR_ABORTED is actually caused by trying to load a non-page (eg. downloadable PDF),
     // if so, don't report as an error
     page.once("requestfailed", (req: HTTPRequest) => {
-      ignoreAbort = shouldIgnoreAbort(req);
+      ignoreAbort = shouldIgnoreAbort(req, data);
     });
 
     let isHTMLPage = data.isHTMLPage;
@@ -2559,7 +2559,7 @@ self.__bx_behaviors.selectMainBehavior();
   }
 }
 
-function shouldIgnoreAbort(req: HTTPRequest) {
+function shouldIgnoreAbort(req: HTTPRequest, data: PageState) {
   try {
     const failure = req.failure();
     const failureText = (failure && failure.errorText) || "";
@@ -2581,6 +2581,8 @@ function shouldIgnoreAbort(req: HTTPRequest) {
       headers["content-disposition"] ||
       (headers["content-type"] && !headers["content-type"].startsWith("text/"))
     ) {
+      data.status = resp.status();
+      data.mime = headers["content-type"].split(";")[0];
       return true;
     }
   } catch (e) {

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -391,10 +391,8 @@ export class Recorder {
         // check if this is a false positive -- a valid download that's already been fetched
         // the abort is just for page, but download will succeed
         if (type === "Document" && reqresp.isValidBinary()) {
-          this.serializeToWARC(reqresp);
-          this.addPageRecord(reqresp);
           this.removeReqResp(requestId);
-          return;
+          return this.serializeToWARC(reqresp);
         } else if (
           url &&
           reqresp.requestHeaders &&
@@ -426,8 +424,8 @@ export class Recorder {
     }
     reqresp.status = 0;
     reqresp.errorText = errorText;
-
     this.addPageRecord(reqresp);
+
     this.removeReqResp(requestId);
   }
 

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -392,7 +392,9 @@ export class Recorder {
         // the abort is just for page, but download will succeed
         if (type === "Document" && reqresp.isValidBinary()) {
           this.serializeToWARC(reqresp);
-          //} else if (url) {
+          this.addPageRecord(reqresp);
+          this.removeReqResp(requestId);
+          return;
         } else if (
           url &&
           reqresp.requestHeaders &&

--- a/tests/pdf-crawl.test.js
+++ b/tests/pdf-crawl.test.js
@@ -1,0 +1,61 @@
+import child_process from "child_process";
+import fs from "fs";
+import path from "path";
+import { WARCParser } from "warcio";
+
+const PDF = "http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf";
+
+test("ensure pdf is crawled", async () => {
+  child_process.execSync(
+    `docker run -v $PWD/test-crawls:/crawls  webrecorder/browsertrix-crawler crawl --url "${PDF}" --collection crawl-pdf`
+  );
+});
+
+test("check that individual WARCs have PDF written as 200 response", async () => {
+  const archiveWarcLists = fs.readdirSync(
+    "test-crawls/collections/crawl-pdf/archive",
+  );
+
+  const warcName = path.join("test-crawls/collections/crawl-pdf/archive", archiveWarcLists[0]);
+
+  const nodeStream = fs.createReadStream(warcName);
+
+  const parser = new WARCParser(nodeStream);
+
+  let statusCode = -1;
+
+  for await (const record of parser) {
+    if (record.warcType !== "response") {
+      continue;
+    }
+
+    if (record.warcTargetURI === PDF) {
+      statusCode = record.httpHeaders.statusCode;
+    }
+  }
+
+  expect(statusCode).toBe(200);
+});
+
+
+test("check that the pages.jsonl file entry contains status code and mime type", () => {
+  expect(
+    fs.existsSync("test-crawls/collections/crawl-pdf/pages/pages.jsonl"),
+  ).toBe(true);
+
+
+  const pages = fs
+    .readFileSync(
+      "test-crawls/collections/crawl-pdf/pages/pages.jsonl",
+      "utf8",
+    )
+    .trim()
+    .split("\n");
+
+  expect(pages.length).toBe(2);
+
+  const page = JSON.parse(pages[1]);
+  expect(page.url).toBe(PDF);
+  expect(page.status).toBe(200);
+  expect(page.mime).toBe("application/pdf");
+});


### PR DESCRIPTION
when loading a PDF as a page, the browser returns a 'false positive' net::ERR_ABORTED even though the PDF is loaded.
- this is already handled, but status code was still being cleared, ensure status code is not reset to 0 on response
- ensure page status and mime are also recorded if this failure is ignored (in shouldIgnoreAbort)

fixes #570

Note: as follow up, should ensure PDFs are directly fetched, even if cookies are being set