### PR TITLE
QA: Ensure empty string is propagated for comparison

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
         run: yarn run tsc
 
       - name: build docker
-        run: docker-compose build
+        run: docker compose build
 
       - name: install python deps for docs
         run: pip install mkdocs-material

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -947,7 +947,7 @@ self.__bx_behaviors.selectMainBehavior();
         this.params.text.includes("to-warc"),
       );
 
-      if (text && (this.textInPages || saveOutput)) {
+      if (text !== null && (this.textInPages || saveOutput)) {
         data.text = text;
       }
     }

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -565,7 +565,11 @@ export class ReplayCrawler extends Crawler {
 
     const dist = levenshtein(origText, replayText);
     const maxLen = Math.max(origText.length, replayText.length);
-    const matchPercent = (maxLen - dist) / maxLen;
+
+    let matchPercent = 1.0;
+    if (maxLen > 0) {
+      matchPercent = (maxLen - dist) / maxLen;
+    }
     logger.info("Levenshtein Dist", { url, dist, matchPercent, maxLen });
 
     const pageInfo = this.pageInfos.get(page);

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -554,26 +554,14 @@ export class ReplayCrawler extends Crawler {
   }
 
   async compareText(page: Page, state: PageState, url: string, date: Date) {
-    const origText = await this.fetchOrigText(
-      page,
-      "text",
-      url,
-      date.toISOString().replace(/[^\d]/g, ""),
-    );
-    const replayText = state.text;
-
-    if (origText === undefined || replayText === undefined) {
-      logger.warn(
-        "Text missing for comparison",
-        {
-          url,
-          origTextLen: origText?.length,
-          replayTextLen: replayText?.length,
-        },
-        "replay",
-      );
-      return;
-    }
+    const origText =
+      (await this.fetchOrigText(
+        page,
+        "text",
+        url,
+        date.toISOString().replace(/[^\d]/g, ""),
+      )) || "";
+    const replayText = state.text || "";
 
     const dist = levenshtein(origText, replayText);
     const maxLen = Math.max(origText.length, replayText.length);

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -554,14 +554,26 @@ export class ReplayCrawler extends Crawler {
   }
 
   async compareText(page: Page, state: PageState, url: string, date: Date) {
-    const origText =
-      (await this.fetchOrigText(
-        page,
-        "text",
-        url,
-        date.toISOString().replace(/[^\d]/g, ""),
-      )) || "";
-    const replayText = state.text || "";
+    const origText = await this.fetchOrigText(
+      page,
+      "text",
+      url,
+      date.toISOString().replace(/[^\d]/g, ""),
+    );
+    const replayText = state.text;
+
+    if (origText === undefined || replayText === undefined) {
+      logger.warn(
+        "Text missing for comparison",
+        {
+          url,
+          origTextLen: origText?.length,
+          replayTextLen: replayText?.length,
+        },
+        "replay",
+      );
+      return;
+    }
 
     const dist = levenshtein(origText, replayText);
     const maxLen = Math.max(origText.length, replayText.length);

--- a/src/util/textextract.ts
+++ b/src/util/textextract.ts
@@ -77,7 +77,8 @@ export class TextExtractViaSnapshot extends BaseTextExtract {
     const result = await this.cdp.send("DOMSnapshot.captureSnapshot", {
       computedStyles: [],
     });
-    return this.parseTextFromDOMSnapshot(result);
+    const text = this.parseTextFromDOMSnapshot(result);
+    return text ? text : "";
   }
 
   parseTextFromDOMSnapshot(
@@ -138,7 +139,8 @@ export class TextExtractViaDocument extends BaseTextExtract {
       depth: -1,
       pierce: true,
     });
-    return this.parseTextFromDOM(result);
+    const text = this.parseTextFromDOM(result);
+    return text ? text : "";
   }
 
   parseTextFromDOM(dom: Protocol.DOM.GetDocumentResponse): string {

--- a/src/util/textextract.ts
+++ b/src/util/textextract.ts
@@ -77,8 +77,7 @@ export class TextExtractViaSnapshot extends BaseTextExtract {
     const result = await this.cdp.send("DOMSnapshot.captureSnapshot", {
       computedStyles: [],
     });
-    const text = this.parseTextFromDOMSnapshot(result);
-    return text ? text : "";
+    return this.parseTextFromDOMSnapshot(result);
   }
 
   parseTextFromDOMSnapshot(
@@ -139,8 +138,7 @@ export class TextExtractViaDocument extends BaseTextExtract {
       depth: -1,
       pierce: true,
     });
-    const text = this.parseTextFromDOM(result);
-    return text ? text : "";
+    return this.parseTextFromDOM(result);
   }
 
   parseTextFromDOM(dom: Protocol.DOM.GetDocumentResponse): string {


### PR DESCRIPTION
Fixes #666 

The root causes of this issue were that: 1. text (specifically replay text in my testing) was sometimes `undefined` rather than an empty string, and 2. when the max length of both original and replay text strings was 0, we had a divide by zero error.

This PR ensures that both are strings before comparison and that we never divide by zero, which means that if no text was able to be extracted in original or replay the `textMatch` score will now be `1.0` rather than `null`.