### PR TITLE
tests: reduce logging

### DIFF
--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -208,6 +208,7 @@ export async function checkDiskUtilization(
   params: Record<string, any>,
   archiveDirSize: number,
   dfOutput = null,
+  doLog = true,
 ) {
   const diskUsage: Record<string, string> = await getDiskUsage(
     collDir,
@@ -217,9 +218,11 @@ export async function checkDiskUtilization(
 
   // Check that disk usage isn't already above threshold
   if (usedPercentage >= params.diskUtilization) {
-    logger.info(
-      `Disk utilization threshold reached ${usedPercentage}% > ${params.diskUtilization}%, stopping`,
-    );
+    if (doLog) {
+      logger.info(
+        `Disk utilization threshold reached ${usedPercentage}% > ${params.diskUtilization}%, stopping`,
+      );
+    }
     return {
       stop: true,
       used: usedPercentage,
@@ -246,9 +249,11 @@ export async function checkDiskUtilization(
   );
 
   if (projectedUsedPercentage >= params.diskUtilization) {
-    logger.info(
-      `Disk utilization projected to reach threshold ${projectedUsedPercentage}% > ${params.diskUtilization}%, stopping`,
-    );
+    if (doLog) {
+      logger.info(
+        `Disk utilization projected to reach threshold ${projectedUsedPercentage}% > ${params.diskUtilization}%, stopping`,
+      );
+    }
     return {
       stop: true,
       used: usedPercentage,

--- a/tests/adblockrules.test.js
+++ b/tests/adblockrules.test.js
@@ -2,32 +2,22 @@ import child_process from "child_process";
 import fs from "fs";
 import yaml from "js-yaml";
 
-function runCrawl(name, config, value, expectedValue) {
+function runCrawl(name, config, commandExtra = "") {
   config.generateCDX = true;
   config.depth = 0;
   config.collection = name;
 
   const configYaml = yaml.dump(config);
 
-  let log = "";
-
   try {
     const proc = child_process.execSync(
-      "docker run -i -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --headless --config stdin",
+      `docker run -i -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --config stdin ${commandExtra}`,
       { input: configYaml, stdin: "inherit", encoding: "utf8" },
     );
 
-    log = proc;
+    //console.log(proc);
   } catch (error) {
-    log = error;
-  }
-
-  try {
-    expect(doesCDXContain(name, value)).toBe(expectedValue);
-  } catch (e) {
-    e.message += "\nCrawl Log\n";
-    e.message += log;
-    throw e;
+    console.log(error);
   }
 }
 
@@ -59,6 +49,9 @@ test("testcrawl with ad block for specific URL", () => {
     blockAds: true,
   };
 
-  runCrawl("adblock-block", config, "www.googletagmanager.com", false);
+  runCrawl("adblock-block", config);
 
+  expect(doesCDXContain("adblock-block", "www.googletagmanager.com")).toBe(
+    false,
+  );
 });

--- a/tests/adblockrules.test.js
+++ b/tests/adblockrules.test.js
@@ -2,22 +2,32 @@ import child_process from "child_process";
 import fs from "fs";
 import yaml from "js-yaml";
 
-function runCrawl(name, config, commandExtra = "") {
+function runCrawl(name, config, value, expectedValue) {
   config.generateCDX = true;
   config.depth = 0;
   config.collection = name;
 
   const configYaml = yaml.dump(config);
 
+  let log = "";
+
   try {
     const proc = child_process.execSync(
-      `docker run -i -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --config stdin ${commandExtra}`,
+      "docker run -i -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --headless --config stdin",
       { input: configYaml, stdin: "inherit", encoding: "utf8" },
     );
 
-    console.log(proc);
+    log = proc;
   } catch (error) {
-    console.log(error);
+    log = error;
+  }
+
+  try {
+    expect(doesCDXContain(name, value)).toBe(expectedValue);
+  } catch (e) {
+    e.message += "\nCrawl Log\n";
+    e.message += log;
+    throw e;
   }
 }
 
@@ -49,9 +59,6 @@ test("testcrawl with ad block for specific URL", () => {
     blockAds: true,
   };
 
-  runCrawl("adblock-block", config);
+  runCrawl("adblock-block", config, "www.googletagmanager.com", false);
 
-  expect(doesCDXContain("adblock-block", "www.googletagmanager.com")).toBe(
-    false,
-  );
 });

--- a/tests/blockrules.test.js
+++ b/tests/blockrules.test.js
@@ -15,7 +15,7 @@ function runCrawl(name, config, commandExtra = "") {
       { input: configYaml, stdin: "inherit", encoding: "utf8" },
     );
 
-    console.log(proc);
+    //console.log(proc);
   } catch (error) {
     console.log(error);
   }

--- a/tests/config_stdin.test.js
+++ b/tests/config_stdin.test.js
@@ -12,7 +12,7 @@ test("pass config file via stdin", async () => {
       { input: configYaml, stdin: "inherit", encoding: "utf8" },
     );
 
-    console.log(proc);
+    //console.log(proc);
   } catch (error) {
     console.log(error);
   }

--- a/tests/rollover-writer.test.js
+++ b/tests/rollover-writer.test.js
@@ -11,8 +11,6 @@ test("set rollover to 500K and ensure individual WARCs rollover, including scree
   let main = 0;
   let screenshots = 0;
 
-  console.log(warcLists);
-
   for (const name of warcLists) {
     if (name.startsWith("rec-")) {
       main++;

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -33,6 +33,7 @@ grpcfuse       1000000      285000    715000  28% /crawls`;
     params,
     5000 * 1024,
     mockDfOutput,
+    false
   );
   expect(returnValue).toEqual({
     stop: false,
@@ -60,6 +61,7 @@ grpcfuse       100000    85000     15000  85% /crawls`;
     params,
     3000 * 1024,
     mockDfOutput,
+    false
   );
   expect(returnValue).toEqual({
     stop: true,

--- a/tests/warcinfo.test.js
+++ b/tests/warcinfo.test.js
@@ -13,7 +13,7 @@ test("run crawl", async() => {
       { input: configYaml, stdin: "inherit", encoding: "utf8" },
     );
 
-    console.log(proc);
+    //console.log(proc);
     success = true;
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
remove logging of crawl logs by default for clearer output from tests, only log in case of error.
Cleaner test results, eg: https://github.com/webrecorder/browsertrix-crawler/actions/runs/9671553142/job/26682374524