### PR TITLE
adjust browser viewport to avoid cutting off bottom of page

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -42,6 +42,10 @@ type LaunchOpts = {
   recording: boolean;
 };
 
+// fixed height of the browser UI (may need to be adjusted in the future)
+// todo: a way to determine this?
+const BROWSER_HEIGHT_OFFSET = 81;
+
 // ==================================================================
 export class Browser {
   profileDir: string;
@@ -94,7 +98,10 @@ export class Browser {
     if (process.env.GEOMETRY) {
       const geom = process.env.GEOMETRY.split("x");
 
-      defaultViewport = { width: Number(geom[0]), height: Number(geom[1]) };
+      defaultViewport = {
+        width: Number(geom[0]),
+        height: Number(geom[1]) - (recording ? 0 : BROWSER_HEIGHT_OFFSET),
+      };
     }
 
     const launchOpts: PuppeteerLaunchOptions = {


### PR DESCRIPTION
- subtract the browser ui height from default viewport computed from screen dimensions
- hard-code height to 81px for now
- fixes #613, bottom of page being cut-off as viewport height was too big

The 81px offset was determined by testing, ideally could get it from somewhere?
Result:
<img width="1438" alt="Screenshot 2024-06-14 at 12 31 21 PM" src="https://github.com/webrecorder/browsertrix-crawler/assets/1015759/f1b5ec09-edb0-4187-bdcd-9a09b63c97ff">


Note: Tested locally, but need to ensure this doesn't break QA when screenshots taken with old viewport, otherwise, need to account for that.
