### PR TITLE
logging: log error message when seed is failed to be created 

### DIFF
--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -687,7 +687,13 @@ class ArgParser {
 
         try {
           argv.scopedSeeds.push(new ScopedSeed({ ...scopeOpts, ...seed }));
-        } catch (e) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (e: any) {
+          logger.error("Failed to create seed", {
+            error: e.toString(),
+            ...scopeOpts,
+            ...seed,
+          });
           if (argv.failOnFailedSeed) {
             logger.fatal(
               "Invalid seed specified, aborting crawl",


### PR DESCRIPTION
for example, due to bad include/exclude regex, fixes #598