### PR TITLE
update current crawl size in redis on each healthcheck call

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1393,6 +1393,8 @@ self.__bx_behaviors.selectMainBehavior();
       return;
     }
 
+    await this.checkLimits();
+
     await this.crawlState.setStatus("running");
 
     this.pagesFH = await this.initPages(this.seedPagesFile, "Seed Pages");

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1206,12 +1206,22 @@ self.__bx_behaviors.selectMainBehavior();
     return res ? frame : null;
   }
 
+  async updateCurrSize(): Promise<number> {
+    if (this.params.dryRun) {
+      return 0;
+    }
+
+    const size = await getDirSize(this.archivesDir);
+
+    await this.crawlState.setArchiveSize(size);
+
+    return size;
+  }
+
   async checkLimits() {
     let interrupt = false;
 
-    const size = this.params.dryRun ? 0 : await getDirSize(this.archivesDir);
-
-    await this.crawlState.setArchiveSize(size);
+    const size = await this.updateCurrSize();
 
     if (this.params.sizeLimit) {
       if (size >= this.params.sizeLimit) {
@@ -1323,6 +1333,9 @@ self.__bx_behaviors.selectMainBehavior();
       this.healthChecker = new HealthChecker(
         this.params.healthCheckPort,
         this.params.workers,
+        async () => {
+          await this.updateCurrSize();
+        },
       );
     }
 


### PR DESCRIPTION
- allows Browsertrix app to adjust size, if needed, more frequently
- run checkLimits() before starting crawl, in case out of space