### PR TITLE
Apply exclusions to redirects

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1964,13 +1964,11 @@ self.__bx_behaviors.selectMainBehavior();
         // log if not already log and rethrow, consider page failed
         if (msg !== "logged") {
           const loadState = data.loadState;
+
+          // excluded in recorder
           if (msg.startsWith("net::ERR_BLOCKED_BY_RESPONSE")) {
-            logger.error("Page Load Blocked, skipping", {
-              msg,
-              loadState,
-              ...logDetails,
-            });
             data.pageSkipped = true;
+            logger.warn("Page Load Blocked, skipping", { msg, loadState });
           } else {
             logger.error("Page Load Failed, will retry", {
               msg,

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -24,6 +24,7 @@ import { RedisCrawlState, WorkerId } from "./state.js";
 import { CDPSession, Protocol } from "puppeteer-core";
 import { Crawler } from "../crawler.js";
 import { getProxyDispatcher } from "./proxy.js";
+import { ScopedSeed } from "./seeds.js";
 
 const MAX_BROWSER_DEFAULT_FETCH_SIZE = 5_000_000;
 const MAX_TEXT_REWRITE_SIZE = 25_000_000;
@@ -147,6 +148,8 @@ export class Recorder {
 
   pageUrl!: string;
   pageid!: string;
+
+  pageSeed?: ScopedSeed;
 
   frameIdToExecId: Map<string, number> | null;
 
@@ -691,11 +694,27 @@ export class Recorder {
 
     reqresp.fetchContinued = true;
 
+    reqresp.fillFetchRequestPaused(params);
+
     if (
       url === this.pageUrl &&
       (!this.pageInfo.ts ||
-        (responseStatusCode && responseStatusCode < this.pageInfo.tsStatus))
+        (responseStatusCode && responseStatusCode <= this.pageInfo.tsStatus))
     ) {
+      const errorReason = await this.blockPageResponse(
+        url,
+        reqresp,
+        responseHeaders,
+      );
+
+      if (errorReason) {
+        await cdp.send("Fetch.failRequest", {
+          requestId,
+          errorReason,
+        });
+        return true;
+      }
+
       logger.debug("Setting page timestamp", {
         ts: reqresp.ts,
         url,
@@ -705,8 +724,6 @@ export class Recorder {
       this.pageInfo.tsStatus = responseStatusCode!;
       this.mainFrameId = params.frameId;
     }
-
-    reqresp.fillFetchRequestPaused(params);
 
     if (this.noResponseForStatus(responseStatusCode)) {
       reqresp.payload = new Uint8Array();
@@ -864,6 +881,36 @@ export class Recorder {
     void this.fetcherQ.add(() => fetcher.load());
     // return true if successful
     return true;
+  }
+
+  async blockPageResponse(
+    url: string,
+    reqresp: RequestResponseInfo,
+    responseHeaders?: Protocol.Fetch.HeaderEntry[],
+  ): Promise<Protocol.Network.ErrorReason | undefined> {
+    if (reqresp.isRedirectStatus()) {
+      try {
+        let loc = this.getLocation(responseHeaders);
+        if (loc) {
+          loc = new URL(loc, url).href;
+
+          this.pageUrl = loc;
+
+          if (this.pageSeed && this.pageSeed.isExcluded(loc)) {
+            logger.warn(
+              "Skipping page that redirects to excluded URL",
+              { newUrl: loc, origUrl: this.pageUrl },
+              "recorder",
+            );
+
+            return "BlockedByResponse";
+          }
+        }
+      } catch (e) {
+        // ignore
+        logger.debug("Redirect check error", e, "recorder");
+      }
+    }
   }
 
   startPage({ pageid, url }: { pageid: string; url: string }) {
@@ -1181,6 +1228,21 @@ export class Recorder {
     for (const header of headers) {
       if (header.name.toLowerCase() === "content-type") {
         return header.value.split(";")[0];
+      }
+    }
+
+    return null;
+  }
+
+  protected getLocation(
+    headers?: Protocol.Fetch.HeaderEntry[] | { name: string; value: string }[],
+  ) {
+    if (!headers) {
+      return null;
+    }
+    for (const header of headers) {
+      if (header.name.toLowerCase() === "location") {
+        return header.value;
       }
     }
 

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -894,8 +894,6 @@ export class Recorder {
         if (loc) {
           loc = new URL(loc, url).href;
 
-          this.pageUrl = loc;
-
           if (this.pageSeed && this.pageSeed.isExcluded(loc)) {
             logger.warn(
               "Skipping page that redirects to excluded URL",

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -280,15 +280,23 @@ export class ScopedSeed {
       }
     }
 
+    if (this.isExcluded(url)) {
+      return false;
+    }
+
+    return { url, isOOS };
+  }
+
+  isExcluded(url: string) {
     // check exclusions
     for (const e of this.exclude) {
       if (e.test(url)) {
         //console.log(`Skipping ${url} excluded by ${e}`);
-        return false;
+        return true;
       }
     }
 
-    return { url, isOOS };
+    return false;
   }
 }
 

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -74,6 +74,7 @@ export class PageState {
   favicon?: string;
 
   skipBehaviors = false;
+  pageSkipped = false;
   filteredFrames: Frame[] = [];
   loadState: LoadState = LoadState.FAILED;
 

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -2,11 +2,7 @@ import os from "os";
 
 import { logger, formatErr } from "./logger.js";
 import { sleep, timedRun } from "./timing.js";
-import {
-  DirectFetchRequest,
-  DirectFetchResponse,
-  Recorder,
-} from "./recorder.js";
+import { Recorder } from "./recorder.js";
 import { rxEscape } from "./seeds.js";
 import { CDPSession, Page } from "puppeteer-core";
 import { PageState, WorkerId } from "./state.js";
@@ -24,9 +20,6 @@ export type WorkerState = {
   workerid: WorkerId;
   // eslint-disable-next-line @typescript-eslint/ban-types
   callbacks: Record<string, Function>;
-  directFetchCapture:
-    | ((request: DirectFetchRequest) => Promise<DirectFetchResponse>)
-    | null;
   recorder: Recorder | null;
   markPageUsed: () => void;
   frameIdToExecId: Map<string, number>;
@@ -175,16 +168,13 @@ export class PageWorker {
         this.page = page;
         this.cdp = cdp;
         this.callbacks = {};
-        const directFetchCapture = this.recorder
-          ? (req: DirectFetchRequest) => this.recorder!.directFetchCapture(req)
-          : null;
+
         this.opts = {
           page,
           cdp,
           workerid,
           callbacks: this.callbacks,
           recorder: this.recorder,
-          directFetchCapture,
           frameIdToExecId: new Map<string, number>(),
           markPageUsed: () => {
             if (!this.alwaysReuse) {

--- a/tests/exclude-redirected.test.js
+++ b/tests/exclude-redirected.test.js
@@ -1,0 +1,21 @@
+import fs from "fs";
+import { execSync } from "child_process";
+
+// example.com includes a link to 'https://www.iana.org/domains/example' which redirects to 'https://www.iana.org/help/example-domains'
+// pgae loading should be blocked on redirected due to exclusion of 'help', though the initial link is loaded
+
+test("ensure exclusion is applied on redirected URL, which contains 'help', so it is not crawled", () => {
+  execSync(
+      "docker run -p 9037:9037 -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://example.com/ --exclude help --collection redir-exclude-test --extraHops 1");
+
+  // no entries besides header
+  expect(
+    fs
+      .readFileSync(
+        "test-crawls/collections/retry-fail/pages/extraPages.jsonl",
+        "utf8",
+      ).trim().split("\n").length
+  ).toBe(1);
+  
+});
+

--- a/tests/exclude-redirected.test.js
+++ b/tests/exclude-redirected.test.js
@@ -12,7 +12,7 @@ test("ensure exclusion is applied on redirected URL, which contains 'help', so i
   expect(
     fs
       .readFileSync(
-        "test-crawls/collections/retry-fail/pages/extraPages.jsonl",
+        "test-crawls/collections/redir-exclude-test/pages/extraPages.jsonl",
         "utf8",
       ).trim().split("\n").length
   ).toBe(1);


### PR DESCRIPTION
- if redirected page is excluded, block loading of page
- mark page as excluded, don't retry, and don't write to page list
- support generic blocking of pages based on initial page response
- fixes #744