### PR TITLE
Ensure partial responses are not written

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1531,10 +1531,8 @@ class AsyncFetcher {
     const { method, url } = reqresp;
     logger.debug("Async started: fetch", { url }, "recorder");
 
-    const headers = new Headers(reqresp.getRequestHeadersDict());
-    if (headers.has("range")) {
-      headers.set("range", "bytes=0-");
-    }
+    const headers = reqresp.getRequestHeadersDict();
+
     const dispatcher = getGlobalDispatcher().compose((dispatch) => {
       return (opts, handler) => {
         if (opts.headers) {

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -752,8 +752,8 @@ export class Recorder {
     if (
       isBrowserContext &&
       !reqresp.inPageContext &&
-      reqresp.payload &&
-      reqresp.payload.length > 0
+      !reqresp.asyncLoading &&
+      reqresp.payload
     ) {
       this.removeReqResp(networkId);
       await this.serializeToWARC(reqresp);
@@ -874,7 +874,7 @@ export class Recorder {
 
   async awaitPageResources() {
     for (const [requestId, reqresp] of this.pendingRequests.entries()) {
-      if (reqresp.payload && reqresp.payload.length > 0) {
+      if (reqresp.payload && !reqresp.asyncLoading) {
         this.removeReqResp(requestId);
         await this.serializeToWARC(reqresp);
         // if no url, and not fetch intercept or async loading,

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -438,9 +438,9 @@ export async function runWorkers(
 
   await Promise.allSettled(workers.map((worker) => worker.run()));
 
-  await crawler.browser.close();
-
   await closeWorkers();
+
+  await crawler.browser.close();
 }
 
 // ===========================================================================


### PR DESCRIPTION
various fixes for streaming, especially related to range requests
- follow up to #709
- fix: prefer streaming current response via takeStream, not only when size is unknown
- don't serialize async responses prematurely
- don't serialize 206 responses if there is size mismatch