### PR TITLE
Fix failOnFailedLimit and add tests

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1159,10 +1159,11 @@ self.__bx_behaviors.selectMainBehavior();
     }
 
     if (this.params.failOnFailedLimit) {
-      const numFailed = this.crawlState.numFailed();
-      if (numFailed >= this.params.failOnFailedLimit) {
+      const numFailed = await this.crawlState.numFailed();
+      const failedLimit = this.params.failOnFailedLimit;
+      if (numFailed >= failedLimit) {
         logger.fatal(
-          `Failed threshold reached ${numFailed} >= ${this.params.failedLimit}, failing crawl`,
+          `Failed threshold reached ${numFailed} >= ${failedLimit}, failing crawl`,
         );
       }
     }

--- a/tests/limit_reached.test.js
+++ b/tests/limit_reached.test.js
@@ -1,8 +1,11 @@
-import child_process from "child_process";
 import fs from "fs";
+import util from "util";
+import { exec as execCallback, execSync } from "child_process";
+
+const exec = util.promisify(execCallback);
 
 test("ensure page limit reached", async () => {
-  child_process.execSync(
+  execSync(
     'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --scopeType prefix --behaviors "" --url https://webrecorder.net/ --limit 12 --workers 2 --collection limit-test --statsFilename stats.json',
   );
 });
@@ -13,4 +16,17 @@ test("check limit written to stats file is as expected", () => {
   expect(dataJSON.crawled).toEqual(12);
   expect(dataJSON.total).toEqual(12);
   expect(dataJSON.limit.hit).toBe(true);
+});
+
+test("ensure crawl fails if failOnFailedLimit is reached", async () => {
+  let passed = true;
+  try {
+    await exec(
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/will404 --url https://specs.webrecorder.net --failOnInvalidStatus --failOnFailedLimit 1 --limit 10 --collection faillimitreached",
+    );
+  } catch (error) {
+    expect(error.code).toEqual(17);
+    passed = false;
+  }
+  expect(passed).toBe(false);
 });


### PR DESCRIPTION
Fixes #575

- Adds a missing await to fetching the number of failed pages from Redis
- Fixes a typo in the fatal logging message
- Adds a test to ensure that the crawl fails with exit code 17 if --failOnInvalidStatus and --failOnFailedLimit 1 are set with a url that will 404