### PR TITLE
Don't filter saving redirect if no response body.

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1059,13 +1059,17 @@ export class Recorder {
       );
       return;
     } else if (reqresp.shouldSkipSave()) {
-      logNetwork("Skipping writing request/response", {
-        requestId,
-        url,
-        method,
-        status,
-        payloadLength: (payload && payload.length) || 0,
-      });
+      logger.debug(
+        "Skipping writing request/response",
+        {
+          requestId,
+          url,
+          method,
+          status,
+          payloadLength: (payload && payload.length) || 0,
+        },
+        "recorder",
+      );
       return;
     }
 
@@ -1568,9 +1572,11 @@ function createResponse(
   const statusline = `HTTP/1.1 ${reqresp.status} ${reqresp.statusText}`;
   const date = new Date(reqresp.ts).toISOString();
 
-  const httpHeaders = reqresp.getResponseHeadersDict(
-    reqresp.payload ? reqresp.payload.length : 0,
-  );
+  if (!reqresp.payload) {
+    reqresp.payload = new Uint8Array();
+  }
+
+  const httpHeaders = reqresp.getResponseHeadersDict(reqresp.payload.length);
 
   const warcHeaders: Record<string, string> = {
     "WARC-Page-ID": pageid,

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -318,10 +318,13 @@ export class RequestResponseInfo {
     // skip cached, OPTIONS/HEAD responses, and 304 or 206 responses
     if (
       this.fromCache ||
-      !this.payload ||
       (this.method && ["OPTIONS", "HEAD"].includes(this.method)) ||
       [206, 304].includes(this.status)
     ) {
+      return true;
+    }
+
+    if (!this.payload && !isRedirectStatus(this.status)) {
       return true;
     }
 

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -324,7 +324,8 @@ export class RequestResponseInfo {
       return true;
     }
 
-    if (!this.payload && !isRedirectStatus(this.status)) {
+    // skip no payload response only if its not a redirect
+    if (!this.payload && !this.isRedirectStatus()) {
       return true;
     }
 

--- a/tests/brave-query-redir.test.js
+++ b/tests/brave-query-redir.test.js
@@ -1,0 +1,37 @@
+import fs from "fs";
+import { execSync } from "child_process";
+
+test("check that gclid query URL is automatically redirected to remove it", async () => {
+  try {
+    execSync(
+      "docker run --rm  -v $PWD/test-crawls:/crawls -i webrecorder/browsertrix-crawler crawl --url 'https://webrecorder.net/about?gclid=abc' --collection test-brave-redir --behaviors \"\" --limit 1 --generateCDX");
+
+  } catch (error) {
+    console.log(error.stderr);
+  }
+
+  const filedata = fs.readFileSync(
+    "test-crawls/collections/test-brave-redir/indexes/index.cdxj",
+    { encoding: "utf-8" },
+  );
+
+  let responseFound = false;
+  let redirectFound = false;
+
+  const lines = filedata.trim().split("\n");
+
+  for (const line of lines) {
+    const json = line.split(" ").slice(2).join(" ");
+    const data = JSON.parse(json);
+    if (data.url === "https://webrecorder.net/about?gclid=abc" && data.status === "307") {
+      redirectFound = true;
+    } else if (data.url === "https://webrecorder.net/about" && data.status === "200") {
+      responseFound = true;
+    }
+    if (responseFound && redirectFound) {
+      break;
+    }
+  }
+
+  expect(redirectFound && responseFound).toBe(true);
+});


### PR DESCRIPTION
It's possible for a redirect, especially a browser-generated one to have headers and no body (eg. Brave removing tracking url query). Don't filter these out from being written to WARC, just send payload to empty buffer.

fixes #627 where Brave-generated redirect response was not stored.