### PR TITLE
ensure extraHops also apply to maxDepth

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1921,7 +1921,7 @@ self.__bx_behaviors.selectMainBehavior();
 
     //data.filteredFrames = await page.frames().filter(frame => this.shouldIncludeFrame(frame, logDetails));
 
-    const { seedId } = data;
+    const { seedId, extraHops } = data;
 
     const seed = await this.crawlState.getSeedAt(
       this.seeds,
@@ -1944,7 +1944,7 @@ self.__bx_behaviors.selectMainBehavior();
     await this.awaitPageLoad(page.mainFrame(), logDetails);
 
     // skip extraction if at max depth
-    if (seed.isAtMaxDepth(depth) || !selectorOptsList) {
+    if (seed.isAtMaxDepth(depth, extraHops) || !selectorOptsList) {
       logger.debug("Skipping Link Extraction, At Max Depth");
       return;
     }

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -225,8 +225,8 @@ export class ScopedSeed {
     return [include, allowHash];
   }
 
-  isAtMaxDepth(depth: number) {
-    return depth >= this.maxDepth;
+  isAtMaxDepth(depth: number, extraHops: number) {
+    return depth >= this.maxDepth && extraHops >= this.maxExtraHops;
   }
 
   isIncluded(
@@ -236,10 +236,6 @@ export class ScopedSeed {
     logDetails = {},
     noOOS = false,
   ): { url: string; isOOS: boolean } | false {
-    if (depth > this.maxDepth) {
-      return false;
-    }
-
     const urlParsed = this.parseUrl(url, logDetails);
     if (!urlParsed) {
       return false;
@@ -262,11 +258,14 @@ export class ScopedSeed {
     //}
     let inScope = false;
 
-    // check scopes
-    for (const s of this.include) {
-      if (s.test(url)) {
-        inScope = true;
-        break;
+    // check scopes if depth <= maxDepth
+    // if depth exceeds, than always out of scope
+    if (depth <= this.maxDepth) {
+      for (const s of this.include) {
+        if (s.test(url)) {
+          inScope = true;
+          break;
+        }
       }
     }
 

--- a/tests/extra_hops_depth.test.js
+++ b/tests/extra_hops_depth.test.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 
 import util from "util";
-import { exec as execCallback } from "child_process";
+import { exec as execCallback, execSync } from "child_process";
 
 const exec = util.promisify(execCallback);
 
@@ -69,3 +69,23 @@ test(
   },
   extraHopsTimeout,
 );
+
+
+test("extra hops applies beyond depth limit", () => {
+    try {
+      execSync(
+        "docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection extra-hops-depth-0 --extraHops 1 --url https://webrecorder.net/ --limit 2 --depth 0 --timeout 10 --exclude community --exclude tools",
+      );
+    } catch (error) {
+      console.log(error);
+    }
+
+    const crawledExtraPages = fs.readFileSync(
+      "test-crawls/collections/extra-hops-depth-0/pages/extraPages.jsonl",
+      "utf8",
+    );
+    const crawledExtraPagesArray = crawledExtraPages.trim().split("\n");
+
+    expect(crawledExtraPagesArray.length - 1).toEqual(1);
+});
+


### PR DESCRIPTION
- if extraHops is set, crawler should visit pages beyond maxDepth
- currently returning out of scope at depth limit even if extraHops is set
- adjust isInScope and isAtMaxDepth to account for extraHops
- fixes #693