### PR TITLE
various edge-case loading optimizations:

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "p-queue": "^7.3.4",
     "pixelmatch": "^5.3.0",
     "pngjs": "^7.0.0",
-    "puppeteer-core": "^23.5.1",
+    "puppeteer-core": "^23.6.0",
     "sax": "^1.3.0",
     "sharp": "^0.32.6",
     "tsc": "^2.0.4",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -175,6 +175,7 @@ export class Crawler {
   finalExit = false;
   uploadAndDeleteLocal = false;
   done = false;
+  postCrawling = false;
 
   textInPages = false;
 
@@ -1536,11 +1537,12 @@ self.__bx_behaviors.selectMainBehavior();
   }
 
   async postCrawl() {
+    this.postCrawling = true;
+    logger.info("Crawling done");
+
     if (this.params.combineWARC && !this.params.dryRun) {
       await this.combineWARC();
     }
-
-    logger.info("Crawling done");
 
     if (
       (this.params.generateCDX || this.params.generateWACZ) &&

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -392,7 +392,6 @@ export class Browser {
     launchOpts: PuppeteerLaunchOptions,
     // eslint-disable-next-line @typescript-eslint/ban-types
     ondisconnect: Function | null = null,
-    //_recording: boolean,
   ) {
     this.browser = await puppeteer.launch(launchOpts);
 

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -484,6 +484,8 @@ export class Browser {
     this.firstCDP.on("Fetch.requestPaused", async (params) => {
       const { frameId, requestId, request } = params;
 
+      const { url } = request;
+
       if (!this.firstCDP) {
         throw new Error("CDP missing");
       }
@@ -491,7 +493,7 @@ export class Browser {
       let foundRecorder = null;
 
       for (const recorder of this.recorders) {
-        if (recorder.swUrls.has(request.url)) {
+        if (recorder.swUrls.has(url)) {
           recorder.swFrameIds.add(frameId);
         }
 
@@ -504,7 +506,7 @@ export class Browser {
       if (!foundRecorder) {
         logger.warn(
           "Skipping URL from unknown frame",
-          { url: request.url, frameId },
+          { url, frameId },
           "recorder",
         );
 
@@ -513,7 +515,7 @@ export class Browser {
         } catch (e) {
           logger.debug(
             "continueResponse failed",
-            { url: request.url, ...formatErr(e), from: "serviceWorker" },
+            { url, ...formatErr(e), from: "serviceWorker" },
             "recorder",
           );
         }

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1101,7 +1101,7 @@ export class Recorder {
     if (
       contentLength < 0 &&
       !this.isEssentialResource(resourceType, mimeType) &&
-      reponseStatusCode >= 200 && responseStatusCode < 300
+      responseStatusCode >= 200 && responseStatusCode < 300
     ) {
       return true;
     }

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -430,8 +430,8 @@ export class Recorder {
         // check if this is a false positive -- a valid download that's already been fetched
         // the abort is just for page, but download will succeed
         if (
-          type === "Document" ||
-          (type === "Media" && reqresp.isValidBinary())
+          (type === "Document" || type === "Media") &&
+          reqresp.isValidBinary()
         ) {
           this.removeReqResp(requestId);
           return this.serializeToWARC(reqresp);
@@ -1422,7 +1422,7 @@ class AsyncFetcher {
           reqresp.payload = Buffer.concat(buffers, currSize);
           externalBuffer.buffers = [reqresp.payload];
         } else if (fh) {
-          logger.warn(
+          logger.debug(
             "Large payload written to WARC, but not returned to browser (would require rereading into memory)",
             { url, actualSize: reqresp.readSize, maxSize: this.maxFetchSize },
             "recorder",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1101,7 +1101,7 @@ export class Recorder {
     if (
       contentLength < 0 &&
       !this.isEssentialResource(resourceType, mimeType) &&
-      responseStatusCode < 300
+      reponseStatusCode >= 200 && responseStatusCode < 300
     ) {
       return true;
     }

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1101,7 +1101,8 @@ export class Recorder {
     if (
       contentLength < 0 &&
       !this.isEssentialResource(resourceType, mimeType) &&
-      responseStatusCode >= 200 && responseStatusCode < 300
+      responseStatusCode >= 200 &&
+      responseStatusCode < 300
     ) {
       return true;
     }

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -49,6 +49,12 @@ export class RequestResponseInfo {
   payload?: Uint8Array;
   isRemoveRange = false;
 
+  // fetchContinued - avoid duplicate fetch response handling
+  fetchContinued = false;
+
+  // is handled in page context
+  inPageContext = false;
+
   // misc
   fromServiceWorker = false;
   fromCache = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,10 +2075,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-devtools-protocol@0.0.1342118:
-  version "0.0.1342118"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1342118.tgz#ea136fc1701572c0830233dcb414dc857e582e0a"
-  integrity sha512-75fMas7PkYNDTmDyb6PRJCH7ILmHLp+BhrZGeMsa4bCh40DTxgCz2NRy5UDzII4C5KuD0oBMZ9vXKhEl6UD/3w==
+devtools-protocol@0.0.1354347:
+  version "0.0.1354347"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1354347.tgz#5cb509610b8f61fc69a31e5c810d5bed002d85ea"
+  integrity sha512-BlmkSqV0V84E2WnEnoPnwyix57rQxAM5SKJjf4TbYOCGLAWtz8CDH8RIaGOjPgPCXo2Mce3kxSY497OySidY3Q==
 
 diff-sequences@^29.6.3:
   version "29.6.3"
@@ -4375,15 +4375,15 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer-core@^23.5.1:
-  version "23.5.1"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-23.5.1.tgz#fac4268820c35d3172e783a1f1a39773b2c0f7c6"
-  integrity sha512-We6xKCSZaZ23+GAYckeNfeDeJIVuhxOBsh/gZkbULu/XLFJ3umSiiQ8Ey927h3g/XrCCr8CnSZ5fvP5v2vB5Yw==
+puppeteer-core@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-23.6.0.tgz#a3e1e09c05f47fb8ca2bc9d4ca200d18e3704303"
+  integrity sha512-se1bhgUpR9C529SgHGr/eyT92mYyQPAhA2S9pGtGrVG2xob9qE6Pbp7TlqiSPlnnY1lINqhn6/67EwkdzOmKqQ==
   dependencies:
     "@puppeteer/browsers" "2.4.0"
     chromium-bidi "0.8.0"
     debug "^4.3.7"
-    devtools-protocol "0.0.1342118"
+    devtools-protocol "0.0.1354347"
     typed-query-selector "^2.12.0"
     ws "^8.18.0"
 


### PR DESCRIPTION
- if too many range requests for same URL are being made, try skipping/failing right away to reduce load
- assume main browser context is used not just for service workers, always enable
- check false positive 'net-aborted' error that may actually be ok for media, as well as documents
- improve logging
- possible fix for issues in #706
- interrupt any pending requests (that may be loading via browser context) after page timeout, log dropped requests