### PR TITLE
btoa() the auth from yaml config too

### DIFF
--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -52,7 +52,7 @@ export class ScopedSeed {
       throw new Error("Invalid URL");
     }
     if (auth || (parsedUrl.username && parsedUrl.password)) {
-      this.auth = auth || btoa(parsedUrl.username + ":" + parsedUrl.password);
+      this.auth = btoa(auth || (parsedUrl.username + ":" + parsedUrl.password));
       parsedUrl.username = "";
       parsedUrl.password = "";
     } else {

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -52,7 +52,7 @@ export class ScopedSeed {
       throw new Error("Invalid URL");
     }
     if (auth || (parsedUrl.username && parsedUrl.password)) {
-      this.auth = btoa(auth || (parsedUrl.username + ":" + parsedUrl.password));
+      this.auth = btoa(auth || parsedUrl.username + ":" + parsedUrl.password);
       parsedUrl.username = "";
       parsedUrl.password = "";
     } else {


### PR DESCRIPTION
I think this small change is needed for specifying the username and password using the `auth` property in the seed configuration?

```yaml
seeds:
  - url: http://www.example.com
    auth: "user:pass"
```

Refs #616