### PR TITLE
add EXPOSE for ports used inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ENV DISPLAY=:99 \
     VNC_PASS=vncpassw0rd! \
     DETACHED_CHILD_PROC=1
 
+EXPOSE 9222 9223 6080
+
 WORKDIR /app
 
 ADD requirements.txt /app/


### PR DESCRIPTION
documents fixed internal ports used in browsertrix, via EXPOSE cmd, addresses #558 