### PR TITLE
Improved handling of pages that redirect back to the same page.

### DIFF
--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -412,6 +412,7 @@ export class ReplayCrawler extends Crawler {
       ts: date,
       comparison: { resourceCounts: {} },
       counts: { jsErrors: 0 },
+      tsStatus: 999,
     };
     this.pageInfos.set(page, pageInfo);
 

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -827,12 +827,12 @@ return inx;
     return await this.redis.zcard(this.qkey);
   }
 
-  async addIfNoDupe(key: string, value: string) {
-    return (await this.redis.sadd(key, value)) === 1;
+  async addIfNoDupe(key: string, url: string, status: number) {
+    return (await this.redis.sadd(key, status + "|" + url)) === 1;
   }
 
-  async removeDupe(key: string, value: string) {
-    return await this.redis.srem(key, value);
+  async removeDupe(key: string, url: string, status: number) {
+    return await this.redis.srem(key, status + "|" + url);
   }
 
   async logError(error: string) {


### PR DESCRIPTION
In the case of a page https://example.com/ which results in a redirect chain: 307 https://example.com/ -> 307 https://auth.example.com/ -> 200 https://example.com/
- Includes status in dupe checks, ensures that `307 https://example.com/` and `200 https://example.com/` are both recorded to WARC
- When setting page timestamp, update the timestamp to the lower status code if above 300, eg. first setting to `307 https://example.com/` and then to `200 https://example.com/`

Fixes #634 

Testing:
- The site: https://www.journaldemontreal.com/ includes such as redirect chain which results in the 200 response not being captured, before this fix. (Note: for replay, a separate fix is needed in wabac.js in case the 307 and 200 responses are the same timestamp, to ensure the 200 one is chosen, this is fixed via: webrecorder/wabac.js#188)

