### PR TITLE
Readd health check on retry

### DIFF
--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -27,7 +27,7 @@ export const ADD_LINK_FUNC = "__bx_addLink";
 export const FETCH_FUNC = "__bx_fetch";
 
 export const MAX_DEPTH = 1000000;
-export const DEFAULT_MAX_RETRIES = 1;
+export const DEFAULT_MAX_RETRIES = 2;
 
 export const FETCH_HEADERS_TIMEOUT_SECS = 30;
 export const PAGE_OP_TIMEOUT_SECS = 5;

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -382,13 +382,13 @@ return inx;
     return await this.redis.incr(this.dkey);
   }
 
-  async markFailed(url: string) {
+  async markFailed(url: string, noRetries = false) {
     return await this.redis.requeuefailed(
       this.pkey,
       this.qkey,
       this.fkey,
       url,
-      this.maxRetries,
+      noRetries ? 0 : this.maxRetries,
       MAX_DEPTH,
     );
   }


### PR DESCRIPTION
- health check failures should be incremented even if retrying, in case restart is needed
- cleanup writePage()
- bump default --maxPageRetries to 2 for better default for Browsertrix