### PR TITLE
Load non-HTML resources directly whenever possible

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -801,7 +801,7 @@ self.__bx_behaviors.selectMainBehavior();
           data.ts = ts || new Date();
           logger.info(
             "Direct fetch successful",
-            { url, ...logDetails },
+            { url, mime, ...logDetails },
             "fetch",
           );
           return;

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -3,6 +3,7 @@ import { getStatusText } from "@webrecorder/wabac/src/utils.js";
 
 import { Protocol } from "puppeteer-core";
 import { postToGetUrl } from "warcio";
+import { HTML_TYPES } from "./constants.js";
 
 const CONTENT_LENGTH = "content-length";
 const CONTENT_TYPE = "content-type";
@@ -361,4 +362,19 @@ export class RequestResponseInfo {
     // replace newlines with spaces
     return value.replace(/\n/g, ", ");
   }
+}
+
+export function isHTMLContentType(contentType: string | null) {
+  // just load if no content-type
+  if (!contentType) {
+    return true;
+  }
+
+  const mime = contentType.split(";")[0];
+
+  if (HTML_TYPES.includes(mime)) {
+    return true;
+  }
+
+  return false;
 }

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -149,12 +149,12 @@ export class RequestResponseInfo {
     }
   }
 
-  isRedirectStatus(status: number) {
-    return status >= 300 && status < 400 && status !== 304;
+  isRedirectStatus() {
+    return this.status >= 300 && this.status < 400 && this.status !== 304;
   }
 
   isSelfRedirect() {
-    if (!this.isRedirectStatus(this.status)) {
+    if (!this.isRedirectStatus()) {
       return false;
     }
 

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -149,10 +149,15 @@ export class RequestResponseInfo {
     }
   }
 
+  isRedirectStatus(status: number) {
+    return status >= 300 && status < 400 && status !== 304;
+  }
+
   isSelfRedirect() {
-    if (this.status < 300 || this.status >= 400 || this.status === 304) {
+    if (!this.isRedirectStatus(this.status)) {
       return false;
     }
+
     try {
       const headers = new Headers(this.getResponseHeadersDict());
       const location = headers.get("location") || "";

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -66,7 +66,7 @@ export class PageState {
 
   callbacks: PageCallbacks = {};
 
-  isHTMLPage?: boolean;
+  isHTMLPage = true;
   text?: string;
   screenshotView?: Buffer;
   favicon?: string;

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -20,8 +20,11 @@ export type WorkerOpts = {
   workerid: WorkerId;
   // eslint-disable-next-line @typescript-eslint/ban-types
   callbacks: Record<string, Function>;
-  directFetchCapture?:
-    | ((url: string) => Promise<{ fetched: boolean; mime: string }>)
+  directFetchCapture:
+    | ((
+        url: string,
+        headers: Record<string, string>,
+      ) => Promise<{ fetched: boolean; mime: string; ts: Date }>)
     | null;
   frameIdToExecId: Map<string, number>;
 };
@@ -171,7 +174,8 @@ export class PageWorker {
         this.cdp = cdp;
         this.callbacks = {};
         const directFetchCapture = this.recorder
-          ? (x: string) => this.recorder!.directFetchCapture(x)
+          ? (x: string, h: Record<string, string>) =>
+              this.recorder!.directFetchCapture(x, h)
           : null;
         this.opts = {
           page,

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -2,7 +2,7 @@ import os from "os";
 
 import { logger, formatErr } from "./logger.js";
 import { sleep, timedRun } from "./timing.js";
-import { Recorder } from "./recorder.js";
+import { DirectFetchRequest, Recorder } from "./recorder.js";
 import { rxEscape } from "./seeds.js";
 import { CDPSession, Page } from "puppeteer-core";
 import { PageState, WorkerId } from "./state.js";
@@ -22,8 +22,7 @@ export type WorkerOpts = {
   callbacks: Record<string, Function>;
   directFetchCapture:
     | ((
-        url: string,
-        headers: Record<string, string>,
+        request: DirectFetchRequest,
       ) => Promise<{ fetched: boolean; mime: string; ts: Date }>)
     | null;
   frameIdToExecId: Map<string, number>;
@@ -174,8 +173,7 @@ export class PageWorker {
         this.cdp = cdp;
         this.callbacks = {};
         const directFetchCapture = this.recorder
-          ? (x: string, h: Record<string, string>) =>
-              this.recorder!.directFetchCapture(x, h)
+          ? (req: DirectFetchRequest) => this.recorder!.directFetchCapture(req)
           : null;
         this.opts = {
           page,


### PR DESCRIPTION
Optimize the direct loading of non-HTML pages. Currently, the behavior is:
- make a HEAD request first
- make a direct fetch request only if HEAD request is a non-HTML and 200
- only use fetch request if non-HTML and 200 and doesn't set any cookies

This changes the behavior to:
- get cookies from browser for page URL
- make a direct fetch request with cookies, if provided
- only use fetch request if non-HTML and 200
Also:
- ensures pageinfo is properly set with timestamp for direct fetch.
- remove obsolete Agent handling that is no longer used in default (fetch)

If fetch request results in HTML, the response is aborted and browser loading is used.

Note: initially attempted to handle redirects, but gets a bit complicated since many need to follow the redirect check to determine if request is non-HTML, and would need to buffer those responses, and not write them in case they need to be dropped in favor of browser loading. Erring on side of caution of requiring 4xx/5xx responses to still be loaded through browser, just in case.

Other optimization: it is possible to turn on http/2 loading for fetch, as mentioned in: https://github.com/nodejs/undici/issues/2750#issuecomment-1941009554 (the obsolete Agent setup from http/https modules has been removed)