### PR TITLE
Change some logged errors to warns

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -953,12 +953,6 @@ self.__bx_behaviors.selectMainBehavior();
         this.healthChecker.resetErrors();
       }
     } else {
-      logger.warn(
-        "Page Load Failed",
-        { loadState, ...logDetails },
-        "pageStatus",
-      );
-
       await this.crawlState.markFailed(data.url);
 
       if (this.healthChecker) {
@@ -1809,10 +1803,20 @@ self.__bx_behaviors.selectMainBehavior();
         } else {
           // log if not already log and rethrow
           if (msg !== "logged") {
-            logger.error("Page Load Timeout, skipping page", {
-              msg,
-              ...logDetails,
-            });
+            const loadState = data.loadState;
+            if (loadState >= LoadState.CONTENT_LOADED) {
+              logger.warn("Page Load Timeout, skipping further processing", {
+                msg,
+                loadState,
+                ...logDetails,
+              });
+            } else {
+              logger.error("Page Load Failed, skipping page", {
+                msg,
+                loadState,
+                ...logDetails,
+              });
+            }
             e.message = "logged";
           }
           throw e;

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -913,6 +913,7 @@ self.__bx_behaviors.selectMainBehavior();
           "Behaviors timed out",
           logDetails,
           "behavior",
+          true,
         );
 
         await this.netIdle(page, logDetails);

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1272,7 +1272,7 @@ class AsyncFetcher {
       if (e.message === "response-filtered-out") {
         throw e;
       }
-      logger.warn(
+      logger.debug(
         "Streaming Fetch Error",
         { url, networkId, filename, ...formatErr(e), ...logDetails },
         "recorder",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1272,7 +1272,7 @@ class AsyncFetcher {
       if (e.message === "response-filtered-out") {
         throw e;
       }
-      logger.error(
+      logger.warn(
         "Streaming Fetch Error",
         { url, networkId, filename, ...formatErr(e), ...logDetails },
         "recorder",

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -276,6 +276,7 @@ export class PageWorker {
           "Page Worker Timeout",
           this.logDetails,
           "worker",
+          true,
         ),
         this.crashBreak,
       ]);


### PR DESCRIPTION
Fixes #599 

This PR modifies the following logging messages from `error` to `warn`, to avoid alarming users for fairly expected behavior:

- Behavior timeout
- Page worker timeout
- Streaming fetch error (will already trigger another page error message)