### PR TITLE
save state: export pending list as array of json strings + fix importing save state to support pending

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1652,18 +1652,18 @@ self.__bx_behaviors.selectMainBehavior();
     }
 
     const realSize = await this.crawlState.queueSize();
-    const pendingList = await this.crawlState.getPendingList();
+    const pendingPages = await this.crawlState.getPendingList();
     const done = await this.crawlState.numDone();
     const failed = await this.crawlState.numFailed();
-    const total = realSize + pendingList.length + done;
+    const total = realSize + pendingPages.length + done;
     const limit = { max: this.pageLimit || 0, hit: this.limitHit };
     const stats = {
       crawled: done,
       total: total,
-      pending: pendingList.length,
+      pending: pendingPages.length,
       failed: failed,
       limit: limit,
-      pendingPages: pendingList.map((x) => JSON.stringify(x)),
+      pendingPages,
     };
 
     logger.info("Crawl statistics", stats, "crawlStatus");

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -670,8 +670,20 @@ return 0;
       seen.push(data.url);
     }
 
-    for (const json of state.pending) {
-      const data = JSON.parse(json);
+    for (let json of state.pending) {
+      let data;
+
+      // if the data is string, parse
+      if (typeof json === "string") {
+        data = JSON.parse(json);
+        // otherwise, use as is, set json to json version
+      } else if (typeof json === "object") {
+        data = json;
+        json = JSON.stringify(data);
+      } else {
+        continue;
+      }
+
       if (checkScope) {
         if (!this.recheckScope(data, seeds)) {
           continue;
@@ -741,8 +753,7 @@ return 0;
   }
 
   async getPendingList() {
-    const list = await this.redis.hvals(this.pkey);
-    return list.map((x) => JSON.parse(x));
+    return await this.redis.hvals(this.pkey);
   }
 
   async getErrorList() {


### PR DESCRIPTION
The save state export accidentally exported the pending data as an object, instead of a list of JSON strings, as it is stored in Redis, while import was expecting list of json strings. The getPendingList() function parses the json, but then was re-encoding it for writeStats(). This was likely a mistake.
This PR fixes things:
- support loading pending state as both array of objects and array of json strings for backwards compatibility
- save state as array of json strings
- remove json decoding and encoding in getPendingList() and writeStats()

Fixes #568