### PR TITLE
Loosen selectors for login fields in automated profile creation

### DIFF
--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -266,10 +266,10 @@ async function automatedProfile(
 
   try {
     u = await page.waitForSelector(
-      "//input[contains(@name, 'user') or contains(@name, 'email')]",
+      "input[name='user'],input[name='username'],input[name='email']",
     );
     p = await page.waitForSelector(
-      "//input[contains(@name, 'pass') and @type='password']",
+      "input[type='password'].input[name='pass'],input[name='password']",
     );
   } catch (e) {
     if (params.debugScreenshot) {

--- a/tests/pageinfo-records.test.js
+++ b/tests/pageinfo-records.test.js
@@ -113,7 +113,7 @@ function validateResourcesIndex(json) {
       { status: 200, mime: "text/css", type: "stylesheet" },
     "https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro&display=swap":
       { status: 200, mime: "text/css", type: "stylesheet" },
-    "https://stats.browsertrix.com/js/script.js": {
+    "https://stats.browsertrix.com/js/script.tagged-events.js": {
       status: 200,
       mime: "application/javascript",
       type: "script",
@@ -158,7 +158,7 @@ function validateResourcesAbout(json) {
       { status: 200, mime: "text/css", type: "stylesheet" },
     "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@700;900&display=swap":
       { status: 200, mime: "text/css", type: "stylesheet" },
-    "https://stats.browsertrix.com/js/script.js": {
+    "https://stats.browsertrix.com/js/script.tagged-events.js": {
       status: 200,
       mime: "application/javascript",
       type: "script",


### PR DESCRIPTION
Fixes #637 

- Username will match if name attribute is one of: user, username, email
- Password will match if type is password and name attribute is one of: pass, password

This loosens the rules sufficiently to solve the issue with the URL in the linked issue without requiring users to pass custom CSS selectors at this point.

It looks like we were also using XPath methods like contains whereas puppeteer expects CSS selectors, hence the syntax change.