### PR TITLE
Fix regressions with `failOnFailedSeed` option

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1734,10 +1734,15 @@ self.__bx_behaviors.selectMainBehavior();
 
       if (failed) {
         if (failCrawlOnError) {
-          logger.fatal("Seed Page Load Error, failing crawl", {
-            status,
-            ...logDetails,
-          });
+          logger.fatal(
+            "Seed Page Load Error, failing crawl",
+            {
+              status,
+              ...logDetails,
+            },
+            "general",
+            1,
+          );
         } else {
           logger.error(
             isChromeError ? "Page Crashed on Load" : "Page Invalid Status",
@@ -1775,10 +1780,15 @@ self.__bx_behaviors.selectMainBehavior();
           data.skipBehaviors = true;
         } else if (failCrawlOnError) {
           // if fail on error, immediately fail here
-          logger.fatal("Page Load Timeout, failing crawl", {
-            msg,
-            ...logDetails,
-          });
+          logger.fatal(
+            "Page Load Timeout, failing crawl",
+            {
+              msg,
+              ...logDetails,
+            },
+            "general",
+            1,
+          );
         } else {
           // log if not already log and rethrow
           if (msg !== "logged") {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1727,8 +1727,13 @@ self.__bx_behaviors.selectMainBehavior();
 
       let failed = isChromeError;
 
-      if (this.params.failOnInvalidStatus && (status === 0 || status >= 400)) {
+      if (
+        (this.params.failOnInvalidStatus || failCrawlOnError) &&
+        (!status || status < 100 || status >= 400)
+      ) {
         // Handle 0, 4xx, or 5xx response as a page load error
+        // Regardless of whether failOnInvalidStatus is set, fail crawl if seed is
+        // 0/4xx/5xx and failOnFailedSeed is set to prevent breaking change from 0.x
         failed = true;
       }
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1727,8 +1727,8 @@ self.__bx_behaviors.selectMainBehavior();
 
       let failed = isChromeError;
 
-      if (this.params.failOnInvalidStatus && status >= 400) {
-        // Handle 4xx or 5xx response as a page load error
+      if (this.params.failOnInvalidStatus && (status === 0 || status >= 400)) {
+        // Handle 0, 4xx, or 5xx response as a page load error
         failed = true;
       }
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1727,10 +1727,7 @@ self.__bx_behaviors.selectMainBehavior();
 
       let failed = isChromeError;
 
-      if (
-        (this.params.failOnInvalidStatus) &&
-        (status >= 400)
-      ) {
+      if (this.params.failOnInvalidStatus && status >= 400) {
         // Handle 4xx or 5xx response as a page load error
         failed = true;
       }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1728,12 +1728,10 @@ self.__bx_behaviors.selectMainBehavior();
       let failed = isChromeError;
 
       if (
-        (this.params.failOnInvalidStatus || failCrawlOnError) &&
-        (!status || status < 100 || status >= 400)
+        (this.params.failOnInvalidStatus) &&
+        (status >= 400)
       ) {
-        // Handle 0, 4xx, or 5xx response as a page load error
-        // Regardless of whether failOnInvalidStatus is set, fail crawl if seed is
-        // 0/4xx/5xx and failOnFailedSeed is set to prevent breaking change from 0.x
+        // Handle 4xx or 5xx response as a page load error
         failed = true;
       }
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -499,7 +499,7 @@ class ArgParser {
       failOnFailedSeed: {
         describe:
           "If set, crawler will fail with exit code 1 if any seed fails. When combined with --failOnInvalidStatus," +
-          "will result in crawl failling with exit code 1 if any seed has a 4xx/5xx response",
+          "will result in crawl failing with exit code 1 if any seed has a 4xx/5xx response",
         type: "boolean",
         default: false,
       },

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -678,7 +678,10 @@ class ArgParser {
         } catch (e) {
           if (argv.failOnFailedSeed) {
             logger.fatal(
-              `Invalid Seed "${seed.url}" specified, aborting crawl.`,
+              "Invalid Seed specified, aborting crawl.",
+              { url: seed.url },
+              "general",
+              1,
             );
           }
         }

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -498,7 +498,8 @@ class ArgParser {
 
       failOnFailedSeed: {
         describe:
-          "If set, crawler will fail with exit code 1 if any seed fails",
+          "If set, crawler will fail with exit code 1 if any seed fails. Crawl will fail if any seeds have a" +
+          "4xx or 5xx response regardless of whether failOnInvalidStatus is set",
         type: "boolean",
         default: false,
       },
@@ -512,7 +513,7 @@ class ArgParser {
 
       failOnInvalidStatus: {
         describe:
-          "If set, will treat pages with non-200 response as failures. When combined with --failOnFailedLimit or --failOnFailedSeed" +
+          "If set, will treat pages with non-200 response as failures. When combined with --failOnFailedLimit" +
           "may result in crawl failing due to non-200 responses",
         type: "boolean",
         default: false,

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -513,8 +513,8 @@ class ArgParser {
 
       failOnInvalidStatus: {
         describe:
-          "If set, will treat pages with non-200 response as failures. When combined with --failOnFailedLimit" +
-          "may result in crawl failing due to non-200 responses",
+          "If set, will treat pages with 4xx or 5xx response as failures. When combined with --failOnFailedLimit" +
+          " or --failOnFailedSeed may result in crawl failing due to non-200 responses",
         type: "boolean",
         default: false,
       },

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -678,7 +678,7 @@ class ArgParser {
         } catch (e) {
           if (argv.failOnFailedSeed) {
             logger.fatal(
-              "Invalid Seed specified, aborting crawl.",
+              "Invalid seed specified, aborting crawl",
               { url: seed.url },
               "general",
               1,
@@ -688,10 +688,10 @@ class ArgParser {
       }
 
       if (!argv.scopedSeeds.length) {
-        logger.fatal("No valid seeds specified, aborting crawl.");
+        logger.fatal("No valid seeds specified, aborting crawl");
       }
     } else if (!argv.qaSource) {
-      logger.fatal("--qaSource required for QA mode!");
+      logger.fatal("--qaSource required for QA mode");
     }
 
     // Resolve statsFilename

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -498,8 +498,8 @@ class ArgParser {
 
       failOnFailedSeed: {
         describe:
-          "If set, crawler will fail with exit code 1 if any seed fails. Crawl will fail if any seeds have a" +
-          "4xx or 5xx response regardless of whether failOnInvalidStatus is set",
+          "If set, crawler will fail with exit code 1 if any seed fails. When combined with --failOnInvalidStatus," +
+          "will result in crawl failling with exit code 1 if any seed has a 4xx/5xx response",
         type: "boolean",
         default: false,
       },

--- a/tests/seeds.test.js
+++ b/tests/seeds.test.js
@@ -23,18 +23,33 @@ test("ensure one invalid seed fails crawl if failOnFailedSeed is set", async () 
       "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url example.invalid --generateWACZ --limit 1 --failOnFailedSeed --collection failseed",
     );
   } catch (error) {
+    expect(error.code).toEqual(1);
     passed = false;
   }
   expect(passed).toBe(false);
 });
 
-test("ensure seed with 0/4xx/5xx response fails crawl if failOnFailedSeed and failOnInvalidStatus is set", async () => {
+test("ensure seed with network error fails crawl if failOnFailedSeed and failOnInvalidStatus is set", async () => {
   let passed = true;
   try {
     await exec(
       "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://example.invalid --generateWACZ --limit 2 --failOnFailedSeed --failOnInvalidStatus --collection failseedstatus",
     );
   } catch (error) {
+    expect(error.code).toEqual(1);
+    passed = false;
+  }
+  expect(passed).toBe(false);
+});
+
+test("ensure seed with 4xx/5xx response fails crawl if failOnFailedSeed and failOnInvalidStatus is set", async () => {
+  let passed = true;
+  try {
+    await exec(
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/404 --generateWACZ --limit 2 --failOnFailedSeed --failOnInvalidStatus --collection failseedstatus",
+    );
+  } catch (error) {
+    expect(error.code).toEqual(1);
     passed = false;
   }
   expect(passed).toBe(false);
@@ -60,6 +75,7 @@ test("ensure crawl fails if no valid seeds are passed", async () => {
       "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url iana.org/ --url example.invalid --generateWACZ --limit 2 --collection allinvalidseeds",
     );
   } catch (error) {
+    expect(error.code).toEqual(1);
     passed = false;
   }
   expect(passed).toBe(false);

--- a/tests/seeds.test.js
+++ b/tests/seeds.test.js
@@ -7,7 +7,7 @@ test("ensure one invalid seed doesn't end crawl if failOnFailedSeed is not set",
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://example.invalid --generateWACZ --limit 1 --collection invalidseed",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://example.invalid --generateWACZ --limit 2 --collection invalidseed",
     );
   } catch (error) {
     console.log(error);
@@ -20,7 +20,7 @@ test("ensure one invalid seed fails crawl if failOnFailedSeed is set", async () 
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url example.invalid --generateWACZ --limit 1 --failOnFailedSeed --collection failseed",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url example.invalid --generateWACZ --limit 2 --failOnFailedSeed --collection failseed",
     );
   } catch (error) {
     expect(error.code).toEqual(1);

--- a/tests/seeds.test.js
+++ b/tests/seeds.test.js
@@ -40,16 +40,17 @@ test("ensure seed with 0/4xx/5xx response fails crawl if failOnFailedSeed and fa
   expect(passed).toBe(false);
 });
 
-test("ensure seed with 0/4xx/5xx response fails crawl even if only failOnFailedSeed is set", async () => {
+test("ensure seed with 4xx/5xx response succeeds if failOnInvalidStatus is not set", async () => {
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://example.invalid --generateWACZ --limit 2 --failOnFailedSeed --collection failseedstatussolo",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/404 --generateWACZ --limit 2 --failOnFailedSeed --collection failseedwithoutinvalidstatus",
     );
   } catch (error) {
+    console.log(error);
     passed = false;
   }
-  expect(passed).toBe(false);
+  expect(passed).toBe(true);
 });
 
 test("ensure crawl fails if no valid seeds are passed", async () => {

--- a/tests/seeds.test.js
+++ b/tests/seeds.test.js
@@ -29,7 +29,7 @@ test("ensure one invalid seed fails crawl if failOnFailedSeed is set", async () 
   expect(passed).toBe(false);
 });
 
-test("ensure seed with 4xx/5xx response fails crawl if failOnFailedSeed and failOnInvalidStatus is set", async () => {
+test("ensure seed with 0/4xx/5xx response fails crawl if failOnFailedSeed and failOnInvalidStatus is set", async () => {
   let passed = true;
   try {
     await exec(

--- a/tests/seeds.test.js
+++ b/tests/seeds.test.js
@@ -46,7 +46,7 @@ test("ensure seed with 4xx/5xx response fails crawl if failOnFailedSeed and fail
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/404 --generateWACZ --limit 2 --failOnFailedSeed --failOnInvalidStatus --collection failseed404status",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/doesntexist --generateWACZ --limit 2 --failOnFailedSeed --failOnInvalidStatus --collection failseed404status",
     );
   } catch (error) {
     expect(error.code).toEqual(1);
@@ -59,7 +59,7 @@ test("ensure seed with 4xx/5xx response succeeds if failOnInvalidStatus is not s
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/404 --generateWACZ --limit 2 --failOnFailedSeed --collection failseedwithoutinvalidstatus",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/doesntexist --generateWACZ --limit 2 --failOnFailedSeed --collection failseedwithoutinvalidstatus",
     );
   } catch (error) {
     console.log(error);

--- a/tests/seeds.test.js
+++ b/tests/seeds.test.js
@@ -7,7 +7,7 @@ test("ensure one invalid seed doesn't end crawl if failOnFailedSeed is not set",
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url example.com/invalid-seed --generateWACZ --limit 1 --collection invalidseed",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://example.invalid --generateWACZ --limit 1 --collection invalidseed",
     );
   } catch (error) {
     console.log(error);
@@ -20,9 +20,23 @@ test("ensure one invalid seed fails crawl if failOnFailedSeed is set", async () 
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url example.com/invalid-seed --generateWACZ --limit 1 --failOnFailedSeed --collection failseed",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url example.invalid --generateWACZ --limit 1 --failOnFailedSeed --collection failseed",
     );
   } catch (error) {
+    console.log(error);
+    passed = false;
+  }
+  expect(passed).toBe(false);
+});
+
+test("ensure seed with 4xx/5xx response fails crawl if failOnFailedSeed and failOnInvalidStatus is set", async () => {
+  let passed = true;
+  try {
+    await exec(
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://example.invalid --generateWACZ --limit 1 --failOnFailedSeed --failOnInvalidStatus --collection failseedstatus",
+    );
+  } catch (error) {
+    console.log(error);
     passed = false;
   }
   expect(passed).toBe(false);
@@ -32,9 +46,10 @@ test("ensure crawl fails if no valid seeds are passed", async () => {
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url iana.org/ --url example.com/invalid-seed --generateWACZ --limit 1 --collection allinvalidseeds",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url iana.org/ --url example.invalid --generateWACZ --limit 1 --collection allinvalidseeds",
     );
   } catch (error) {
+    console.log(error);
     passed = false;
   }
   expect(passed).toBe(false);

--- a/tests/seeds.test.js
+++ b/tests/seeds.test.js
@@ -42,11 +42,11 @@ test("ensure seed with network error fails crawl if failOnFailedSeed and failOnI
   expect(passed).toBe(false);
 });
 
-test("ensure seed with 4xx/5xx response fails crawl if failOnFailedSeed and failOnInvalidStatus is set", async () => {
+test("ensure seed with 4xx/5xx response fails crawl if failOnFailedSeed and failOnInvalidStatus are set", async () => {
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/404 --generateWACZ --limit 2 --failOnFailedSeed --failOnInvalidStatus --collection failseedstatus",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/404 --generateWACZ --limit 2 --failOnFailedSeed --failOnInvalidStatus --collection failseed404status",
     );
   } catch (error) {
     expect(error.code).toEqual(1);
@@ -75,7 +75,7 @@ test("ensure crawl fails if no valid seeds are passed", async () => {
       "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url iana.org/ --url example.invalid --generateWACZ --limit 2 --collection allinvalidseeds",
     );
   } catch (error) {
-    expect(error.code).toEqual(1);
+    expect(error.code).toEqual(17);
     passed = false;
   }
   expect(passed).toBe(false);

--- a/tests/seeds.test.js
+++ b/tests/seeds.test.js
@@ -23,7 +23,6 @@ test("ensure one invalid seed fails crawl if failOnFailedSeed is set", async () 
       "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url example.invalid --generateWACZ --limit 1 --failOnFailedSeed --collection failseed",
     );
   } catch (error) {
-    console.log(error);
     passed = false;
   }
   expect(passed).toBe(false);
@@ -33,10 +32,21 @@ test("ensure seed with 0/4xx/5xx response fails crawl if failOnFailedSeed and fa
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://example.invalid --generateWACZ --limit 1 --failOnFailedSeed --failOnInvalidStatus --collection failseedstatus",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://example.invalid --generateWACZ --limit 2 --failOnFailedSeed --failOnInvalidStatus --collection failseedstatus",
     );
   } catch (error) {
-    console.log(error);
+    passed = false;
+  }
+  expect(passed).toBe(false);
+});
+
+test("ensure seed with 0/4xx/5xx response fails crawl even if only failOnFailedSeed is set", async () => {
+  let passed = true;
+  try {
+    await exec(
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://example.invalid --generateWACZ --limit 2 --failOnFailedSeed --collection failseedstatussolo",
+    );
+  } catch (error) {
     passed = false;
   }
   expect(passed).toBe(false);
@@ -46,10 +56,9 @@ test("ensure crawl fails if no valid seeds are passed", async () => {
   let passed = true;
   try {
     await exec(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url iana.org/ --url example.invalid --generateWACZ --limit 1 --collection allinvalidseeds",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url iana.org/ --url example.invalid --generateWACZ --limit 2 --collection allinvalidseeds",
     );
   } catch (error) {
-    console.log(error);
     passed = false;
   }
   expect(passed).toBe(false);


### PR DESCRIPTION
Fixes #563 

This PR makes a few changes to fix a regression in behavior around `failOnFailedSeed` for the 1.x releases:

- Fail with exit code 1, not 17, when pages are unreachable due to DNS not resolving or other network errors if the page is a seed and `failOnFailedSeed` is set
- Extend tests, add test to ensure crawl succeeds on 404 seed status code if `failOnINvalidStatus` isn't set

(Edited after reverting change related to invalid statuses)