### PR TITLE
clear out core dumps to avoid using up volume space:

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# disable core dumps
+ulimit -c 0
+
 # Get UID/GID from volume dir
 
 VOLUME_UID=$(stat -c '%u' /crawls)

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { logger } from "./util/logger.js";
 import { setExitOnRedisError } from "./util/redis.js";
 import { Crawler } from "./crawler.js";
 import { ReplayCrawler } from "./replaycrawler.js";
+import fs from "node:fs";
 
 let crawler: Crawler | null = null;
 
@@ -54,6 +55,13 @@ if (process.argv[1].endsWith("qa")) {
   crawler = new ReplayCrawler();
 } else {
   crawler = new Crawler();
+}
+
+// remove any core dumps which could be taking up space in the working dir
+try {
+  fs.unlinkSync("./core");
+} catch (e) {
+  //ignore
 }
 
 await crawler.run();


### PR DESCRIPTION
- add 'ulimit -c' to startup script
- delete any './core' files that exist in working dir just in case
- fixes #738