### PR TITLE
Additional direct fetch improvements

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -48,7 +48,6 @@ import {
   BEHAVIOR_LOG_FUNC,
   DEFAULT_SELECTORS,
   DISPLAY,
-  FETCH_HEADERS_TIMEOUT_SECS,
   PAGE_OP_TIMEOUT_SECS,
   SITEMAP_INITIAL_FETCH_TIMEOUT_SECS,
 } from "./util/constants.js";
@@ -265,12 +264,11 @@ export class Crawler {
     this.seeds = this.params.scopedSeeds as ScopedSeed[];
     this.numOriginalSeeds = this.seeds.length;
 
-    // sum of page load + behavior timeouts + 2 x fetch + cloudflare + link extraction timeouts + extra page delay
+    // sum of page load + behavior timeouts + 2 x pageop timeouts (for cloudflare, link extraction) + extra page delay
     // if exceeded, will interrupt and move on to next page (likely behaviors or some other operation is stuck)
     this.maxPageTime =
       this.params.pageLoadTimeout +
       this.params.behaviorTimeout +
-      FETCH_HEADERS_TIMEOUT_SECS * 2 +
       PAGE_OP_TIMEOUT_SECS * 2 +
       this.params.pageExtraDelay;
 

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -397,6 +397,8 @@ export class ReplayCrawler extends Crawler {
       return;
     }
 
+    opts.markPageUsed();
+
     const date = new Date(ts);
 
     const timestamp = date.toISOString().slice(0, 19).replace(/[T:-]/g, "");

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -26,6 +26,10 @@ export const BEHAVIOR_LOG_FUNC = "__bx_log";
 export const ADD_LINK_FUNC = "__bx_addLink";
 export const MAX_DEPTH = 1000000;
 
+export const FETCH_HEADERS_TIMEOUT_SECS = 30;
+export const PAGE_OP_TIMEOUT_SECS = 5;
+export const SITEMAP_INITIAL_FETCH_TIMEOUT_SECS = 30;
+
 export const DEFAULT_SELECTORS = [
   {
     selector: "a[href]",

--- a/src/util/originoverride.ts
+++ b/src/util/originoverride.ts
@@ -2,6 +2,8 @@ import { HTTPRequest, Page } from "puppeteer-core";
 import { formatErr, logger } from "./logger.js";
 import { Browser } from "./browser.js";
 
+import { fetch } from "undici";
+
 export class OriginOverride {
   originOverride: { origUrl: URL; destUrl: URL }[];
 

--- a/tests/multi-instance-crawl.test.js
+++ b/tests/multi-instance-crawl.test.js
@@ -33,7 +33,7 @@ afterAll(async () => {
 });
 
 function runCrawl(name) {
-  const crawler = exec(`docker run --rm -v $PWD/test-crawls:/crawls --network=crawl --hostname=${name} webrecorder/browsertrix-crawler crawl --url https://www.webrecorder.net/ --limit 4 --collection shared-${name} --crawlId testcrawl --redisStoreUrl redis://redis:6379`);
+  const crawler = exec(`docker run --rm -v $PWD/test-crawls:/crawls --network=crawl --hostname=${name} webrecorder/browsertrix-crawler crawl --url https://www.webrecorder.net/ --limit 4 --exclude community --collection shared-${name} --crawlId testcrawl --redisStoreUrl redis://redis:6379`);
 
   return new Promise((resolve) => {
     crawler.on("exit", (code) => {
@@ -74,7 +74,7 @@ test("finish crawls successfully", async () => {
   const res = await Promise.allSettled([crawler1, crawler2]);
   expect(res[0].value).toBe(0);
   expect(res[1].value).toBe(0);
-}, 270000);
+}, 180000);
 
 test("ensure correct number of pages", () => {
 

--- a/tests/multi-instance-crawl.test.js
+++ b/tests/multi-instance-crawl.test.js
@@ -74,7 +74,7 @@ test("finish crawls successfully", async () => {
   const res = await Promise.allSettled([crawler1, crawler2]);
   expect(res[0].value).toBe(0);
   expect(res[1].value).toBe(0);
-}, 180000);
+}, 270000);
 
 test("ensure correct number of pages", () => {
 


### PR DESCRIPTION
- use existing headersTimeout in undici to limit time to headers fetch to 30 seconds, reject direct fetch if timeout is reached
- allow full page timeout for loading payload via direct fetch
- support setting global fetch() settings
- add markPageUsed() to only reuse pages when not doing direct fetch
- apply auth headers to direct fetch
- catch failed fetch and timeout errors
- support failOnFailedSeeds for direct fetch, ensure timeout is working