### PR TITLE
Disable behaviors entirely if --behaviors array is empty

### DIFF
--- a/docs/docs/user-guide/behaviors.md
+++ b/docs/docs/user-guide/behaviors.md
@@ -10,6 +10,8 @@ See [Browsertrix Behaviors](https://github.com/webrecorder/browsertrix-behaviors
 
 Browsertrix Crawler includes a `--pageExtraDelay`/`--delay` option, which can be used to have the crawler sleep for a configurable number of seconds after behaviors before moving on to the next page.
 
+To disable behaviors for a crawl, use `--behaviors ""`.
+
 ## Additional Custom Behaviors
 
 Custom behaviors can be mounted into the crawler and loaded from there. For example:

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -484,7 +484,11 @@ export class Crawler {
 
     logger.info("Seeds", this.seeds);
 
-    logger.info("Behavior Options", this.params.behaviorOpts);
+    if (this.params.behaviorOpts) {
+      logger.info("Behavior Options", this.params.behaviorOpts);
+    } else {
+      logger.info("Behaviors disabled");
+    }
 
     if (this.params.profile) {
       logger.info("With Browser Profile", { url: this.params.profile });

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -630,10 +630,14 @@ class ArgParser {
 
     // background behaviors to apply
     const behaviorOpts: { [key: string]: string | boolean } = {};
-    argv.behaviors.forEach((x: string) => (behaviorOpts[x] = true));
-    behaviorOpts.log = BEHAVIOR_LOG_FUNC;
-    behaviorOpts.startEarly = true;
-    argv.behaviorOpts = JSON.stringify(behaviorOpts);
+    if (argv.behaviors.length > 0) {
+      argv.behaviors.forEach((x: string) => (behaviorOpts[x] = true));
+      behaviorOpts.log = BEHAVIOR_LOG_FUNC;
+      behaviorOpts.startEarly = true;
+      argv.behaviorOpts = JSON.stringify(behaviorOpts);
+    } else {
+      argv.behaviorOpts = "";
+    }
 
     argv.text = argv.text || [];
 


### PR DESCRIPTION
Fixes #651 

## Testing

1. Verify that with default options or specifying at least one behavior, behaviors are run and logged as expected
2. Verify that with `--behaviors ""`, no behaviors are run and the only behavior-related message logged is "Behaviors disabled" near the beginning of the crawl