### PR TITLE
link extraction promise cleanup:

### DIFF
--- a/src/util/timing.ts
+++ b/src/util/timing.ts
@@ -18,14 +18,16 @@ export function timedRun(
   // return Promise return value or log error if timeout is reached first
   const timeout = seconds * 1000;
 
+  let tm: NodeJS.Timeout;
+
   const rejectPromiseOnTimeout = (timeout: number) => {
     return new Promise((resolve, reject) => {
-      setTimeout(() => reject("timeout reached"), timeout);
+      tm = setTimeout(() => reject("timeout reached"), timeout);
     });
   };
 
-  return Promise.race([promise, rejectPromiseOnTimeout(timeout)]).catch(
-    (err) => {
+  return Promise.race([promise, rejectPromiseOnTimeout(timeout)])
+    .catch((err) => {
       if (err === "timeout reached") {
         const logFunc = isWarn ? logger.warn : logger.error;
         logFunc.call(
@@ -38,8 +40,8 @@ export function timedRun(
         //logger.error("Unknown exception", {...errJSON(err), ...logDetails}, context);
         throw err;
       }
-    },
-  );
+    })
+    .finally(() => clearTimeout(tm));
 }
 
 export function secondsElapsed(startTime: number, nowDate: Date | null = null) {


### PR DESCRIPTION
- catch frame.evaluate() directly and log errors there to avoid any possibility of exception being propagated before wrapping in timedRun()
- also add clearTimeout() to timedRun()
- possibly fixes openzim/zimit#376