### PR TITLE
crawler args typing

### DIFF
--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -43,9 +43,9 @@ Options:
                                                                            tom"]
       --scopeIncludeRx, --include           Regex of page URLs that should be in
                                             cluded in the crawl (defaults to the
-                                             immediate directory of URL)
+                                             immediate directory of URL)[string]
       --scopeExcludeRx, --exclude           Regex of page URLs that should be ex
-                                            cluded from the crawl.
+                                            cluded from the crawl.      [string]
       --allowHashUrls                       Allow Hashtag URLs, useful for singl
                                             e-page-application crawling or when
                                             different hashtags load dynamic cont
@@ -56,14 +56,14 @@ Options:
                                             an iframe      [array] [default: []]
       --blockMessage                        If specified, when a URL is blocked,
                                              a record with this error message is
-                                             added instead              [string]
+                                             added instead[string] [default: ""]
       --blockAds, --blockads                If set, block advertisements from be
                                             ing loaded (based on Stephen Black's
                                              blocklist)
                                                       [boolean] [default: false]
       --adBlockMessage                      If specified, when an ad is blocked,
                                              a record with this error message is
-                                             added instead              [string]
+                                             added instead[string] [default: ""]
   -c, --collection                          Collection name to crawl to (replay
                                             will be accessible under this name i
                                             n pywb preview)
@@ -79,7 +79,7 @@ Options:
       ineWarc                                         [boolean] [default: false]
       --rolloverSize                        If set, declare the rollover size
                                                   [number] [default: 1000000000]
-      --generateWACZ, --generatewacz, --ge  If set, generate wacz
+      --generateWACZ, --generatewacz, --ge  If set, generate WACZ on disk
       nerateWacz                                      [boolean] [default: false]
       --logging                             Logging options for crawler, can inc
                                             lude: stats (enabled by default), js
@@ -94,15 +94,15 @@ Options:
   , "state", "redis", "storage", "text", "exclusion", "screenshots", "screencast
   ", "originOverride", "healthcheck", "browser", "blocking", "behavior", "behavi
   orScript", "jsError", "fetch", "pageStatus", "memoryStatus", "crawlStatus", "l
-                              inks", "sitemap", "replay", "proxy"] [default: []]
+                      inks", "sitemap", "wacz", "replay", "proxy"] [default: []]
       --logExcludeContext                   Comma-separated list of contexts to
                                             NOT include in logs
   [array] [choices: "general", "worker", "recorder", "recorderNetwork", "writer"
   , "state", "redis", "storage", "text", "exclusion", "screenshots", "screencast
   ", "originOverride", "healthcheck", "browser", "blocking", "behavior", "behavi
   orScript", "jsError", "fetch", "pageStatus", "memoryStatus", "crawlStatus", "l
-  inks", "sitemap", "replay", "proxy"] [default: ["recorderNetwork","jsError","s
-                                                                    creencast"]]
+  inks", "sitemap", "wacz", "replay", "proxy"] [default: ["recorderNetwork","jsE
+                                                            rror","screencast"]]
       --text                                Extract initial (default) or final t
                                             ext to pages.jsonl or WARC resource
                                             record(s)
@@ -127,15 +127,15 @@ Options:
                                              those greater than or equal to (>=)
                                              provided ISO Date string (YYYY-MM-D
                                             D or YYYY-MM-DDTHH:MM:SS or partial
-                                            date)
+                                            date)                       [string]
       --sitemapToDate, --sitemapTo          If set, filter URLs from sitemaps to
                                              those less than or equal to (<=) pr
                                             ovided ISO Date string (YYYY-MM-DD o
                                             r YYYY-MM-DDTHH:MM:SS or partial dat
-                                            e)
+                                            e)                          [string]
       --statsFilename                       If set, output stats as JSON to this
                                              file. (Relative filename resolves t
-                                            o crawl working directory)
+                                            o crawl working directory)  [string]
       --behaviors                           Which background behaviors to enable
                                              on each page
   [array] [choices: "autoplay", "autofetch", "autoscroll", "siteSpecific"] [defa
@@ -304,7 +304,7 @@ Options:
   --shutdownWait            Shutdown browser in interactive after this many seco
                             nds, if no pings received      [number] [default: 0]
   --profile                 Path or HTTP(S) URL to tar.gz file which contains th
-                            e browser profile directory                 [string]
+                            e browser profile directory   [string] [default: ""]
   --windowSize              Browser window dimensions, specified as: width,heigh
                             t                    [string] [default: "1360,1020"]
   --cookieDays              If >0, set all cookies, including session cookies, t

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -52,7 +52,7 @@ import {
   SITEMAP_INITIAL_FETCH_TIMEOUT_SECS,
 } from "./util/constants.js";
 
-import { AdBlockRules, BlockRules } from "./util/blockrules.js";
+import { AdBlockRules, BlockRuleDecl, BlockRules } from "./util/blockrules.js";
 import { OriginOverride } from "./util/originoverride.js";
 
 import {
@@ -1395,7 +1395,7 @@ self.__bx_behaviors.selectMainBehavior();
 
     if (this.params.blockRules && this.params.blockRules.length) {
       this.blockRules = new BlockRules(
-        this.params.blockRules,
+        this.params.blockRules as BlockRuleDecl[],
         this.captureBasePrefix,
         this.params.blockMessage,
       );
@@ -1404,7 +1404,9 @@ self.__bx_behaviors.selectMainBehavior();
     this.screencaster = this.initScreenCaster();
 
     if (this.params.originOverride && this.params.originOverride.length) {
-      this.originOverride = new OriginOverride(this.params.originOverride);
+      this.originOverride = new OriginOverride(
+        this.params.originOverride as string[],
+      );
     }
 
     await this._addInitialSeeds();

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -12,7 +12,7 @@ import {
   WorkerId,
 } from "./util/state.js";
 
-import { parseArgs } from "./util/argParser.js";
+import { CrawlerArgs, parseArgs } from "./util/argParser.js";
 
 import yaml from "js-yaml";
 
@@ -107,8 +107,7 @@ type PageEntry = {
 
 // ============================================================================
 export class Crawler {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  params: any;
+  params: CrawlerArgs;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   origConfig: any;
 
@@ -200,8 +199,8 @@ export class Crawler {
 
   constructor() {
     const args = this.parseArgs();
-    this.params = args.parsed;
-    this.origConfig = args.origConfig;
+    this.params = args as CrawlerArgs;
+    this.origConfig = this.params.origConfig;
 
     // root collections dir
     this.collDir = path.join(
@@ -2183,7 +2182,7 @@ self.__bx_behaviors.selectMainBehavior();
           id: "pages",
           title,
         };
-        header.hasText = this.params.text.includes("to-pages");
+        header.hasText = this.params.text.includes("to-pages") + "";
         if (this.params.text.length) {
           logger.debug("Text Extraction: " + this.params.text.join(","));
         } else {
@@ -2290,8 +2289,12 @@ self.__bx_behaviors.selectMainBehavior();
       return;
     }
 
-    const fromDate = this.params.sitemapFromDate;
-    const toDate = this.params.sitemapToDate;
+    const fromDate = this.params.sitemapFromDate
+      ? new Date(this.params.sitemapFromDate)
+      : undefined;
+    const toDate = this.params.sitemapToDate
+      ? new Date(this.params.sitemapToDate)
+      : undefined;
     const headers = this.headers;
 
     logger.info(

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -871,7 +871,7 @@ self.__bx_behaviors.selectMainBehavior();
 
         const result = await timedRun(
           directFetchCapture({ url, headers, cdp }),
-          this.params.timeout,
+          this.params.pageLoadTimeout,
           "Direct fetch of page URL timed out",
           logDetails,
           "fetch",

--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -48,22 +48,27 @@ function initArgs() {
       user: {
         describe:
           "The username for the login. If not specified, will be prompted",
+        type: "string",
       },
 
       password: {
         describe:
           "The password for the login. If not specified, will be prompted (recommended)",
+        type: "string",
       },
 
       filename: {
         describe:
           "The filename for the profile tarball, stored within /crawls/profiles if absolute path not provided",
+        type: "string",
         default: "/crawls/profiles/profile.tar.gz",
       },
 
       debugScreenshot: {
         describe:
           "If specified, take a screenshot after login and save as this filename",
+        type: "boolean",
+        default: false,
       },
 
       headless: {
@@ -99,15 +104,15 @@ function initArgs() {
       },
 
       windowSize: {
-        type: "string",
         describe: "Browser window dimensions, specified as: width,height",
+        type: "string",
         default: getDefaultWindowSize(),
       },
 
       cookieDays: {
-        type: "number",
         describe:
           "If >0, set all cookies, including session cookies, to have this duration in days before saving profile",
+        type: "number",
         default: 7,
       },
 

--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -7,7 +7,7 @@ import http, { IncomingMessage, ServerResponse } from "http";
 import readline from "readline";
 import child_process from "child_process";
 
-import yargs, { Options } from "yargs";
+import yargs from "yargs";
 
 import { logger } from "./util/logger.js";
 
@@ -35,96 +35,101 @@ const behaviors = fs.readFileSync(
   { encoding: "utf8" },
 );
 
-function cliOpts(): { [key: string]: Options } {
-  return {
-    url: {
-      describe: "The URL of the login page",
-      type: "string",
-      demandOption: true,
-    },
+function initArgs() {
+  return yargs(process.argv)
+    .usage("browsertrix-crawler profile [options]")
+    .options({
+      url: {
+        describe: "The URL of the login page",
+        type: "string",
+        demandOption: true,
+      },
 
-    user: {
-      describe:
-        "The username for the login. If not specified, will be prompted",
-    },
+      user: {
+        describe:
+          "The username for the login. If not specified, will be prompted",
+      },
 
-    password: {
-      describe:
-        "The password for the login. If not specified, will be prompted (recommended)",
-    },
+      password: {
+        describe:
+          "The password for the login. If not specified, will be prompted (recommended)",
+      },
 
-    filename: {
-      describe:
-        "The filename for the profile tarball, stored within /crawls/profiles if absolute path not provided",
-      default: "/crawls/profiles/profile.tar.gz",
-    },
+      filename: {
+        describe:
+          "The filename for the profile tarball, stored within /crawls/profiles if absolute path not provided",
+        default: "/crawls/profiles/profile.tar.gz",
+      },
 
-    debugScreenshot: {
-      describe:
-        "If specified, take a screenshot after login and save as this filename",
-    },
+      debugScreenshot: {
+        describe:
+          "If specified, take a screenshot after login and save as this filename",
+      },
 
-    headless: {
-      describe: "Run in headless mode, otherwise start xvfb",
-      type: "boolean",
-      default: false,
-    },
+      headless: {
+        describe: "Run in headless mode, otherwise start xvfb",
+        type: "boolean",
+        default: false,
+      },
 
-    automated: {
-      describe: "Start in automated mode, no interactive browser",
-      type: "boolean",
-      default: false,
-    },
+      automated: {
+        describe: "Start in automated mode, no interactive browser",
+        type: "boolean",
+        default: false,
+      },
 
-    interactive: {
-      describe: "Deprecated. Now the default option!",
-      type: "boolean",
-      default: false,
-    },
+      interactive: {
+        describe: "Deprecated. Now the default option!",
+        type: "boolean",
+        default: false,
+      },
 
-    shutdownWait: {
-      describe:
-        "Shutdown browser in interactive after this many seconds, if no pings received",
-      type: "number",
-      default: 0,
-    },
+      shutdownWait: {
+        describe:
+          "Shutdown browser in interactive after this many seconds, if no pings received",
+        type: "number",
+        default: 0,
+      },
 
-    profile: {
-      describe:
-        "Path or HTTP(S) URL to tar.gz file which contains the browser profile directory",
-      type: "string",
-    },
+      profile: {
+        describe:
+          "Path or HTTP(S) URL to tar.gz file which contains the browser profile directory",
+        type: "string",
+        default: "",
+      },
 
-    windowSize: {
-      type: "string",
-      describe: "Browser window dimensions, specified as: width,height",
-      default: getDefaultWindowSize(),
-    },
+      windowSize: {
+        type: "string",
+        describe: "Browser window dimensions, specified as: width,height",
+        default: getDefaultWindowSize(),
+      },
 
-    cookieDays: {
-      type: "number",
-      describe:
-        "If >0, set all cookies, including session cookies, to have this duration in days before saving profile",
-      default: 7,
-    },
+      cookieDays: {
+        type: "number",
+        describe:
+          "If >0, set all cookies, including session cookies, to have this duration in days before saving profile",
+        default: 7,
+      },
 
-    proxyServer: {
-      describe:
-        "if set, will use specified proxy server. Takes precedence over any env var proxy settings",
-      type: "string",
-    },
+      proxyServer: {
+        describe:
+          "if set, will use specified proxy server. Takes precedence over any env var proxy settings",
+        type: "string",
+      },
 
-    sshProxyPrivateKeyFile: {
-      describe: "path to SSH private key for SOCKS5 over SSH proxy connection",
-      type: "string",
-    },
+      sshProxyPrivateKeyFile: {
+        describe:
+          "path to SSH private key for SOCKS5 over SSH proxy connection",
+        type: "string",
+      },
 
-    sshProxyKnownHostsFile: {
-      describe:
-        "path to SSH known hosts file for SOCKS5 over SSH proxy connection",
-      type: "string",
-    },
-  };
+      sshProxyKnownHostsFile: {
+        describe:
+          "path to SSH known hosts file for SOCKS5 over SSH proxy connection",
+        type: "string",
+      },
+    })
+    .parseSync();
 }
 
 function getDefaultWindowSize() {
@@ -140,10 +145,7 @@ function handleTerminate(signame: string) {
 }
 
 async function main() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const params: any = yargs(process.argv)
-    .usage("browsertrix-crawler profile [options]")
-    .option(cliOpts()).argv;
+  const params = initArgs();
 
   logger.setDebugLogging(true);
 

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -110,8 +110,8 @@ export class ReplayCrawler extends Crawler {
 
     this.infoWriter = null;
 
-    this.includeRx = parseRx(this.params.include);
-    this.excludeRx = parseRx(this.params.include);
+    this.includeRx = parseRx(this.params.scopeIncludeRx);
+    this.excludeRx = parseRx(this.params.scopeExcludeRx);
   }
 
   async bootstrap(): Promise<void> {

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -24,578 +24,7 @@ import {
 } from "./logger.js";
 import { SaveState } from "./state.js";
 
-export function initArgs(argv: string[]) {
-  const coerce = (array: string[]): string[] => {
-    return array.flatMap((v) => v.split(",")).filter((x) => !!x);
-  };
-
-  return yargs(hideBin(argv))
-    .usage("crawler [options]")
-    .options({
-      seeds: {
-        alias: "url",
-        describe: "The URL to start crawling from",
-        type: "array",
-        default: [],
-      },
-
-      seedFile: {
-        alias: ["urlFile"],
-        describe:
-          "If set, read a list of seed urls, one per line, from the specified",
-        type: "string",
-      },
-
-      workers: {
-        alias: "w",
-        describe: "The number of workers to run in parallel",
-        default: 1,
-        type: "number",
-      },
-
-      crawlId: {
-        alias: "id",
-        describe:
-          "A user provided ID for this crawl or crawl configuration (can also be set via CRAWL_ID env var, defaults to hostname)",
-        type: "string",
-      },
-
-      waitUntil: {
-        describe:
-          "Puppeteer page.goto() condition to wait for before continuing, can be multiple separated by ','",
-        type: "array",
-        default: ["load", "networkidle2"],
-        choices: WAIT_UNTIL_OPTS,
-        coerce,
-      },
-
-      depth: {
-        describe: "The depth of the crawl for all seeds",
-        default: -1,
-        type: "number",
-      },
-
-      extraHops: {
-        describe: "Number of extra 'hops' to follow, beyond the current scope",
-        default: 0,
-        type: "number",
-      },
-
-      pageLimit: {
-        alias: "limit",
-        describe: "Limit crawl to this number of pages",
-        default: 0,
-        type: "number",
-      },
-
-      maxPageLimit: {
-        describe:
-          "Maximum pages to crawl, overriding  pageLimit if both are set",
-        default: 0,
-        type: "number",
-      },
-
-      pageLoadTimeout: {
-        alias: "timeout",
-        describe: "Timeout for each page to load (in seconds)",
-        default: 90,
-        type: "number",
-      },
-
-      scopeType: {
-        describe:
-          "A predefined scope of the crawl. For more customization, use 'custom' and set scopeIncludeRx regexes",
-        type: "string",
-        choices: [
-          "page",
-          "page-spa",
-          "prefix",
-          "host",
-          "domain",
-          "any",
-          "custom",
-        ],
-      },
-
-      scopeIncludeRx: {
-        alias: "include",
-        describe:
-          "Regex of page URLs that should be included in the crawl (defaults to the immediate directory of URL)",
-        type: "string",
-      },
-
-      scopeExcludeRx: {
-        alias: "exclude",
-        describe: "Regex of page URLs that should be excluded from the crawl.",
-        type: "string",
-      },
-
-      allowHashUrls: {
-        describe:
-          "Allow Hashtag URLs, useful for single-page-application crawling or when different hashtags load dynamic content",
-      },
-
-      blockRules: {
-        describe:
-          "Additional rules for blocking certain URLs from being loaded, by URL regex and optionally via text match in an iframe",
-        type: "array",
-        default: [],
-      },
-
-      blockMessage: {
-        describe:
-          "If specified, when a URL is blocked, a record with this error message is added instead",
-        type: "string",
-        default: "",
-      },
-
-      blockAds: {
-        alias: "blockads",
-        describe:
-          "If set, block advertisements from being loaded (based on Stephen Black's blocklist)",
-        type: "boolean",
-        default: false,
-      },
-
-      adBlockMessage: {
-        describe:
-          "If specified, when an ad is blocked, a record with this error message is added instead",
-        type: "string",
-        default: "",
-      },
-
-      collection: {
-        alias: "c",
-        describe:
-          "Collection name to crawl to (replay will be accessible under this name in pywb preview)",
-        type: "string",
-        default: "crawl-@ts",
-      },
-
-      headless: {
-        describe: "Run in headless mode, otherwise start xvfb",
-        type: "boolean",
-        default: false,
-      },
-
-      driver: {
-        describe: "JS driver for the crawler",
-        type: "string",
-        default: "./defaultDriver.js",
-      },
-
-      generateCDX: {
-        alias: ["generatecdx", "generateCdx"],
-        describe:
-          "If set, generate index (CDXJ) for use with pywb after crawl is done",
-        type: "boolean",
-        default: false,
-      },
-
-      combineWARC: {
-        alias: ["combinewarc", "combineWarc"],
-        describe: "If set, combine the warcs",
-        type: "boolean",
-        default: false,
-      },
-
-      rolloverSize: {
-        describe: "If set, declare the rollover size",
-        default: 1000000000,
-        type: "number",
-      },
-
-      generateWACZ: {
-        alias: ["generatewacz", "generateWacz"],
-        describe: "If set, generate WACZ on disk",
-        type: "boolean",
-        default: false,
-      },
-
-      logging: {
-        describe:
-          "Logging options for crawler, can include: stats (enabled by default), jserrors, debug",
-        type: "array",
-        default: ["stats"],
-        coerce,
-      },
-
-      logLevel: {
-        describe: "Comma-separated list of log levels to include in logs",
-        type: "array",
-        default: [],
-        coerce,
-      },
-
-      context: {
-        alias: "logContext",
-        describe: "Comma-separated list of contexts to include in logs",
-        type: "array",
-        default: [],
-        choices: LOG_CONTEXT_TYPES,
-        coerce,
-      },
-
-      logExcludeContext: {
-        describe: "Comma-separated list of contexts to NOT include in logs",
-        type: "array",
-        default: DEFAULT_EXCLUDE_LOG_CONTEXTS,
-        choices: LOG_CONTEXT_TYPES,
-        coerce,
-      },
-
-      text: {
-        describe:
-          "Extract initial (default) or final text to pages.jsonl or WARC resource record(s)",
-        type: "array",
-        choices: EXTRACT_TEXT_TYPES,
-        coerce: (array) => {
-          // backwards compatibility: default --text true / --text -> --text to-pages
-          if (!array.length || (array.length === 1 && array[0] === "true")) {
-            return ["to-pages"];
-          }
-          if (array.length === 1 && array[0] === "false") {
-            return [];
-          }
-          return coerce(array);
-        },
-      },
-
-      cwd: {
-        describe:
-          "Crawl working directory for captures (pywb root). If not set, defaults to process.cwd()",
-        type: "string",
-        default: process.cwd(),
-      },
-
-      mobileDevice: {
-        describe:
-          "Emulate mobile device by name from: https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts",
-        type: "string",
-      },
-
-      userAgent: {
-        describe: "Override user-agent with specified string",
-        type: "string",
-      },
-
-      userAgentSuffix: {
-        describe:
-          "Append suffix to existing browser user-agent (ex: +MyCrawler, info@example.com)",
-        type: "string",
-      },
-
-      useSitemap: {
-        alias: "sitemap",
-        describe:
-          "If enabled, check for sitemaps at /sitemap.xml, or custom URL if URL is specified",
-      },
-
-      sitemapFromDate: {
-        alias: "sitemapFrom",
-        describe:
-          "If set, filter URLs from sitemaps to those greater than or equal to (>=) provided ISO Date string (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS or partial date)",
-        type: "string",
-      },
-
-      sitemapToDate: {
-        alias: "sitemapTo",
-        describe:
-          "If set, filter URLs from sitemaps to those less than or equal to (<=) provided ISO Date string (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS or partial date)",
-        type: "string",
-      },
-
-      statsFilename: {
-        type: "string",
-        describe:
-          "If set, output stats as JSON to this file. (Relative filename resolves to crawl working directory)",
-      },
-
-      behaviors: {
-        describe: "Which background behaviors to enable on each page",
-        type: "array",
-        default: ["autoplay", "autofetch", "autoscroll", "siteSpecific"],
-        choices: ["autoplay", "autofetch", "autoscroll", "siteSpecific"],
-        coerce,
-      },
-
-      behaviorTimeout: {
-        describe:
-          "If >0, timeout (in seconds) for in-page behavior will run on each page. If 0, a behavior can run until finish.",
-        default: 90,
-        type: "number",
-      },
-
-      postLoadDelay: {
-        describe:
-          "If >0, amount of time to sleep (in seconds) after page has loaded, before taking screenshots / getting text / running behaviors",
-        default: 0,
-        type: "number",
-      },
-
-      pageExtraDelay: {
-        alias: "delay",
-        describe:
-          "If >0, amount of time to sleep (in seconds) after behaviors before moving on to next page",
-        default: 0,
-        type: "number",
-      },
-
-      dedupPolicy: {
-        describe: "Deduplication policy",
-        default: "skip",
-        type: "string",
-        choices: ["skip", "revisit", "keep"],
-      },
-
-      profile: {
-        describe:
-          "Path or HTTP(S) URL to tar.gz file which contains the browser profile directory",
-        type: "string",
-      },
-
-      screenshot: {
-        describe:
-          "Screenshot options for crawler, can include: view, thumbnail, fullPage",
-        type: "array",
-        default: [],
-        choices: Array.from(Object.keys(screenshotTypes)),
-        coerce,
-      },
-
-      screencastPort: {
-        describe:
-          "If set to a non-zero value, starts an HTTP server with screencast accessible on this port",
-        type: "number",
-        default: 0,
-      },
-
-      screencastRedis: {
-        describe:
-          "If set, will use the state store redis pubsub for screencasting. Requires --redisStoreUrl to be set",
-        type: "boolean",
-        default: false,
-      },
-
-      warcInfo: {
-        alias: ["warcinfo"],
-        describe:
-          "Optional fields added to the warcinfo record in combined WARCs",
-        //type: "object"
-      },
-
-      redisStoreUrl: {
-        describe:
-          "If set, url for remote redis server to store state. Otherwise, using local redis instance",
-        type: "string",
-        default: "redis://localhost:6379/0",
-      },
-
-      saveState: {
-        describe:
-          "If the crawl state should be serialized to the crawls/ directory. Defaults to 'partial', only saved when crawl is interrupted",
-        type: "string",
-        default: "partial",
-        choices: ["never", "partial", "always"],
-      },
-
-      saveStateInterval: {
-        describe:
-          "If save state is set to 'always', also save state during the crawl at this interval (in seconds)",
-        type: "number",
-        default: 300,
-      },
-
-      saveStateHistory: {
-        describe:
-          "Number of save states to keep during the duration of a crawl",
-        type: "number",
-        default: 5,
-      },
-
-      sizeLimit: {
-        describe:
-          "If set, save state and exit if size limit exceeds this value",
-        type: "number",
-        default: 0,
-      },
-
-      diskUtilization: {
-        describe:
-          "If set, save state and exit if disk utilization exceeds this percentage value",
-        type: "number",
-        default: 90,
-      },
-
-      timeLimit: {
-        describe: "If set, save state and exit after time limit, in seconds",
-        type: "number",
-        default: 0,
-      },
-
-      healthCheckPort: {
-        describe: "port to run healthcheck on",
-        type: "number",
-        default: 0,
-      },
-
-      overwrite: {
-        describe:
-          "overwrite current crawl data: if set, existing collection directory will be deleted before crawl is started",
-        type: "boolean",
-        default: false,
-      },
-
-      waitOnDone: {
-        describe:
-          "if set, wait for interrupt signal when finished instead of exiting",
-        type: "boolean",
-        default: false,
-      },
-
-      restartsOnError: {
-        describe:
-          "if set, assume will be restarted if interrupted, don't run post-crawl processes on interrupt",
-        type: "boolean",
-        default: false,
-      },
-
-      netIdleWait: {
-        describe:
-          "if set, wait for network idle after page load and after behaviors are done (in seconds). if -1 (default), determine based on scope",
-        type: "number",
-        default: -1,
-      },
-
-      lang: {
-        describe:
-          "if set, sets the language used by the browser, should be ISO 639 language[-country] code",
-        type: "string",
-      },
-
-      title: {
-        describe:
-          "If set, write supplied title into WACZ datapackage.json metadata",
-        type: "string",
-      },
-
-      description: {
-        alias: ["desc"],
-        describe:
-          "If set, write supplied description into WACZ datapackage.json metadata",
-        type: "string",
-      },
-
-      originOverride: {
-        describe:
-          "if set, will redirect requests from each origin in key to origin in the value, eg. --originOverride https://host:port=http://alt-host:alt-port",
-        type: "array",
-        default: [],
-      },
-
-      logErrorsToRedis: {
-        describe: "If set, write error messages to redis",
-        type: "boolean",
-        default: false,
-      },
-
-      writePagesToRedis: {
-        describe: "If set, write page objects to redis",
-        type: "boolean",
-        default: false,
-      },
-
-      failOnFailedSeed: {
-        describe:
-          "If set, crawler will fail with exit code 1 if any seed fails. When combined with --failOnInvalidStatus," +
-          "will result in crawl failing with exit code 1 if any seed has a 4xx/5xx response",
-        type: "boolean",
-        default: false,
-      },
-
-      failOnFailedLimit: {
-        describe:
-          "If set, save state and exit if number of failed pages exceeds this value",
-        type: "number",
-        default: 0,
-      },
-
-      failOnInvalidStatus: {
-        describe:
-          "If set, will treat pages with 4xx or 5xx response as failures. When combined with --failOnFailedLimit" +
-          " or --failOnFailedSeed may result in crawl failing due to non-200 responses",
-        type: "boolean",
-        default: false,
-      },
-
-      customBehaviors: {
-        describe:
-          "injects a custom behavior file or set of behavior files in a directory",
-        type: "string",
-      },
-
-      debugAccessRedis: {
-        describe:
-          "if set, runs internal redis without protected mode to allow external access (for debugging)",
-        type: "boolean",
-      },
-
-      debugAccessBrowser: {
-        describe: "if set, allow debugging browser on port 9222 via CDP",
-        type: "boolean",
-      },
-
-      warcPrefix: {
-        describe:
-          "prefix for WARC files generated, including WARCs added to WACZ",
-        type: "string",
-      },
-
-      serviceWorker: {
-        alias: "sw",
-        describe:
-          "service worker handling: disabled, enabled, or disabled with custom profile",
-        choices: SERVICE_WORKER_OPTS,
-        default: "disabled",
-      },
-
-      proxyServer: {
-        describe:
-          "if set, will use specified proxy server. Takes precedence over any env var proxy settings",
-        type: "string",
-      },
-
-      dryRun: {
-        describe:
-          "If true, no archive data is written to disk, only pages and logs (and optionally saved state).",
-        type: "boolean",
-      },
-
-      qaSource: {
-        describe: "Required for QA mode. Source (WACZ or multi WACZ) for QA",
-        type: "string",
-      },
-
-      qaDebugImageDiff: {
-        describe:
-          "if specified, will write crawl.png, replay.png and diff.png for each page where they're different",
-        type: "boolean",
-      },
-
-      sshProxyPrivateKeyFile: {
-        describe:
-          "path to SSH private key for SOCKS5 over SSH proxy connection",
-        type: "string",
-      },
-
-      sshProxyKnownHostsFile: {
-        describe:
-          "path to SSH known hosts file for SOCKS5 over SSH proxy connection",
-        type: "string",
-      },
-    });
-}
-
+// ============================================================================
 export type CrawlerArgs = ReturnType<typeof parseArgs> & {
   logContext: LogContext[];
   logExcludeContext: LogContext[];
@@ -614,6 +43,580 @@ export type CrawlerArgs = ReturnType<typeof parseArgs> & {
 
 // ============================================================================
 class ArgParser {
+  initArgs(argv: string[]) {
+    const coerce = (array: string[]): string[] => {
+      return array.flatMap((v) => v.split(",")).filter((x) => !!x);
+    };
+
+    return yargs(hideBin(argv))
+      .usage("crawler [options]")
+      .options({
+        seeds: {
+          alias: "url",
+          describe: "The URL to start crawling from",
+          type: "array",
+          default: [],
+        },
+
+        seedFile: {
+          alias: ["urlFile"],
+          describe:
+            "If set, read a list of seed urls, one per line, from the specified",
+          type: "string",
+        },
+
+        workers: {
+          alias: "w",
+          describe: "The number of workers to run in parallel",
+          default: 1,
+          type: "number",
+        },
+
+        crawlId: {
+          alias: "id",
+          describe:
+            "A user provided ID for this crawl or crawl configuration (can also be set via CRAWL_ID env var, defaults to hostname)",
+          type: "string",
+        },
+
+        waitUntil: {
+          describe:
+            "Puppeteer page.goto() condition to wait for before continuing, can be multiple separated by ','",
+          type: "array",
+          default: ["load", "networkidle2"],
+          choices: WAIT_UNTIL_OPTS,
+          coerce,
+        },
+
+        depth: {
+          describe: "The depth of the crawl for all seeds",
+          default: -1,
+          type: "number",
+        },
+
+        extraHops: {
+          describe:
+            "Number of extra 'hops' to follow, beyond the current scope",
+          default: 0,
+          type: "number",
+        },
+
+        pageLimit: {
+          alias: "limit",
+          describe: "Limit crawl to this number of pages",
+          default: 0,
+          type: "number",
+        },
+
+        maxPageLimit: {
+          describe:
+            "Maximum pages to crawl, overriding  pageLimit if both are set",
+          default: 0,
+          type: "number",
+        },
+
+        pageLoadTimeout: {
+          alias: "timeout",
+          describe: "Timeout for each page to load (in seconds)",
+          default: 90,
+          type: "number",
+        },
+
+        scopeType: {
+          describe:
+            "A predefined scope of the crawl. For more customization, use 'custom' and set scopeIncludeRx regexes",
+          type: "string",
+          choices: [
+            "page",
+            "page-spa",
+            "prefix",
+            "host",
+            "domain",
+            "any",
+            "custom",
+          ],
+        },
+
+        scopeIncludeRx: {
+          alias: "include",
+          describe:
+            "Regex of page URLs that should be included in the crawl (defaults to the immediate directory of URL)",
+          type: "string",
+        },
+
+        scopeExcludeRx: {
+          alias: "exclude",
+          describe:
+            "Regex of page URLs that should be excluded from the crawl.",
+          type: "string",
+        },
+
+        allowHashUrls: {
+          describe:
+            "Allow Hashtag URLs, useful for single-page-application crawling or when different hashtags load dynamic content",
+        },
+
+        blockRules: {
+          describe:
+            "Additional rules for blocking certain URLs from being loaded, by URL regex and optionally via text match in an iframe",
+          type: "array",
+          default: [],
+        },
+
+        blockMessage: {
+          describe:
+            "If specified, when a URL is blocked, a record with this error message is added instead",
+          type: "string",
+          default: "",
+        },
+
+        blockAds: {
+          alias: "blockads",
+          describe:
+            "If set, block advertisements from being loaded (based on Stephen Black's blocklist)",
+          type: "boolean",
+          default: false,
+        },
+
+        adBlockMessage: {
+          describe:
+            "If specified, when an ad is blocked, a record with this error message is added instead",
+          type: "string",
+          default: "",
+        },
+
+        collection: {
+          alias: "c",
+          describe:
+            "Collection name to crawl to (replay will be accessible under this name in pywb preview)",
+          type: "string",
+          default: "crawl-@ts",
+        },
+
+        headless: {
+          describe: "Run in headless mode, otherwise start xvfb",
+          type: "boolean",
+          default: false,
+        },
+
+        driver: {
+          describe: "JS driver for the crawler",
+          type: "string",
+          default: "./defaultDriver.js",
+        },
+
+        generateCDX: {
+          alias: ["generatecdx", "generateCdx"],
+          describe:
+            "If set, generate index (CDXJ) for use with pywb after crawl is done",
+          type: "boolean",
+          default: false,
+        },
+
+        combineWARC: {
+          alias: ["combinewarc", "combineWarc"],
+          describe: "If set, combine the warcs",
+          type: "boolean",
+          default: false,
+        },
+
+        rolloverSize: {
+          describe: "If set, declare the rollover size",
+          default: 1000000000,
+          type: "number",
+        },
+
+        generateWACZ: {
+          alias: ["generatewacz", "generateWacz"],
+          describe: "If set, generate WACZ on disk",
+          type: "boolean",
+          default: false,
+        },
+
+        logging: {
+          describe:
+            "Logging options for crawler, can include: stats (enabled by default), jserrors, debug",
+          type: "array",
+          default: ["stats"],
+          coerce,
+        },
+
+        logLevel: {
+          describe: "Comma-separated list of log levels to include in logs",
+          type: "array",
+          default: [],
+          coerce,
+        },
+
+        context: {
+          alias: "logContext",
+          describe: "Comma-separated list of contexts to include in logs",
+          type: "array",
+          default: [],
+          choices: LOG_CONTEXT_TYPES,
+          coerce,
+        },
+
+        logExcludeContext: {
+          describe: "Comma-separated list of contexts to NOT include in logs",
+          type: "array",
+          default: DEFAULT_EXCLUDE_LOG_CONTEXTS,
+          choices: LOG_CONTEXT_TYPES,
+          coerce,
+        },
+
+        text: {
+          describe:
+            "Extract initial (default) or final text to pages.jsonl or WARC resource record(s)",
+          type: "array",
+          choices: EXTRACT_TEXT_TYPES,
+          coerce: (array) => {
+            // backwards compatibility: default --text true / --text -> --text to-pages
+            if (!array.length || (array.length === 1 && array[0] === "true")) {
+              return ["to-pages"];
+            }
+            if (array.length === 1 && array[0] === "false") {
+              return [];
+            }
+            return coerce(array);
+          },
+        },
+
+        cwd: {
+          describe:
+            "Crawl working directory for captures (pywb root). If not set, defaults to process.cwd()",
+          type: "string",
+          default: process.cwd(),
+        },
+
+        mobileDevice: {
+          describe:
+            "Emulate mobile device by name from: https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts",
+          type: "string",
+        },
+
+        userAgent: {
+          describe: "Override user-agent with specified string",
+          type: "string",
+        },
+
+        userAgentSuffix: {
+          describe:
+            "Append suffix to existing browser user-agent (ex: +MyCrawler, info@example.com)",
+          type: "string",
+        },
+
+        useSitemap: {
+          alias: "sitemap",
+          describe:
+            "If enabled, check for sitemaps at /sitemap.xml, or custom URL if URL is specified",
+        },
+
+        sitemapFromDate: {
+          alias: "sitemapFrom",
+          describe:
+            "If set, filter URLs from sitemaps to those greater than or equal to (>=) provided ISO Date string (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS or partial date)",
+          type: "string",
+        },
+
+        sitemapToDate: {
+          alias: "sitemapTo",
+          describe:
+            "If set, filter URLs from sitemaps to those less than or equal to (<=) provided ISO Date string (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS or partial date)",
+          type: "string",
+        },
+
+        statsFilename: {
+          type: "string",
+          describe:
+            "If set, output stats as JSON to this file. (Relative filename resolves to crawl working directory)",
+        },
+
+        behaviors: {
+          describe: "Which background behaviors to enable on each page",
+          type: "array",
+          default: ["autoplay", "autofetch", "autoscroll", "siteSpecific"],
+          choices: ["autoplay", "autofetch", "autoscroll", "siteSpecific"],
+          coerce,
+        },
+
+        behaviorTimeout: {
+          describe:
+            "If >0, timeout (in seconds) for in-page behavior will run on each page. If 0, a behavior can run until finish.",
+          default: 90,
+          type: "number",
+        },
+
+        postLoadDelay: {
+          describe:
+            "If >0, amount of time to sleep (in seconds) after page has loaded, before taking screenshots / getting text / running behaviors",
+          default: 0,
+          type: "number",
+        },
+
+        pageExtraDelay: {
+          alias: "delay",
+          describe:
+            "If >0, amount of time to sleep (in seconds) after behaviors before moving on to next page",
+          default: 0,
+          type: "number",
+        },
+
+        dedupPolicy: {
+          describe: "Deduplication policy",
+          default: "skip",
+          type: "string",
+          choices: ["skip", "revisit", "keep"],
+        },
+
+        profile: {
+          describe:
+            "Path or HTTP(S) URL to tar.gz file which contains the browser profile directory",
+          type: "string",
+        },
+
+        screenshot: {
+          describe:
+            "Screenshot options for crawler, can include: view, thumbnail, fullPage",
+          type: "array",
+          default: [],
+          choices: Array.from(Object.keys(screenshotTypes)),
+          coerce,
+        },
+
+        screencastPort: {
+          describe:
+            "If set to a non-zero value, starts an HTTP server with screencast accessible on this port",
+          type: "number",
+          default: 0,
+        },
+
+        screencastRedis: {
+          describe:
+            "If set, will use the state store redis pubsub for screencasting. Requires --redisStoreUrl to be set",
+          type: "boolean",
+          default: false,
+        },
+
+        warcInfo: {
+          alias: ["warcinfo"],
+          describe:
+            "Optional fields added to the warcinfo record in combined WARCs",
+          //type: "object"
+        },
+
+        redisStoreUrl: {
+          describe:
+            "If set, url for remote redis server to store state. Otherwise, using local redis instance",
+          type: "string",
+          default: "redis://localhost:6379/0",
+        },
+
+        saveState: {
+          describe:
+            "If the crawl state should be serialized to the crawls/ directory. Defaults to 'partial', only saved when crawl is interrupted",
+          type: "string",
+          default: "partial",
+          choices: ["never", "partial", "always"],
+        },
+
+        saveStateInterval: {
+          describe:
+            "If save state is set to 'always', also save state during the crawl at this interval (in seconds)",
+          type: "number",
+          default: 300,
+        },
+
+        saveStateHistory: {
+          describe:
+            "Number of save states to keep during the duration of a crawl",
+          type: "number",
+          default: 5,
+        },
+
+        sizeLimit: {
+          describe:
+            "If set, save state and exit if size limit exceeds this value",
+          type: "number",
+          default: 0,
+        },
+
+        diskUtilization: {
+          describe:
+            "If set, save state and exit if disk utilization exceeds this percentage value",
+          type: "number",
+          default: 90,
+        },
+
+        timeLimit: {
+          describe: "If set, save state and exit after time limit, in seconds",
+          type: "number",
+          default: 0,
+        },
+
+        healthCheckPort: {
+          describe: "port to run healthcheck on",
+          type: "number",
+          default: 0,
+        },
+
+        overwrite: {
+          describe:
+            "overwrite current crawl data: if set, existing collection directory will be deleted before crawl is started",
+          type: "boolean",
+          default: false,
+        },
+
+        waitOnDone: {
+          describe:
+            "if set, wait for interrupt signal when finished instead of exiting",
+          type: "boolean",
+          default: false,
+        },
+
+        restartsOnError: {
+          describe:
+            "if set, assume will be restarted if interrupted, don't run post-crawl processes on interrupt",
+          type: "boolean",
+          default: false,
+        },
+
+        netIdleWait: {
+          describe:
+            "if set, wait for network idle after page load and after behaviors are done (in seconds). if -1 (default), determine based on scope",
+          type: "number",
+          default: -1,
+        },
+
+        lang: {
+          describe:
+            "if set, sets the language used by the browser, should be ISO 639 language[-country] code",
+          type: "string",
+        },
+
+        title: {
+          describe:
+            "If set, write supplied title into WACZ datapackage.json metadata",
+          type: "string",
+        },
+
+        description: {
+          alias: ["desc"],
+          describe:
+            "If set, write supplied description into WACZ datapackage.json metadata",
+          type: "string",
+        },
+
+        originOverride: {
+          describe:
+            "if set, will redirect requests from each origin in key to origin in the value, eg. --originOverride https://host:port=http://alt-host:alt-port",
+          type: "array",
+          default: [],
+        },
+
+        logErrorsToRedis: {
+          describe: "If set, write error messages to redis",
+          type: "boolean",
+          default: false,
+        },
+
+        writePagesToRedis: {
+          describe: "If set, write page objects to redis",
+          type: "boolean",
+          default: false,
+        },
+
+        failOnFailedSeed: {
+          describe:
+            "If set, crawler will fail with exit code 1 if any seed fails. When combined with --failOnInvalidStatus," +
+            "will result in crawl failing with exit code 1 if any seed has a 4xx/5xx response",
+          type: "boolean",
+          default: false,
+        },
+
+        failOnFailedLimit: {
+          describe:
+            "If set, save state and exit if number of failed pages exceeds this value",
+          type: "number",
+          default: 0,
+        },
+
+        failOnInvalidStatus: {
+          describe:
+            "If set, will treat pages with 4xx or 5xx response as failures. When combined with --failOnFailedLimit" +
+            " or --failOnFailedSeed may result in crawl failing due to non-200 responses",
+          type: "boolean",
+          default: false,
+        },
+
+        customBehaviors: {
+          describe:
+            "injects a custom behavior file or set of behavior files in a directory",
+          type: "string",
+        },
+
+        debugAccessRedis: {
+          describe:
+            "if set, runs internal redis without protected mode to allow external access (for debugging)",
+          type: "boolean",
+        },
+
+        debugAccessBrowser: {
+          describe: "if set, allow debugging browser on port 9222 via CDP",
+          type: "boolean",
+        },
+
+        warcPrefix: {
+          describe:
+            "prefix for WARC files generated, including WARCs added to WACZ",
+          type: "string",
+        },
+
+        serviceWorker: {
+          alias: "sw",
+          describe:
+            "service worker handling: disabled, enabled, or disabled with custom profile",
+          choices: SERVICE_WORKER_OPTS,
+          default: "disabled",
+        },
+
+        proxyServer: {
+          describe:
+            "if set, will use specified proxy server. Takes precedence over any env var proxy settings",
+          type: "string",
+        },
+
+        dryRun: {
+          describe:
+            "If true, no archive data is written to disk, only pages and logs (and optionally saved state).",
+          type: "boolean",
+        },
+
+        qaSource: {
+          describe: "Required for QA mode. Source (WACZ or multi WACZ) for QA",
+          type: "string",
+        },
+
+        qaDebugImageDiff: {
+          describe:
+            "if specified, will write crawl.png, replay.png and diff.png for each page where they're different",
+          type: "boolean",
+        },
+
+        sshProxyPrivateKeyFile: {
+          describe:
+            "path to SSH private key for SOCKS5 over SSH proxy connection",
+          type: "string",
+        },
+
+        sshProxyKnownHostsFile: {
+          describe:
+            "path to SSH known hosts file for SOCKS5 over SSH proxy connection",
+          type: "string",
+        },
+      });
+  }
+
   parseArgs(argvParams?: string[], isQA = false) {
     let argv = argvParams || process.argv;
 
@@ -628,7 +631,7 @@ class ArgParser {
 
     let origConfig = {};
 
-    const parsed = initArgs(argv)
+    const parsed = this.initArgs(argv)
       .config(
         "config",
         "Path to YAML config file",

--- a/src/util/blockrules.ts
+++ b/src/util/blockrules.ts
@@ -18,7 +18,7 @@ const BlockState = {
   BLOCK_AD: "advertisement",
 };
 
-type BlockRuleDecl = {
+export type BlockRuleDecl = {
   url?: string;
   frameTextMatch?: string;
   inFrameUrl?: string;

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -149,7 +149,7 @@ declare module "ioredis" {
 }
 
 // ============================================================================
-type SaveState = {
+export type SaveState = {
   done?: number | string[];
   finished: string[];
   queued: string[];

--- a/tests/dryrun.test.js
+++ b/tests/dryrun.test.js
@@ -3,7 +3,7 @@ import fs from "fs";
 
 test("ensure dryRun crawl only writes pages and logs", async () => {
   child_process.execSync(
-    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --generateWACZ  --text --collection dry-run-wr-net --combineWARC --rolloverSize 10000 --limit 2 --title "test title" --description "test description" --warcPrefix custom-prefix --dryRun',
+    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --generateWACZ  --text --collection dry-run-wr-net --combineWARC --rolloverSize 10000 --limit 2 --title "test title" --description "test description" --warcPrefix custom-prefix --dryRun --exclude community',
   );
 
   const files = fs.readdirSync("test-crawls/collections/dry-run-wr-net").sort();

--- a/tests/file_stats.test.js
+++ b/tests/file_stats.test.js
@@ -3,7 +3,7 @@ import fs from "fs";
 
 test("ensure that stats file is modified", async () => {
   const child = child_process.exec(
-    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --generateWACZ --text --limit 3 --collection file-stats --statsFilename progress.json",
+    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --generateWACZ --text --limit 3 --exclude community --collection file-stats --statsFilename progress.json",
   );
 
   // detect crawler exit

--- a/tests/limit_reached.test.js
+++ b/tests/limit_reached.test.js
@@ -6,7 +6,7 @@ const exec = util.promisify(execCallback);
 
 test("ensure page limit reached", async () => {
   execSync(
-    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --scopeType prefix --behaviors "" --url https://webrecorder.net/ --limit 12 --workers 2 --collection limit-test --statsFilename stats.json',
+    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --scopeType prefix --behaviors "" --url https://webrecorder.net/ --limit 12 --workers 2 --collection limit-test --statsFilename stats.json --exclude community',
   );
 });
 

--- a/tests/mult_url_crawl_with_favicon.test.js
+++ b/tests/mult_url_crawl_with_favicon.test.js
@@ -6,7 +6,7 @@ const testIf = (condition, ...args) => condition ? test(...args) : test.skip(...
 
 test("ensure multi url crawl run with docker run passes", async () => {
   child_process.execSync(
-    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/ --generateWACZ --text --collection advanced --combineWARC --rolloverSize 10000 --workers 2 --title "test title" --description "test description" --pages 2 --limit 2',
+    'docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --url https://webrecorder.net/ --generateWACZ --text --collection advanced --combineWARC --rolloverSize 10000 --workers 2 --title "test title" --description "test description" --pages 2 --limit 2 --exclude community',
   );
 });
 

--- a/tests/rollover-writer.test.js
+++ b/tests/rollover-writer.test.js
@@ -3,7 +3,7 @@ import fs from "fs";
 
 test("set rollover to 500K and ensure individual WARCs rollover, including screenshots", async () => {
   child_process.execSync(
-    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --limit 5 --collection rollover-500K --rolloverSize 500000 --screenshot view"
+    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --limit 5 --exclude community --collection rollover-500K --rolloverSize 500000 --screenshot view"
   );
 
   const warcLists = fs.readdirSync("test-crawls/collections/rollover-500K/archive");

--- a/tests/saved-state.test.js
+++ b/tests/saved-state.test.js
@@ -53,7 +53,7 @@ test("check crawl interrupted + saved state written", async () => {
 
   try {
     containerId = execSync(
-      "docker run -d -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection int-state-test --url https://www.webrecorder.net/ --limit 10 --behaviors \"\"",
+      "docker run -d -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection int-state-test --url https://www.webrecorder.net/ --limit 10 --behaviors \"\" --exclude community",
       { encoding: "utf-8" },
       //wait.callback,
     );
@@ -129,7 +129,7 @@ test("check crawl restarted with saved state", async () => {
 
   try {
     containerId = execSync(
-      `docker run -d -p ${port}:6379 -e CRAWL_ID=test -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection int-state-test --url https://webrecorder.net/ --config /crawls/collections/int-state-test/crawls/${savedStateFile} --debugAccessRedis --limit 10 --behaviors ""`,
+      `docker run -d -p ${port}:6379 -e CRAWL_ID=test -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection int-state-test --url https://webrecorder.net/ --config /crawls/collections/int-state-test/crawls/${savedStateFile} --debugAccessRedis --limit 10 --behaviors "" --exclude community`,
       { encoding: "utf-8" },
     );
   } catch (error) {

--- a/tests/scopes.test.js
+++ b/tests/scopes.test.js
@@ -13,7 +13,7 @@ function getSeeds(config) {
   };
 
   const res = parseArgs(["node", "crawler", "--config", "stdinconfig"]);
-  return res.parsed.scopedSeeds;
+  return res.scopedSeeds;
 }
 
 test("default scope", async () => {


### PR DESCRIPTION
- Refactors args parsing so that `Crawler.params` is properly timed with CLI options + additions with `CrawlerArgs` type.
- also adds typing to create-login-profile CLI options
- validation still done w/o typing due to how yargs works