### PR TITLE
Fix Pending Request causing timeout

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -323,18 +323,19 @@ export class Recorder {
   }
 
   handleRequestWillBeSent(params: Protocol.Network.RequestWillBeSentEvent) {
-    // only handling redirect here, committing last response in redirect chain
-    // request data stored from requestPaused
     const { redirectResponse, requestId, request, type } = params;
 
     const { headers, method, url } = request;
 
     logNetwork("Network.requestWillBeSent", {
       requestId,
+      url,
       redirectResponse,
       ...this.logDetails,
     });
 
+    // handling redirect here, committing last response in redirect chain
+    // request data stored from requestPaused
     if (redirectResponse) {
       this.handleRedirectResponse(params);
     } else {
@@ -788,8 +789,14 @@ export class Recorder {
       if (reqresp.payload) {
         this.removeReqResp(requestId);
         await this.serializeToWARC(reqresp);
-        // no url, likely invalid
-      } else if (!reqresp.url) {
+        // if no url, and not fetch intercept or async loading,
+        // drop this request, as it was not being loaded
+      } else if (!reqresp.url || (!reqresp.fetch && !reqresp.asyncLoading)) {
+        logger.debug(
+          "Removing pending request that was never fetched",
+          { requestId, url: reqresp.url, ...this.logDetails },
+          "recorder",
+        );
         this.removeReqResp(requestId);
       }
     }
@@ -805,12 +812,16 @@ export class Recorder {
           url: string;
           expectedSize?: number;
           readSize?: number;
+          resourceType?: string;
         } = { requestId, url };
         if (reqresp.expectedSize) {
           entry.expectedSize = reqresp.expectedSize;
         }
         if (reqresp.readSize) {
           entry.readSize = reqresp.readSize;
+        }
+        if (reqresp.resourceType) {
+          entry.resourceType = reqresp.resourceType;
         }
         pending.push(entry);
       }

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -791,7 +791,10 @@ export class Recorder {
         await this.serializeToWARC(reqresp);
         // if no url, and not fetch intercept or async loading,
         // drop this request, as it was not being loaded
-      } else if (!reqresp.url || (!reqresp.fetch && !reqresp.asyncLoading)) {
+      } else if (
+        !reqresp.url ||
+        (!reqresp.intercepting && !reqresp.asyncLoading)
+      ) {
         logger.debug(
           "Removing pending request that was never fetched",
           { requestId, url: reqresp.url, ...this.logDetails },

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -53,8 +53,6 @@ export class RequestResponseInfo {
 
   frameId?: string;
 
-  fetch = false;
-
   resourceType?: string;
 
   // TODO: Fix this the next time the file is edited.
@@ -64,6 +62,9 @@ export class RequestResponseInfo {
   // stats
   readSize: number = 0;
   expectedSize: number = 0;
+
+  // set to true to indicate request intercepted via Fetch.requestPaused
+  fetch = false;
 
   // set to true to indicate async loading in progress
   asyncLoading: boolean = false;

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -64,7 +64,7 @@ export class RequestResponseInfo {
   expectedSize: number = 0;
 
   // set to true to indicate request intercepted via Fetch.requestPaused
-  fetch = false;
+  intercepting = false;
 
   // set to true to indicate async loading in progress
   asyncLoading: boolean = false;
@@ -84,7 +84,7 @@ export class RequestResponseInfo {
 
     this.responseHeadersList = params.responseHeaders;
 
-    this.fetch = true;
+    this.intercepting = true;
 
     this.frameId = params.frameId;
   }


### PR DESCRIPTION
Occasionally, it seems some pending requests that only go through `Network.requestWillBeSent` but never receive a finished/failed/blocked message persist in the pending request list.

Instead of waiting for them to finish until timeout, just drop these requests. Requests that have never been intercepted (`fetch` is set) and are not being loaded asynchronously (`asyncLoading` is set) should be discarded when the page is done. Large requests that are streaming the response body, etc.. will have one of these flags set.

(Chrome devtools also handles these by marking their state to 'unknown')..

Test:
- Run a crawl of a few pages of: https://www.cbc.ca/news/canada with debug logging
- Observe a few (possibly blocked) tracking requests are stuck in "Finishing pending requests for page" without this fix.
- With this fix, they should be dropped and `Removing pending request that was never fetched` is logged. 