### PR TITLE
headers: better filtering and encoding

### DIFF
--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -153,7 +153,7 @@ export class RequestResponseInfo {
       return false;
     }
     try {
-      const headers = new Headers(this.responseHeaders);
+      const headers = new Headers(this.getResponseHeadersDict());
       const location = headers.get("location") || "";
       const redirUrl = new URL(location, this.url).href;
       return this.url === redirUrl;
@@ -225,6 +225,9 @@ export class RequestResponseInfo {
 
       for (const header of headersList) {
         let headerName = header.name.toLowerCase();
+        if (header.name.startsWith(":")) {
+          continue;
+        }
         if (EXCLUDE_HEADERS.includes(headerName)) {
           headerName = "x-orig-" + headerName;
           continue;
@@ -324,7 +327,7 @@ export class RequestResponseInfo {
 
     const convData = {
       url: this.url,
-      headers: new Headers(this.requestHeaders),
+      headers: new Headers(this.getRequestHeadersDict()),
       method: this.method,
       postData: this.postData || "",
     };

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -236,7 +236,7 @@ export class RequestResponseInfo {
           headersDict[headerName] = "" + actualContentLength;
           continue;
         }
-        headersDict[headerName] = header.value.replace(/\n/g, ", ");
+        headersDict[headerName] = this._encodeHeaderValue(header.value);
       }
     }
 
@@ -259,7 +259,7 @@ export class RequestResponseInfo {
         headersDict[key] = "" + actualContentLength;
         continue;
       }
-      headersDict[key] = headersDict[key].replace(/\n/g, ", ");
+      headersDict[key] = this._encodeHeaderValue(headersDict[key]);
     }
 
     return headersDict;
@@ -350,5 +350,15 @@ export class RequestResponseInfo {
     }
 
     return this.url;
+  }
+
+  _encodeHeaderValue(value: string) {
+    value = value.replace(/\n/g, ", ");
+    // check if not ASCII, then encode
+    // eslint-disable-next-line no-control-regex
+    if (!/^[\x00-\x7F]*$/.test(value)) {
+      value = encodeURI(value);
+    }
+    return value;
   }
 }

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -353,12 +353,12 @@ export class RequestResponseInfo {
   }
 
   _encodeHeaderValue(value: string) {
-    value = value.replace(/\n/g, ", ");
-    // check if not ASCII, then encode
+    // check if not ASCII, then encode, replace encoded newlines
     // eslint-disable-next-line no-control-regex
     if (!/^[\x00-\x7F]*$/.test(value)) {
-      value = encodeURI(value);
+      return encodeURI(value).replace(/%0A/g, ", ");
     }
-    return value;
+    // replace newlines with spaces
+    return value.replace(/\n/g, ", ");
   }
 }


### PR DESCRIPTION
Ensure headers are processed via internal checks before attempting to pass to `new Headers` to ensure validity:
- filter out http/2 style pseudoheaders (starting with ':')
- check if header values are non-ascii, and if so, encode with `encodeURI`

fixes #569 + prep for latest version of image which contain pseudoheaders (replaces #546)

Testing:
- Try crawling a page that contains non-ASCII values in headers, eg: https://www.hra-news.org/fa/wp-content/uploads/2016/11/Reza-Alijan%C4%B1.jpg contains a non-ASCII value in location header