### PR TITLE
Ignore invalid URLs in redirects

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -400,6 +400,17 @@ export class Recorder {
       return;
     }
 
+    try {
+      new URL(reqresp.url);
+    } catch (e) {
+      logger.warn(
+        "Skipping invalid URL from redirect",
+        { url: reqresp.url, status: reqresp.status, ...this.logDetails },
+        "recorder",
+      );
+      return;
+    }
+
     this.serializeToWARC(reqresp);
   }
 


### PR DESCRIPTION
ensure URL from redirects are valid - it's possible that a redirect is a 'synthetic' redirect created by the browser for http->https enforcement, which may include an invalid URL. eg: http://<invalid url> -> https://<invalid url>
Prevent trying to record this invalid URL
fixes #654

Repro:
From #654, running `docker run --rm -v $PWD/crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.worldradiohistory.com/BOOKSHELF-ARH/ --url https://www.worldradiohistory.com/BOOKSHELF-ARH/Bookshelf_Bernards_Babani.htm --limit 2 --logging debug` results in a crashing exception - the second page redirects to an invalid http URL, which creates an automatic redirect to an invalid https URL.

Didn't make this more broad so can catch other edge cases where invalid URLs could arise.
