### PR TITLE
browser policies: disable restoring any tabs on startup + set new tab URL to about:blank

### DIFF
--- a/config/policies/lockdown-profilebrowser.json
+++ b/config/policies/lockdown-profilebrowser.json
@@ -1,4 +1,6 @@
 {
+    "NewTabPageLocation": "about:blank",
+    "RestoreOnStartup": 5,
     "IncognitoModeAvailability": 1,
     "TorDisabled": true,
     "AllowFileSelectionDialogs": false,


### PR DESCRIPTION
addresses memory issues with profiles as they accumulate tabs! fixes webrecorder/browsertrix#1880