### PR TITLE
Fix synching extraSeeds state with multiple crawler instances

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1860,7 +1860,18 @@ self.__bx_behaviors.selectMainBehavior();
 
     const { seedId } = data;
 
-    const seed = this.params.scopedSeeds[seedId];
+    const seed = await this.crawlState.getSeedAt(
+      this.params.scopedSeeds,
+      seedId,
+    );
+
+    if (!seed) {
+      logger.error(
+        "Seed Id not found, likely invalid crawl state - skipping link extraction and behaviors",
+        { seedId, ...logDetails },
+      );
+      return;
+    }
 
     await this.checkCF(page, logDetails);
 

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -166,7 +166,7 @@ export class ReplayCrawler extends Crawler {
     await this.loadPages(this.qaSource);
   }
 
-  isInScope() {
+  async isInScope() {
     return true;
   }
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -377,7 +377,7 @@ class ArgParser {
 
       redisStoreUrl: {
         describe:
-          "If set, url for remote redis server to store state. Otherwise, using in-memory store",
+          "If set, url for remote redis server to store state. Otherwise, using local redis instance",
         type: "string",
         default: "redis://localhost:6379/0",
       },

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -137,6 +137,14 @@ declare module "ioredis" {
       maxRetryPending: number,
       maxRegularDepth: number,
     ): Result<number, Context>;
+
+    addnewseed(
+      esKey: string,
+      esMap: string,
+      skey: string,
+      url: string,
+      seedData: string,
+    ): Result<number, Context>;
   }
 }
 
@@ -169,6 +177,7 @@ export class RedisCrawlState {
   ekey: string;
   pageskey: string;
   esKey: string;
+  esMap: string;
 
   sitemapDoneKey: string;
 
@@ -192,6 +201,7 @@ export class RedisCrawlState {
     this.pageskey = this.key + ":pages";
 
     this.esKey = this.key + ":extraSeeds";
+    this.esMap = this.key + ":esMap";
 
     this.sitemapDoneKey = this.key + ":sitemapDone";
 
@@ -297,6 +307,20 @@ if not res then
   end
 end
 return 0;
+`,
+    });
+
+    redis.defineCommand("addnewseed", {
+      numberOfKeys: 3,
+      lua: `
+local res = redis.call('hget', KEYS[2], ARGV[2]);
+if res:
+    return tonumber(res);
+
+local inx = redis.call('lpush', KEYS[1], ARGV[1]) - 1;
+redis.call('hset', KEYS[2], ARGV[2], tostring(inx));
+redis.call('sadd', KEYS[3], ARGV[2]);
+return inx;
 `,
     });
   }
@@ -825,12 +849,41 @@ return 0;
         "state",
       );
     }
-    seeds.push(seeds[origSeedId].newScopedSeed(newUrl));
-    const newSeedId = seeds.length - 1;
     const redirectSeed: ExtraRedirectSeed = { origSeedId, newUrl };
-    await this.redis.sadd(this.skey, newUrl);
-    await this.redis.lpush(this.esKey, JSON.stringify(redirectSeed));
+    const seedData = JSON.stringify(redirectSeed);
+    const newSeedId = await this.redis.addnewseed(
+      this.esKey,
+      this.esMap,
+      this.skey,
+      seedData,
+      newUrl,
+    );
+    seeds[newSeedId] = seeds[origSeedId].newScopedSeed(newUrl);
+
+    //const newSeedId = seeds.length - 1;
+    //await this.redis.sadd(this.skey, newUrl);
+    //await this.redis.lpush(this.esKey, JSON.stringify(redirectSeed));
     return newSeedId;
+  }
+
+  async getSeedAt(seeds: ScopedSeed[], newSeedId: number) {
+    if (seeds[newSeedId]) {
+      return seeds[newSeedId];
+    }
+
+    const newSeedDataList = await this.redis.lrange(
+      this.esKey,
+      newSeedId,
+      newSeedId,
+    );
+    if (newSeedDataList.length) {
+      const { origSeedId, newUrl } = JSON.parse(
+        newSeedDataList[0],
+      ) as ExtraRedirectSeed;
+      seeds[newSeedId] = seeds[origSeedId].newScopedSeed(newUrl);
+    }
+
+    return seeds[newSeedId];
   }
 
   async getExtraSeeds() {

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -351,7 +351,7 @@ export class PageWorker {
       // see if any work data in the queue
       if (data) {
         // filter out any out-of-scope pages right away
-        if (!this.crawler.isInScope(data, this.logDetails)) {
+        if (!(await this.crawler.isInScope(data, this.logDetails))) {
           logger.info("Page no longer in scope", data);
           await crawlState.markExcluded(data.url);
           continue;

--- a/tests/multi-instance-crawl.test.js
+++ b/tests/multi-instance-crawl.test.js
@@ -1,0 +1,137 @@
+import {exec, execSync} from "child_process";
+import fs from "fs";
+import { Redis } from "ioredis";
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+
+let redisId;
+let crawler1, crawler2;
+
+beforeAll(() => {
+  fs.rmSync("./test-crawls/collections/shared-crawler-1", { recursive: true, force: true });
+  fs.rmSync("./test-crawls/collections/shared-crawler-2", { recursive: true, force: true });
+
+  execSync("docker network create crawl");
+
+  redisId = execSync("docker run --rm --network=crawl -p 37379:6379 --name redis -d redis");
+
+  crawler1 = runCrawl("crawler-1");
+  crawler2 = runCrawl("crawler-2");
+});
+
+afterAll(async () => {
+  execSync(`docker kill ${redisId}`);
+
+  await sleep(3000);
+
+  await Promise.allSettled([crawler1, crawler2]);
+
+  execSync("docker network rm crawl");
+});
+
+function runCrawl(name) {
+  const crawler = exec(`docker run --rm -v $PWD/test-crawls:/crawls --network=crawl --hostname=${name} webrecorder/browsertrix-crawler crawl --url https://www.webrecorder.net/ --limit 4 --collection shared-${name} --crawlId testcrawl --redisStoreUrl redis://redis:6379`);
+
+  return new Promise((resolve) => {
+    crawler.on("exit", (code) => {
+      resolve(code);
+    });
+  });
+}
+
+test("run crawlers with external redis", async () => {
+  const redis = new Redis("redis://127.0.0.1:37379/0", { lazyConnect: true, retryStrategy: () => null });
+
+  await sleep(3000);
+
+  await redis.connect({ maxRetriesPerRequest: 50 });
+
+  let count = 0;
+
+  while (true) {
+    try {
+      const values = await redis.hgetall("testcrawl:status");
+      expect(values["crawler-1"]).toBe("running");
+      expect(values["crawler-2"]).toBe("running");
+      break;
+    } catch (e) {
+      if (count++ < 5) {
+        await sleep(1000);
+        continue;
+      }
+
+      throw e;
+    }
+  }
+
+});
+
+
+test("finish crawls successfully", async () => {
+  const res = await Promise.allSettled([crawler1, crawler2]);
+  expect(res[0].value).toBe(0);
+  expect(res[1].value).toBe(0);
+});
+
+test("ensure correct number of pages", () => {
+
+  expect(
+    fs.existsSync("test-crawls/collections/shared-crawler-1/pages/pages.jsonl"),
+  ).toBe(true);
+
+  expect(
+    fs.existsSync("test-crawls/collections/shared-crawler-2/pages/pages.jsonl"),
+  ).toBe(true);
+
+  const pages_1 = fs
+    .readFileSync(
+      "test-crawls/collections/shared-crawler-1/pages/pages.jsonl",
+      "utf8",
+    )
+    .trim()
+    .split("\n");
+
+  const pages_2 = fs
+    .readFileSync(
+      "test-crawls/collections/shared-crawler-2/pages/pages.jsonl",
+      "utf8",
+    )
+    .trim()
+    .split("\n");
+
+  // add 2 for heading in each file
+  expect(pages_1.length + pages_2.length).toBe(1 + 2);
+});
+
+test("ensure correct number of extraPages", () => {
+
+  expect(
+    fs.existsSync("test-crawls/collections/shared-crawler-1/pages/extraPages.jsonl"),
+  ).toBe(true);
+
+  expect(
+    fs.existsSync("test-crawls/collections/shared-crawler-2/pages/extraPages.jsonl"),
+  ).toBe(true);
+
+  const pages_1 = fs
+    .readFileSync(
+      "test-crawls/collections/shared-crawler-1/pages/extraPages.jsonl",
+      "utf8",
+    )
+    .trim()
+    .split("\n");
+
+  const pages_2 = fs
+    .readFileSync(
+      "test-crawls/collections/shared-crawler-2/pages/extraPages.jsonl",
+      "utf8",
+    )
+    .trim()
+    .split("\n");
+
+  // add 2 for heading in each file
+  expect(pages_1.length + pages_2.length).toBe(3 + 2);
+});


### PR DESCRIPTION
Fixes #604 

Ensures that extra seeds are propagated to all crawler instances.
Adds a new redis hashmap key to store the extraSeed mappings url->extraSeeds index, to ensure the extra seeds are added in the same order on other instances, even if encountered in different order.
Add a new redis lua primitive 'addnewseed' which combines several operations: check if extra seed already exists and returning existing index, add new seed to extraSeed list, also add to regular URL seed list.

The end result is to ensure that the extra seeds added to the end are always in the same order:

Regular Seeds (from config)   Extra Seeds (stored in Redis)
[0... N)                                      [N, N+M)

Redis stores these in a list [0, M) and the mapping url->index [0, M) is also stored in redis to ensure the same ordering.

Testing:
- Run a crawl with a redirecting site, eg. www.webrecorder.net, with scale >1. Crawler instances should not fail.