### PR TITLE
Add WARC-Protocol header

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1900,10 +1900,6 @@ function createResponse(
     );
   }
 
-  if (reqresp.cipher) {
-    warcHeaders["WARC-Cipher-Suite"] = reqresp.cipher;
-  }
-
   if (reqresp.resourceType) {
     warcHeaders["WARC-Resource-Type"] = reqresp.resourceType;
   }

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1880,7 +1880,7 @@ function createResponse(
 
   const url = reqresp.url;
   const warcVersion = "WARC/1.1";
-  const statusline = `HTTP/1.1 ${reqresp.status} ${reqresp.statusText}`;
+  const statusline = `${reqresp.httpProtocol} ${reqresp.status} ${reqresp.statusText}`;
   const date = new Date(reqresp.ts).toISOString();
 
   if (!reqresp.payload) {
@@ -1939,7 +1939,9 @@ function createRequest(
 
   const urlParsed = new URL(url);
 
-  const statusline = `${method} ${url.slice(urlParsed.origin.length)} HTTP/1.1`;
+  const statusline = `${method} ${url.slice(urlParsed.origin.length)} ${
+    reqresp.httpProtocol
+  }`;
 
   const requestBody = reqresp.postData
     ? [encoder.encode(reqresp.postData)]

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -17,7 +17,7 @@ import {
   rewriteHLS,
 } from "@webrecorder/wabac";
 
-import { WARCRecord } from "warcio";
+import { WARCRecord, multiValueHeader } from "warcio";
 import { TempFileBuffer, WARCSerializer } from "warcio/node";
 import { WARCWriter } from "./warcwriter.js";
 import { RedisCrawlState, WorkerId } from "./state.js";
@@ -1894,7 +1894,10 @@ function createResponse(
   };
 
   if (reqresp.protocols.length) {
-    warcHeaders["WARC-Protocol"] = reqresp.protocols.join(", ");
+    warcHeaders["WARC-Protocol"] = multiValueHeader(
+      "WARC-Protocol",
+      reqresp.protocols,
+    );
   }
 
   if (reqresp.cipher) {

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1893,6 +1893,14 @@ function createResponse(
     "WARC-Page-ID": pageid,
   };
 
+  if (reqresp.protocols.length) {
+    warcHeaders["WARC-Protocol"] = reqresp.protocols.join(", ");
+  }
+
+  if (reqresp.cipher) {
+    warcHeaders["WARC-Cipher-Suite"] = reqresp.cipher;
+  }
+
   if (reqresp.resourceType) {
     warcHeaders["WARC-Resource-Type"] = reqresp.resourceType;
   }

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -2,9 +2,8 @@ import { getCustomRewriter, getStatusText } from "@webrecorder/wabac";
 
 import { Protocol } from "puppeteer-core";
 import { postToGetUrl } from "warcio";
-import { Response } from "undici";
-
 import { HTML_TYPES } from "./constants.js";
+import { Response } from "undici";
 
 const CONTENT_LENGTH = "content-length";
 const CONTENT_RANGE = "content-range";
@@ -27,6 +26,8 @@ export class RequestResponseInfo {
   method?: string;
   url!: string;
 
+  // protocol for WARC record
+  httpProtocol = "HTTP/1.1";
   protocols: string[] = [];
 
   mimeType?: string;
@@ -135,6 +136,9 @@ export class RequestResponseInfo {
     this.setStatus(response.status, response.statusText);
 
     if (response.protocol) {
+      if (response.protocol === "http/1.0") {
+        this.httpProtocol = "HTTP/1.0";
+      }
       this.protocols.push(response.protocol);
     }
 

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -2,8 +2,9 @@ import { getCustomRewriter, getStatusText } from "@webrecorder/wabac";
 
 import { Protocol } from "puppeteer-core";
 import { postToGetUrl } from "warcio";
-import { HTML_TYPES } from "./constants.js";
 import { Response } from "undici";
+
+import { HTML_TYPES } from "./constants.js";
 import { logger } from "./logger.js";
 
 const CONTENT_LENGTH = "content-length";

--- a/tests/pageinfo-records.test.js
+++ b/tests/pageinfo-records.test.js
@@ -24,10 +24,9 @@ test("run warc and ensure pageinfo records contain the correct resources", async
   let foundInvalid = false;
 
   for await (const record of parser) {
-    if (record.warcType === "response" && 
+    if (record.warcType === "response" &&
       (record.warcTargetURI === "https://oldwebrecorder.net/" || record.warcTargetURI === "https://old.webrecorder.net/about")) {
       expect(record.warcHeaders.headers.get("WARC-Protocol")).toBe("h2, tls/1.3");
-      expect(record.warcHeaders.headers.get("WARC-Cipher-Suite")).toBe("TLS_AES_128_GCM_SHA256");
     }
 
     if (

--- a/tests/pageinfo-records.test.js
+++ b/tests/pageinfo-records.test.js
@@ -24,7 +24,8 @@ test("run warc and ensure pageinfo records contain the correct resources", async
   let foundInvalid = false;
 
   for await (const record of parser) {
-    if (record.warcType === "response") {
+    if (record.warcType === "response" && 
+      (record.warcTargetURI === "https://oldwebrecorder.net/" || record.warcTargetURI === "https://old.webrecorder.net/about")) {
       expect(record.warcHeaders.headers.get("WARC-Protocol")).toBe("h2, tls/1.3");
       expect(record.warcHeaders.headers.get("WARC-Cipher-Suite")).toBe("TLS_AES_128_GCM_SHA256");
     }

--- a/tests/pageinfo-records.test.js
+++ b/tests/pageinfo-records.test.js
@@ -25,7 +25,7 @@ test("run warc and ensure pageinfo records contain the correct resources", async
 
   for await (const record of parser) {
     if (record.warcType === "response" &&
-      (record.warcTargetURI === "https://oldwebrecorder.net/" || record.warcTargetURI === "https://old.webrecorder.net/about")) {
+      (record.warcTargetURI === "https://old.webrecorder.net/" || record.warcTargetURI === "https://old.webrecorder.net/about")) {
       expect(record.warcHeaders.headers.get("WARC-Protocol")).toBe("h2, tls/1.3");
     }
 

--- a/tests/pageinfo-records.test.js
+++ b/tests/pageinfo-records.test.js
@@ -24,6 +24,11 @@ test("run warc and ensure pageinfo records contain the correct resources", async
   let foundInvalid = false;
 
   for await (const record of parser) {
+    if (record.warcType === "response") {
+      expect(record.warcHeaders.headers.get("WARC-Protocol")).toBe("h2, tls/1.3");
+      expect(record.warcHeaders.headers.get("WARC-Cipher-Suite")).toBe("TLS_AES_128_GCM_SHA256");
+    }
+
     if (
       !foundIndex &&
       record.warcTargetURI === "urn:pageinfo:https://old.webrecorder.net/"


### PR DESCRIPTION
- add WARC-Protocol header combining http + tls protocols as repeated headers
- ~~add WARC-Cipher-Suite header, mapping Chrome NetworkSecurityDetails to known cipher suites~~
- fixes #641

A few caveats:
For now, just adding WARC-Protocol here as WARC-Cipher-Suite needs more testing.
~~- The WARC-Cipher-Suite data is not directly available from the browser, so must be inferred based on the available info.~~