### PR TITLE
Implemented option for FullPage screenshot after the behaviours have run

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1031,6 +1031,21 @@ self.__bx_behaviors.selectMainBehavior();
         if (textextract && this.params.text.includes("final-to-warc")) {
           await textextract.extractAndStoreText("textFinal", true, true);
         }
+
+        if (this.params.screenshot && this.screenshotWriter) {
+          await page.evaluate(() => {
+            window.scrollTo(0, 0);
+          });
+          const screenshots = new Screenshots({
+            browser: this.browser,
+            page,
+            url,
+            writer: this.screenshotWriter,
+          });
+          if (this.params.screenshot.includes("fullPageAfterBehaviors")) {
+            await screenshots.takeFullPageAfterBehaviours();
+          }
+        }
       }
     }
   }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1035,7 +1035,7 @@ self.__bx_behaviors.selectMainBehavior();
         if (
           this.params.screenshot &&
           this.screenshotWriter &&
-          this.params.screenshot.includes("fullPageAfterBehaviors")
+          this.params.screenshot.includes("fullPageFinal")
         ) {
           await page.evaluate(() => {
             window.scrollTo(0, 0);
@@ -1046,7 +1046,7 @@ self.__bx_behaviors.selectMainBehavior();
             url,
             writer: this.screenshotWriter,
           });
-          await screenshots.takeFullPageAfterBehaviours();
+          await screenshots.takeFullPageFinal();
         }
       }
     }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1032,7 +1032,11 @@ self.__bx_behaviors.selectMainBehavior();
           await textextract.extractAndStoreText("textFinal", true, true);
         }
 
-        if (this.params.screenshot && this.screenshotWriter) {
+        if (
+          this.params.screenshot &&
+          this.screenshotWriter &&
+          this.params.screenshot.includes("fullPageAfterBehaviors")
+        ) {
           await page.evaluate(() => {
             window.scrollTo(0, 0);
           });
@@ -1042,9 +1046,7 @@ self.__bx_behaviors.selectMainBehavior();
             url,
             writer: this.screenshotWriter,
           });
-          if (this.params.screenshot.includes("fullPageAfterBehaviors")) {
-            await screenshots.takeFullPageAfterBehaviours();
-          }
+          await screenshots.takeFullPageAfterBehaviours();
         }
       }
     }

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -390,7 +390,7 @@ class ArgParser {
 
         screenshot: {
           describe:
-          "Screenshot options for crawler, can include: view, thumbnail, fullPage, fullPageAfterBehaviors",
+            "Screenshot options for crawler, can include: view, thumbnail, fullPage, fullPageAfterBehaviors",
           type: "array",
           default: [],
           choices: Array.from(Object.keys(screenshotTypes)),

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -390,7 +390,7 @@ class ArgParser {
 
         screenshot: {
           describe:
-            "Screenshot options for crawler, can include: view, thumbnail, fullPage",
+          "Screenshot options for crawler, can include: view, thumbnail, fullPage, fullPageAfterBehaviors",
           type: "array",
           default: [],
           choices: Array.from(Object.keys(screenshotTypes)),

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -390,7 +390,7 @@ class ArgParser {
 
         screenshot: {
           describe:
-            "Screenshot options for crawler, can include: view, thumbnail, fullPage, fullPageAfterBehaviors",
+            "Screenshot options for crawler, can include: view, thumbnail, fullPage, fullPageFinal",
           type: "array",
           default: [],
           choices: Array.from(Object.keys(screenshotTypes)),

--- a/src/util/screenshots.ts
+++ b/src/util/screenshots.ts
@@ -15,7 +15,11 @@ type ScreenShotDesc = {
   encoding: "binary";
 };
 
-type ScreeshotType = "view" | "thumbnail" | "fullPage" | "fullPageAfterBehaviors";
+type ScreeshotType =
+  | "view"
+  | "thumbnail"
+  | "fullPage"
+  | "fullPageAfterBehaviors";
 
 export const screenshotTypes: Record<string, ScreenShotDesc> = {
   view: {
@@ -69,7 +73,10 @@ export class Screenshots {
     state: PageState | null = null,
   ) {
     try {
-      if (screenshotType !== "fullPage" && screenshotType !== "fullPageAfterBehaviors") {
+      if (
+        screenshotType !== "fullPage" &&
+        screenshotType !== "fullPageAfterBehaviors"
+      ) {
         await this.browser.setViewport(this.page, {
           width: 1920,
           height: 1080,

--- a/src/util/screenshots.ts
+++ b/src/util/screenshots.ts
@@ -15,7 +15,7 @@ type ScreenShotDesc = {
   encoding: "binary";
 };
 
-type ScreeshotType = "view" | "thumbnail" | "fullPage";
+type ScreeshotType = "view" | "thumbnail" | "fullPage" | "fullPageAfterBehaviors";
 
 export const screenshotTypes: Record<string, ScreenShotDesc> = {
   view: {
@@ -31,6 +31,12 @@ export const screenshotTypes: Record<string, ScreenShotDesc> = {
     encoding: "binary",
   },
   fullPage: {
+    type: "png",
+    omitBackground: true,
+    fullPage: true,
+    encoding: "binary",
+  },
+  fullPageAfterBehaviors: {
     type: "png",
     omitBackground: true,
     fullPage: true,
@@ -63,7 +69,7 @@ export class Screenshots {
     state: PageState | null = null,
   ) {
     try {
-      if (screenshotType !== "fullPage") {
+      if (screenshotType !== "fullPage" && screenshotType !== "fullPageAfterBehaviors") {
         await this.browser.setViewport(this.page, {
           width: 1920,
           height: 1080,
@@ -103,6 +109,10 @@ export class Screenshots {
 
   async takeFullPage() {
     await this.take("fullPage");
+  }
+
+  async takeFullPageAfterBehaviours() {
+    await this.take("fullPageAfterBehaviors");
   }
 
   async takeThumbnail() {

--- a/src/util/screenshots.ts
+++ b/src/util/screenshots.ts
@@ -15,11 +15,7 @@ type ScreenShotDesc = {
   encoding: "binary";
 };
 
-type ScreeshotType =
-  | "view"
-  | "thumbnail"
-  | "fullPage"
-  | "fullPageAfterBehaviors";
+type ScreeshotType = "view" | "thumbnail" | "fullPage" | "fullPageFinal";
 
 export const screenshotTypes: Record<string, ScreenShotDesc> = {
   view: {
@@ -40,7 +36,7 @@ export const screenshotTypes: Record<string, ScreenShotDesc> = {
     fullPage: true,
     encoding: "binary",
   },
-  fullPageAfterBehaviors: {
+  fullPageFinal: {
     type: "png",
     omitBackground: true,
     fullPage: true,
@@ -73,10 +69,7 @@ export class Screenshots {
     state: PageState | null = null,
   ) {
     try {
-      if (
-        screenshotType !== "fullPage" &&
-        screenshotType !== "fullPageAfterBehaviors"
-      ) {
+      if (screenshotType !== "fullPage" && screenshotType !== "fullPageFinal") {
         await this.browser.setViewport(this.page, {
           width: 1920,
           height: 1080,
@@ -118,8 +111,8 @@ export class Screenshots {
     await this.take("fullPage");
   }
 
-  async takeFullPageAfterBehaviours() {
-    await this.take("fullPageAfterBehaviors");
+  async takeFullPageFinal() {
+    await this.take("fullPageFinal");
   }
 
   async takeThumbnail() {


### PR DESCRIPTION
This PR implements a new option to take the FullPage screenshot **after** the behaviours have run instead of before.
This allows to capture elements that might not be fully loaded until the whole page is visited.

I only implemented for fullpage as I think it is the only screenshot where this is useful and the only case where I would need it, as it can include content not currently in frame. Feel free to expand on that as needed.

Related to #486

Tested with custom docker, though I had to ensure setuptools v71 as else it would not build.