### PR TITLE
separate fetch api for autofetch bbehavior + additional improvements on partial responses:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         run: yarn add -D http-server
 
       - name: install py-wacz as root for tests
-        run: sudo pip install wacz
+        run: sudo pip install wacz --ignore-installed
 
       - name: run all tests as root
         run: sudo DOCKER_HOST_NAME=172.17.0.1 CI=true yarn test -validate

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@novnc/novnc": "1.4.0",
     "@webrecorder/wabac": "^2.20.7",
-    "browsertrix-behaviors": "^0.6.5",
+    "browsertrix-behaviors": "^0.6.6",
     "client-zip": "^2.4.5",
     "css-selector-parser": "^3.0.5",
     "fetch-socks": "^1.3.0",
@@ -37,7 +37,7 @@
     "tsc": "^2.0.4",
     "undici": "^6.18.2",
     "uuid": "8.3.2",
-    "warcio": "^2.4.2",
+    "warcio": "^2.4.3",
     "ws": "^7.4.4",
     "yargs": "^17.7.2"
   },
@@ -67,7 +67,7 @@
   },
   "resolutions": {
     "wrap-ansi": "7.0.0",
-    "warcio": "^2.4.2",
+    "warcio": "^2.4.3",
     "@novnc/novnc": "1.4.0"
   }
 }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -46,6 +46,7 @@ import { Browser } from "./util/browser.js";
 import {
   ADD_LINK_FUNC,
   BEHAVIOR_LOG_FUNC,
+  FETCH_FUNC,
   DISPLAY,
   ExtractSelector,
   PAGE_OP_TIMEOUT_SECS,
@@ -693,6 +694,7 @@ export class Crawler {
     cdp,
     workerid,
     callbacks,
+    recorder,
     frameIdToExecId,
   }: WorkerOpts) {
     await this.browser.setupPage({ page, cdp });
@@ -766,6 +768,10 @@ self.__bx_behaviors.selectMainBehavior();
         await this.checkBehaviorScripts(cdp);
         this.behaviorsChecked = true;
       }
+
+      await page.exposeFunction(FETCH_FUNC, (url: string) => {
+        return recorder.addExternalFetch(url, cdp);
+      });
 
       await this.browser.addInitScript(page, initScript);
     }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -770,7 +770,7 @@ self.__bx_behaviors.selectMainBehavior();
       }
 
       await page.exposeFunction(FETCH_FUNC, (url: string) => {
-        return recorder.addExternalFetch(url, cdp);
+        return recorder ? recorder.addExternalFetch(url, cdp) : true;
       });
 
       await this.browser.addInitScript(page, initScript);

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -24,6 +24,8 @@ export const EXTRACT_TEXT_TYPES = ["to-pages", "to-warc", "final-to-warc"];
 
 export const BEHAVIOR_LOG_FUNC = "__bx_log";
 export const ADD_LINK_FUNC = "__bx_addLink";
+export const FETCH_FUNC = "__bx_fetch";
+
 export const MAX_DEPTH = 1000000;
 
 export const FETCH_HEADERS_TIMEOUT_SECS = 30;

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -335,6 +335,13 @@ export class RequestResponseInfo {
     return this.fromCache && !this.payload;
   }
 
+  deleteRange() {
+    if (this.requestHeaders) {
+      delete this.requestHeaders["range"];
+      delete this.requestHeaders["Range"];
+    }
+  }
+
   shouldSkipSave() {
     // skip cached, OPTIONS/HEAD responses, and 304 responses
     if (

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -27,7 +27,7 @@ export type WorkerOpts = {
   directFetchCapture:
     | ((request: DirectFetchRequest) => Promise<DirectFetchResponse>)
     | null;
-  recorder: Recorder;
+  recorder: Recorder | null;
   markPageUsed: () => void;
   frameIdToExecId: Map<string, number>;
   isAuthSet?: boolean;
@@ -184,7 +184,7 @@ export class PageWorker {
           cdp,
           workerid,
           callbacks: this.callbacks,
-          recorder: this.recorder!,
+          recorder: this.recorder,
           directFetchCapture,
           frameIdToExecId: new Map<string, number>(),
           markPageUsed: () => {

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -27,6 +27,7 @@ export type WorkerOpts = {
   directFetchCapture:
     | ((request: DirectFetchRequest) => Promise<DirectFetchResponse>)
     | null;
+  recorder: Recorder;
   markPageUsed: () => void;
   frameIdToExecId: Map<string, number>;
   isAuthSet?: boolean;
@@ -183,6 +184,7 @@ export class PageWorker {
           cdp,
           workerid,
           callbacks: this.callbacks,
+          recorder: this.recorder!,
           directFetchCapture,
           frameIdToExecId: new Map<string, number>(),
           markPageUsed: () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,10 +1435,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.1"
 
-browsertrix-behaviors@^0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.6.5.tgz#a8e3da231caff8e54e34cac6ed3ff431c68b664d"
-  integrity sha512-URUMUPdU0O2J8rmgzrzY4BzT8vv/iYNQUf/B1Eif3ntMsMC51R4/MGgOC8d7pUDCfy5tnOkV1FGlhB9A5LLQrw==
+browsertrix-behaviors@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.6.6.tgz#10bcccfb091c051f5c886d5f69487e6d184078de"
+  integrity sha512-UPNcU9dV0nAvUwJHKKYCkuqdYdlMjK7AWYDyr4xBpSq55xmEh2wQlwQyDyJuUUUrhJNII4NqXK24hVXPdvf5VA==
   dependencies:
     query-selector-shadow-dom "^1.0.1"
 
@@ -5006,10 +5006,10 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-warcio@^2.4.0, warcio@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.2.tgz#782d8dcb0769f271b0ae96521fb4969e2570e9b3"
-  integrity sha512-QYbZ3EGYtnAIrzL7Bajo7ak87pipilpkIfaFIzFQWUX4wuXNuKqnfQy/EAoi2tEIl3VJgsWcL+wjjk4+15MKbQ==
+warcio@^2.4.0, warcio@^2.4.2, warcio@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.3.tgz#37ff95c2358d0d5ddb16e924fe200c4774b3903d"
+  integrity sha512-c397HNfLE7yJsyVF3XKXB+Yh3q3WKljhdYRPkKF9eyZMtB+HIxj1aBqgq0nTYz492KMKtzygBo0Gx+Gi0fJ9dg==
   dependencies:
     "@types/pako" "^1.0.7"
     "@types/stream-buffers" "^3.0.7"


### PR DESCRIPTION
Chromium now interrupts fetch() if abort() is called or page is navigated, so autofetch behavior using native fetch() is less than ideal. This PR adds support for __bx_fetch() command for autofetch behavior (supported in browsertrix-behaviors 0.6.6) to fetch separately from browser's reguar fetch()
- __bx_fetch() starts a fetch, but does not return content to browser, doesn't need abort(), unaffected by page navigation, but will still try to use browser network stack when possible, making it more efficient for background fetching.
- if network stack fetch fails, fallback to regular node fetch() in the crawler.
Additional improvements for interrupted fetch:
- don't store truncated media responses, even for 200
- avoid doing duplicate async fetching if response already handled (eg. fetch handled in multiple contexts)
- fixes #735, where fetch was interrupted, resulted in an empty response
