### PR TITLE
disable socat by default

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -496,11 +496,13 @@ export class Crawler {
       }
     });
 
-    child_process.spawn(
-      "socat",
-      ["tcp-listen:9222,reuseaddr,fork", "tcp:localhost:9221"],
-      { detached: RUN_DETACHED },
-    );
+    if (this.params.debugAccessBrowser) {
+      child_process.spawn(
+        "socat",
+        ["tcp-listen:9222,reuseaddr,fork", "tcp:localhost:9221"],
+        { detached: RUN_DETACHED },
+      );
+    }
 
     if (!this.params.headless && !process.env.NO_XVFB) {
       child_process.spawn(

--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -394,10 +394,13 @@ class InteractiveBrowser {
     targetId: string,
   ) {
     logger.info("Creating Profile Interactively...");
-    child_process.spawn("socat", [
-      "tcp-listen:9222,reuseaddr,fork",
-      "tcp:localhost:9221",
-    ]);
+
+    if (params.headless) {
+      child_process.spawn("socat", [
+        "tcp-listen:9222,reuseaddr,fork",
+        "tcp:localhost:9221",
+      ]);
+    }
 
     this.params = params;
     this.browser = browser;

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -531,6 +531,11 @@ class ArgParser {
         type: "boolean",
       },
 
+      debugAccessBrowser: {
+        describe: "if set, allow debugging browser on port 9222 via CDP",
+        type: "boolean",
+      },
+
       warcPrefix: {
         describe:
           "prefix for WARC files generated, including WARCs added to WACZ",


### PR DESCRIPTION
- crawling: add '--debugAccessBrowser' flag to enable connecting via 9222, only run socat then
- profiles: only run socat in headless mode