### PR TITLE
recorder: add missing shouldSkip() to responseReceived callback

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -238,7 +238,7 @@ export class Recorder {
   handleResponseReceived(params: Protocol.Network.ResponseReceivedEvent) {
     const { requestId, response, type } = params;
 
-    const { mimeType, url } = response;
+    const { mimeType, url, headers } = response;
 
     logNetwork("Network.responseReceived", {
       requestId,
@@ -247,6 +247,10 @@ export class Recorder {
     });
 
     if (mimeType === MIME_EVENT_STREAM) {
+      return;
+    }
+
+    if (this.shouldSkip(headers, url, undefined, type)) {
       return;
     }
 


### PR DESCRIPTION
Fixes #601, fixes issue with extra wait on PDF pages, where browser seems to be waiting for a chrome-extension:// URL.
These should have already be getting skipped, but missed here.

Testing:
- Crawl a redirecting PDF, which currently will load in the browser (due to redirect): https://dpconline.org/about/governance/articles-of-association-2
- Verify no chrome-extension:// URLs are being waited on.