### PR TITLE
Fix header newline escape

### DIFF
--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -255,14 +255,14 @@ export class RequestResponseInfo {
         headersDict[key] = "" + actualContentLength;
         continue;
       }
+      const value = this._encodeHeaderValue(headersDict[key]);
+
       if (EXCLUDE_HEADERS.includes(keyLower)) {
-        headersDict["x-orig-" + key] = this._encodeHeaderValue(
-          headersDict[key],
-        );
+        headersDict["x-orig-" + key] = value;
         delete headersDict[key];
-        continue;
+      } else {
+        headersDict[key] = value;
       }
-      headersDict[key] = this._encodeHeaderValue(headersDict[key]);
     }
 
     return headersDict;

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -359,7 +359,7 @@ export class RequestResponseInfo {
     // check if not ASCII, then encode, replace encoded newlines
     // eslint-disable-next-line no-control-regex
     if (!/^[\x00-\x7F]*$/.test(value)) {
-      return encodeURI(value).replace(/%0A/g, ", ");
+      value = encodeURI(value).replace(/%0A/g, ", ");
     }
     // replace newlines with spaces
     return value.replace(/\n/g, ", ");

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -230,13 +230,12 @@ export class RequestResponseInfo {
         if (header.name.startsWith(":")) {
           continue;
         }
-        if (EXCLUDE_HEADERS.includes(headerName)) {
-          headerName = "x-orig-" + headerName;
-          continue;
-        }
         if (actualContentLength && headerName === CONTENT_LENGTH) {
           headersDict[headerName] = "" + actualContentLength;
           continue;
+        }
+        if (EXCLUDE_HEADERS.includes(headerName)) {
+          headerName = "x-orig-" + headerName;
         }
         headersDict[headerName] = this._encodeHeaderValue(header.value);
       }
@@ -252,13 +251,15 @@ export class RequestResponseInfo {
         continue;
       }
       const keyLower = key.toLowerCase();
-      if (EXCLUDE_HEADERS.includes(keyLower)) {
-        headersDict["x-orig-" + key] = headersDict[key];
-        delete headersDict[key];
-        continue;
-      }
       if (actualContentLength && keyLower === CONTENT_LENGTH) {
         headersDict[key] = "" + actualContentLength;
+        continue;
+      }
+      if (EXCLUDE_HEADERS.includes(keyLower)) {
+        headersDict["x-orig-" + key] = this._encodeHeaderValue(
+          headersDict[key],
+        );
+        delete headersDict[key];
         continue;
       }
       headersDict[key] = this._encodeHeaderValue(headersDict[key]);


### PR DESCRIPTION
- Ensure newline escaping happens consistently, even for 'excluded' headers which get a `x-orig-` prefix but are still added
- Ensure excluded headers in list path are still added with `x-orig-` prefix.
- fixes #607 