### PR TITLE
Make it clear that profile argument can be an HTTP(S) URL

### DIFF
--- a/docs/docs/user-guide/browser-profiles.md
+++ b/docs/docs/user-guide/browser-profiles.md
@@ -76,7 +76,7 @@ The profile creation script attempts to detect the username and password fields 
 
 ## Using Browser Profile with a Crawl
 
-To use a previously created profile with a crawl, use the `--profile` flag or `profile` option. The `--profile` flag can then be used to specify any Brave Browser profile stored as a tarball. Using profiles created with same or older version of Browsertrix Crawler is recommended to ensure compatibility. This option allows running a crawl with the browser already pre-configured, logged in to certain sites, language settings configured, etc.
+To use a previously created profile with a crawl, use the `--profile` flag or `profile` option. The `--profile` flag can then be used to specify any Brave Browser profile stored as a tarball. Browser profile can be either stored locally and provided as a path, or available online at any HTTP(S) URL which will be downloaded before starting the crawl. Using profiles created with same or older version of Browsertrix Crawler is recommended to ensure compatibility. This option allows running a crawl with the browser already pre-configured, logged in to certain sites, language settings configured, etc.
 
 After running the above command, you can now run a crawl with the profile, as follows:
 

--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -292,8 +292,8 @@ Options:
                                                       [boolean] [default: false]
   --shutdownWait     Shutdown browser in interactive after this many seconds, if
                       no pings received                    [number] [default: 0]
-  --profile          Path or HTTP(S) URL to tar.gz file which will be used as
-                      the browser profile                               [string]
+  --profile          Path or HTTP(S) URL to tar.gz file which contains the brows
+                     er profile directory                               [string]
   --windowSize       Browser window dimensions, specified as: width,height
                                                  [string] [default: "1360,1020"]
   --proxy                                             [boolean] [default: false]

--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -292,8 +292,8 @@ Options:
                                                       [boolean] [default: false]
   --shutdownWait     Shutdown browser in interactive after this many seconds, if
                       no pings received                    [number] [default: 0]
-  --profile          Path to tar.gz file which will be extracted and used as the
-                      browser profile                                   [string]
+  --profile          Path or HTTP(S) URL to tar.gz file which will be used as
+                      the browser profile                               [string]
   --windowSize       Browser window dimensions, specified as: width,height
                                                  [string] [default: "1360,1020"]
   --proxy                                             [boolean] [default: false]

--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -155,9 +155,9 @@ Options:
                                                            [number] [default: 0]
       --dedupPolicy                         Deduplication policy
                  [string] [choices: "skip", "revisit", "keep"] [default: "skip"]
-      --profile                             Path to tar.gz file which will be ex
-                                            tracted and used as the browser prof
-                                            ile                         [string]
+      --profile                             Path or HTTP(S) URL to tar.gz file w
+                                            hich contains the browser profile di
+                                            rectory                     [string]
       --screenshot                          Screenshot options for crawler, can
                                             include: view, thumbnail, fullPage
                 [array] [choices: "view", "thumbnail", "fullPage"] [default: []]

--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -90,7 +90,7 @@ function cliOpts(): { [key: string]: Options } {
 
     profile: {
       describe:
-        "Path to tar.gz file which will be extracted and used as the browser profile",
+        "Path or HTTP(S) URL to tar.gz file which will be used as the browser profile",
       type: "string",
     },
 

--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -90,7 +90,7 @@ function cliOpts(): { [key: string]: Options } {
 
     profile: {
       describe:
-        "Path or HTTP(S) URL to tar.gz file which will be used as the browser profile",
+        "Path or HTTP(S) URL to tar.gz file which contains the browser profile directory",
       type: "string",
     },
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -341,7 +341,7 @@ class ArgParser {
 
       profile: {
         describe:
-          "Path to tar.gz file which will be extracted and used as the browser profile",
+          "Path or HTTP(S) URL to tar.gz file which will be used as the browser profile",
         type: "string",
       },
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -341,7 +341,7 @@ class ArgParser {
 
       profile: {
         describe:
-          "Path or HTTP(S) URL to tar.gz file which will be used as the browser profile",
+          "Path or HTTP(S) URL to tar.gz file which contains the browser profile directory",
         type: "string",
       },
 


### PR DESCRIPTION
Small documentation enhancement to make it clear that browser profile can be passed as HTTP(S) URL as well.

Nota: I simplified the doc by not specifying anymore that the tar.gz will be extracted, I think it is a detail which most user shouldn't be concerned about.