### PR TITLE
Fix 206 response + general video handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ADD config/ /app/
 
 ADD html/ /app/html/
 
-ARG RWP_VERSION=2.1.1
+ARG RWP_VERSION=2.1.2
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/ui.js /app/html/rwp/
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/sw.js /app/html/rwp/
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/adblock/adblock.gz /app/html/rwp/adblock.gz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@novnc/novnc": "^1.4.0",
     "@types/sax": "^1.2.7",
-    "@webrecorder/wabac": "^2.19.1",
+    "@webrecorder/wabac": "^2.19.4",
     "browsertrix-behaviors": "^0.6.2",
     "crc": "^4.3.2",
     "fetch-socks": "^1.3.0",

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -20,7 +20,7 @@ export function formatErr(e: unknown): Record<string, any> {
   } else if (typeof e === "object") {
     return e || {};
   } else {
-    return { message: (e as object).toString() };
+    return { message: (e as object) + "" };
   }
 }
 

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -584,6 +584,10 @@ export class Recorder {
 
         const reqresp = new RequestResponseInfo("0");
         reqresp.fillRequest(params.request, params.resourceType);
+        if (reqresp.requestHeaders) {
+          delete reqresp.requestHeaders["range"];
+          delete reqresp.requestHeaders["Range"];
+        }
         reqresp.frameId = params.frameId;
 
         this.addAsyncFetch(
@@ -604,6 +608,8 @@ export class Recorder {
           { range, contentLen, url, ...this.logDetails },
           "recorder",
         );
+        this.removeReqResp(networkId);
+        return false;
       }
     }
 
@@ -1620,7 +1626,7 @@ class NetworkLoadStreamAsyncFetcher extends AsyncFetcher {
       return;
     }
 
-    reqresp.status = httpStatusCode || 0;
+    reqresp.setStatus(httpStatusCode || 200);
     reqresp.responseHeaders = headers || {};
 
     return this.takeStreamIter(cdp, stream);

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1145,7 +1145,7 @@ export class Recorder {
       !isRedirectStatus(status) &&
       !(await this.crawlState.addIfNoDupe(WRITE_DUPE_KEY, url, status))
     ) {
-      logNetwork("Skipping dupe", { url });
+      logNetwork("Skipping dupe", { url, status, ...this.logDetails });
       return;
     }
 

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1007,6 +1007,7 @@ export class Recorder {
         "recorder",
       );
       reqresp.payload = encoder.encode(newString);
+      reqresp.isRemoveRange = true;
       return true;
     } else {
       return false;
@@ -1640,6 +1641,10 @@ function createResponse(
   pageid: string,
   contentIter?: AsyncIterable<Uint8Array> | Iterable<Uint8Array>,
 ) {
+  if (reqresp.isRemoveRange && reqresp.status === 206) {
+    reqresp.setStatus(200);
+  }
+
   const url = reqresp.url;
   const warcVersion = "WARC/1.1";
   const statusline = `HTTP/1.1 ${reqresp.status} ${reqresp.statusText}`;

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -77,11 +77,17 @@ export class RequestResponseInfo {
     this.requestId = requestId;
   }
 
+  setStatus(status: number, statusText?: string) {
+    this.status = status;
+    this.statusText = statusText || getStatusText(this.status);
+  }
+
   fillFetchRequestPaused(params: Protocol.Fetch.RequestPausedEvent) {
     this.fillRequest(params.request, params.resourceType);
 
-    this.status = params.responseStatusCode || 0;
-    this.statusText = params.responseStatusText || getStatusText(this.status);
+    if (params.responseStatusCode) {
+      this.setStatus(params.responseStatusCode, params.responseStatusText);
+    }
 
     this.responseHeadersList = params.responseHeaders;
 
@@ -117,8 +123,7 @@ export class RequestResponseInfo {
 
     this.url = response.url.split("#")[0];
 
-    this.status = response.status;
-    this.statusText = response.statusText || getStatusText(this.status);
+    this.setStatus(response.status, response.statusText);
 
     this.protocol = response.protocol;
 
@@ -183,8 +188,7 @@ export class RequestResponseInfo {
 
   fillFetchResponse(response: Response) {
     this.responseHeaders = Object.fromEntries(response.headers);
-    this.status = response.status;
-    this.statusText = response.statusText || getStatusText(this.status);
+    this.setStatus(response.status, response.statusText);
   }
 
   fillRequestExtraInfo(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1300,21 +1300,21 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@webrecorder/wabac@^2.19.1":
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.19.1.tgz#ce0d609f9e90c708af99945e1fa338be0ba2b5f9"
-  integrity sha512-m8Fi70OkhzkicbcbN5TrrBpj5D/EZKzVp5905kGPoC2F2zLqxUDMzx1FOHt2sTO/1b9NMvBmw9Pk1JQyYEm6rA==
+"@webrecorder/wabac@^2.19.4":
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.19.4.tgz#6c91a65928413b8394f17b57f57a803dcb111dbe"
+  integrity sha512-USWUoreSfgyeYYrC2/o2YYr4dCUSwgOSzbpdapqh90VQ4Fb0fjwPAiessBCH4rA5yd9QpOgWdkapDmXvLx6Bww==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"
     "@peculiar/x509" "^1.9.2"
-    "@webrecorder/wombat" "^3.7.8"
+    "@webrecorder/wombat" "^3.7.11"
     acorn "^8.10.0"
     auto-js-ipfs "^2.1.1"
     base64-js "^1.5.1"
     brotli "^1.3.3"
     buffer "^6.0.3"
-    fast-xml-parser "^4.2.5"
+    fast-xml-parser "^4.4.0"
     hash-wasm "^4.9.0"
     http-link-header "^1.1.3"
     http-status-codes "^2.1.4"
@@ -1329,10 +1329,10 @@
     stream-browserify "^3.0.0"
     warcio "^2.2.1"
 
-"@webrecorder/wombat@^3.7.8":
-  version "3.7.8"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.7.8.tgz#a414278b6fbd99bc02a97e384f0373307e60d9fa"
-  integrity sha512-BmEHrvGLHPQtECmCK9Oz7G3p2StsyaFOlNmAMDSNK/GjqPH+UWZOqDryBkWryTh+pFZXKblqyotLtvR4YxVyeQ==
+"@webrecorder/wombat@^3.7.11":
+  version "3.7.11"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.7.11.tgz#27539f52317b2d80af4f28d971d59b53bc0f2b96"
+  integrity sha512-WlGpKjHUpP2aZo/OrY5aduNX/TVdo+hSkzu9as/63wSQ4ZFWIqZ+pxYXci43hjV5oVjcMP4KALLq+V+Fuo8qSA==
   dependencies:
     warcio "^2.2.0"
 
@@ -2431,7 +2431,7 @@ fast-xml-parser@^4.2.2:
   dependencies:
     strnum "^1.0.5"
 
-fast-xml-parser@^4.2.5:
+fast-xml-parser@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz#341cc98de71e9ba9e651a67f41f1752d1441a501"
   integrity sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==


### PR DESCRIPTION
Refactors handling of 206 responses:
- If a 206 response is encountered, and its actually the full range, convert to 200 and rewrite range and content-range headers to x-range and x-orig-range. This is to support rewriting of 206 responses for DASH manifests
- If a partial 206 response starting with `0-`, do a full async fetch separately.
- If a partial 206 response not starting with 0-, just ignore (very likely a duplicate picked up when handling the 0- response)
- Don't stream content-types that can be rewritten, since streaming prevents rewriting. Fixes rewriting on DASH/HLS manifests which have no content-length and don't get properly rewritten.
- Overall, adds missing rewriting of DASH/HLS manifests that have no content-length and are served as 206.
- Update to latest wabac.js which fixes rewriting of DASH manifest to avoid duplicate '<?xml' prefix, webrecorder/wabac.js#192
- Fixes #645 

Testing:
Combined with RWP 2.1.2 (released), this fixes the capture and replay of videos on such sites as:
- https://www.rferl.org/a/weeks-best-rferl-videos-stories-27-2024/33030874.html
- https://www.bbc.com/news/videos/cy7985ly17yo (replay doesn't yet work 100% but probably not related)
