### PR TITLE
Retry Failed Pages + Ignore Hashtags in Redirect Check

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1038,9 +1038,13 @@ self.__bx_behaviors.selectMainBehavior();
 
   async doPostLoadActions(opts: WorkerState, saveOutput = false) {
     const { page, cdp, data, workerid } = opts;
-    const { url } = data;
+    const { url, status } = data;
 
     if (!data.isHTMLPage) {
+      return;
+    }
+
+    if (status >= 400) {
       return;
     }
 
@@ -1938,10 +1942,15 @@ self.__bx_behaviors.selectMainBehavior();
       throw new Error("no response for page load, assuming failed");
     }
 
-    const respUrl = resp.url();
+    const respUrl = resp.url().split("#")[0];
     const isChromeError = page.url().startsWith("chrome-error://");
 
-    if (depth === 0 && !isChromeError && respUrl !== url && !downloadResponse) {
+    if (
+      depth === 0 &&
+      !isChromeError &&
+      respUrl !== url.split("#")[0] &&
+      !downloadResponse
+    ) {
       data.seedId = await this.crawlState.addExtraSeed(
         this.seeds,
         this.numOriginalSeeds,

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1038,13 +1038,9 @@ self.__bx_behaviors.selectMainBehavior();
 
   async doPostLoadActions(opts: WorkerState, saveOutput = false) {
     const { page, cdp, data, workerid } = opts;
-    const { url, status } = data;
+    const { url } = data;
 
     if (!data.isHTMLPage) {
-      return;
-    }
-
-    if (status >= 400) {
       return;
     }
 

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -308,6 +308,7 @@ if json then
     return 1;
   else
     return 2;
+  end
 end
 return 0;
 `,


### PR DESCRIPTION
- Retry pages that are marked as failed once, at the end of the crawl, in case it was due to a timeout
- Also, don't treat differences in hashtag between seed page loaded and actual URL as a redirect (eg. don't add as new seed)