### PR TITLE
Sitemap Parsing Fixes

### DIFF
--- a/src/util/sitemapper.ts
+++ b/src/util/sitemapper.ts
@@ -146,7 +146,7 @@ export class SitemapReader extends EventEmitter {
       // if specific URL provided, check if its a .xml file or a robots.txt file
       fullUrl = new URL(sitemap, seedUrl).href;
       let expected = null;
-      if (fullUrl.endsWith(".xml")) {
+      if (fullUrl.endsWith(".xml") || fullUrl.endsWith(".xml.gz")) {
         expected = XML_CONTENT_TYPES;
         isSitemap = true;
       } else if (fullUrl.endsWith(".txt")) {


### PR DESCRIPTION
Additional fixes for sitemaps:
- Fix parsing sitemaps that have data wrapped in CDATA fields, fixes part of https://github.com/webrecorder/browsertrix/issues/1750
- Fix parsing where the .gz sitemap have content-encoding and are actually not gzipped
- Ensure error in gzip parsing doesn't break crawl, just errors sitemap parsing. 


Test on:
- https://ipres2022.scot/ for sitemap with CDATA
- https://www.twtich.tv with `--sitemap https://www.twitch.tv/sitemapv2_index.xml.gz` for gzipped with content-encoding and with just `--sitemap` for parsing from robots.txt
- https://example.com/sitemap.xml.gz for general error with gzip