### PR TITLE
Additional exception safety

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -932,7 +932,12 @@ self.__bx_behaviors.selectMainBehavior();
     // run custom driver here
     await this.driver({ page, data, crawler: this });
 
-    data.title = await page.title();
+    data.title = await timedRun(
+      page.title(),
+      PAGE_OP_TIMEOUT_SECS,
+      "Timed out getting page title, something is likely wrong",
+      logDetails,
+    );
     data.favicon = await this.getFavicon(page, logDetails);
 
     await this.doPostLoadActions(opts);

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -371,8 +371,8 @@ export class Browser {
     }
   }
 
-  addInitScript(page: Page, script: string) {
-    return page.evaluateOnNewDocument(script);
+  async addInitScript(page: Page, script: string) {
+    await page.evaluateOnNewDocument(script);
   }
 
   async checkScript(cdp: CDPSession, filename: string, script: string) {

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1249,14 +1249,19 @@ export class Recorder {
     return { fetched, mime, ts };
   }
 
-  async getCookieString(cdp: CDPSession, url: string) {
-    const cookieList: string[] = [];
-    const { cookies } = await cdp.send("Network.getCookies", { urls: [url] });
-    for (const { name, value } of cookies) {
-      cookieList.push(`${name}=${value}`);
-    }
+  async getCookieString(cdp: CDPSession, url: string): Promise<string> {
+    try {
+      const cookieList: string[] = [];
+      const { cookies } = await cdp.send("Network.getCookies", { urls: [url] });
+      for (const { name, value } of cookies) {
+        cookieList.push(`${name}=${value}`);
+      }
 
-    return cookieList.join(";");
+      return cookieList.join(";");
+    } catch (e) {
+      logger.warn("Error getting cookies", { page: url, e }, "recorder");
+      return "";
+    }
   }
 }
 

--- a/src/util/screencaster.ts
+++ b/src/util/screencaster.ts
@@ -123,7 +123,9 @@ class RedisPubSubTransport {
     this.castChannel = `c:${crawlId}:cast`;
     this.ctrlChannel = `c:${crawlId}:ctrl`;
 
-    void this.init(redisUrl);
+    this.init(redisUrl).catch((e) =>
+      logger.warn("error starting cast", e, "screencast"),
+    );
   }
 
   async init(redisUrl: string) {

--- a/src/util/timing.ts
+++ b/src/util/timing.ts
@@ -26,7 +26,7 @@ export function timedRun(
 
   return Promise.race([promise, rejectPromiseOnTimeout(timeout)]).catch(
     (err) => {
-      if (err == "timeout reached") {
+      if (err === "timeout reached") {
         const logFunc = isWarn ? logger.warn : logger.error;
         logFunc.call(
           logger,


### PR DESCRIPTION
- add additional catch() block
- wrap page.title() in timedRun() to catch/log exception if this fails
- log error in getting cookies
- hopefully fixes hard-to-repro edge case crash in openzim/zimit#376