### PR TITLE
fix cookie not being passed to replay regression: for now, add x-waba…

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1751,6 +1751,13 @@ function createResponse(
 
   const httpHeaders = reqresp.getResponseHeadersDict(reqresp.payload.length);
 
+  const cookie =
+    reqresp.requestHeaders &&
+    (reqresp.requestHeaders["cookie"] || reqresp.requestHeaders["Cookie"]);
+  if (cookie) {
+    httpHeaders["x-wabac-preset-cookie"] = cookie;
+  }
+
   const warcHeaders: Record<string, string> = {
     "WARC-Page-ID": pageid,
   };


### PR DESCRIPTION
…c-preset-cookie header for quick fix (same as AWP)

longer fix will involve fixing CDXJ to include the header

Fix replay of X captures and other pages requiring cookies