### PR TITLE
Add group policies, limit browser access to container filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ADD package.json /app/
 ARG REBUILD
 
 # Prefetch tldextract so pywb is able to boot in environments with limited internet access
-RUN tldextract --update 
+RUN tldextract --update
 
 # Download and format ad host blocklist as JSON
 RUN mkdir -p /tmp/ads && cd /tmp/ads && \
@@ -64,8 +64,11 @@ WORKDIR /crawls
 # enable to test custom behaviors build (from browsertrix-behaviors)
 # COPY behaviors.js /app/node_modules/browsertrix-behaviors/dist/behaviors.js
 
+# add brave/chromium group policies
+RUN mkdir -p /etc/brave/policies/managed/
+ADD config/policies /etc/brave/policies/managed/
+
 ADD docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["crawl"]
-

--- a/config/policies/brave-default.json
+++ b/config/policies/brave-default.json
@@ -1,0 +1,6 @@
+{
+    "BraveRewardsDisabled": true,
+    "BraveWalletDisabled": true,
+    "BraveVPNDisabled": 1,
+    "BraveAIChatEnabled": false
+}

--- a/config/policies/lockdown-profilebrowser.json
+++ b/config/policies/lockdown-profilebrowser.json
@@ -1,0 +1,8 @@
+{
+    "IncognitoModeAvailability": 1,
+    "TorDisabled": true,
+    "AllowFileSelectionDialogs": false,
+    "URLBlocklist": [
+        "file://*"
+    ]
+}


### PR DESCRIPTION
Add some default policy settings to disable unneeded Brave features. Helps a bit with #463, but Brave unfortunately doesn't provide all mentioned settings as policy options.

Most important changes are in `config/policies/lockdown-profilebrowser.json` it limits access to the container filesystem especially during interactive profile browser creation. 