### PR TITLE
Fix exit code and stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -608,7 +608,7 @@ export class Crawler {
       }
     } catch (e) {
       logger.error("Crawl failed", e);
-      exitCode = ExitCodes.Failed;
+      exitCode = ExitCodes.CrawlFailed;
       status = "failing";
       if (await this.crawlState.incFailCount()) {
         status = "failed";
@@ -1867,7 +1867,7 @@ self.__bx_behaviors.selectMainBehavior();
           "Unable to write WACZ successfully",
           {},
           "wacz",
-          ExitCodes.Fatal,
+          ExitCodes.UploadError,
         );
       }
     }

--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -147,7 +147,7 @@ function getDefaultWindowSize() {
 
 function handleTerminate(signame: string) {
   logger.info(`Got signal ${signame}, exiting`);
-  process.exit(ExitCodes.GenericError);
+  process.exit(ExitCodes.InterruptedGraceful);
 }
 
 async function main() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ async function handleTerminate(signame: string) {
   logger.info(`${signame} received...`);
   if (!crawler || !crawler.crawlState) {
     logger.error("error: no crawler running, exiting");
-    process.exit(ExitCodes.GenericError);
+    process.exit(ExitCodes.CrawlFailed);
   }
 
   if (crawler.done) {

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -18,6 +18,7 @@ import {
   BEHAVIOR_TYPES,
   ExtractSelector,
   DEFAULT_MAX_RETRIES,
+  ExitCodes,
 } from "./constants.js";
 import { ScopedSeed } from "./seeds.js";
 import { interpolateFilename } from "./storage.js";
@@ -704,6 +705,9 @@ class ArgParser {
     if (argv.collection.search(/^[\w][\w-]*$/) === -1) {
       logger.fatal(
         `\n${argv.collection} is an invalid collection name. Please supply a collection name only using alphanumeric characters and the following characters [_ - ]\n`,
+        {},
+        "general",
+        ExitCodes.FailCrawl,
       );
     }
 
@@ -737,7 +741,12 @@ class ArgParser {
         argv.mobileDevice.replace("-", " ")
       ];
       if (!argv.emulateDevice) {
-        logger.fatal("Unknown device: " + argv.mobileDevice);
+        logger.fatal(
+          "Unknown device: " + argv.mobileDevice,
+          {},
+          "general",
+          ExitCodes.FailCrawl,
+        );
       }
     } else {
       argv.emulateDevice = { viewport: null };
@@ -773,7 +782,12 @@ class ArgParser {
         try {
           parser(selector);
         } catch (e) {
-          logger.fatal("Invalid Link Extraction CSS Selector", { selector });
+          logger.fatal(
+            "Invalid Link Extraction CSS Selector",
+            { selector },
+            "general",
+            ExitCodes.FailCrawl,
+          );
         }
         return { selector, extract, isAttribute };
       });
@@ -828,10 +842,20 @@ class ArgParser {
       }
 
       if (!scopedSeeds.length) {
-        logger.fatal("No valid seeds specified, aborting crawl");
+        logger.fatal(
+          "No valid seeds specified, aborting crawl",
+          {},
+          "general",
+          ExitCodes.FailCrawl,
+        );
       }
     } else if (!argv.qaSource) {
-      logger.fatal("--qaSource required for QA mode");
+      logger.fatal(
+        "--qaSource required for QA mode",
+        {},
+        "general",
+        ExitCodes.FailCrawl,
+      );
     }
 
     argv.scopedSeeds = scopedSeeds;

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -835,7 +835,7 @@ class ArgParser {
               "Invalid seed specified, aborting crawl",
               { url: newSeed.url },
               "general",
-              1,
+              ExitCodes.FailCrawl,
             );
           }
         }

--- a/src/util/blockrules.ts
+++ b/src/util/blockrules.ts
@@ -6,6 +6,7 @@ import { Browser } from "./browser.js";
 
 import { fetch } from "undici";
 import { getProxyDispatcher } from "./proxy.js";
+import { ExitCodes } from "./constants.js";
 
 const RULE_TYPES = ["block", "allowOnly"];
 
@@ -47,7 +48,12 @@ class BlockRule {
     }
 
     if (!RULE_TYPES.includes(this.type)) {
-      logger.fatal('Rule "type" must be: ' + RULE_TYPES.join(", "));
+      logger.fatal(
+        'Rule "type" must be: ' + RULE_TYPES.join(", "),
+        {},
+        "blocking",
+        ExitCodes.FailCrawl,
+      );
     }
   }
 

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -9,7 +9,7 @@ import path from "path";
 import { formatErr, LogContext, logger } from "./logger.js";
 import { initStorage } from "./storage.js";
 
-import { DISPLAY, type ServiceWorkerOpt } from "./constants.js";
+import { DISPLAY, ExitCodes, type ServiceWorkerOpt } from "./constants.js";
 
 import puppeteer, {
   Frame,
@@ -192,6 +192,9 @@ export class Browser {
       if (!storage) {
         logger.fatal(
           "Profile specified relative to s3 storage, but no S3 storage defined",
+          {},
+          "general",
+          ExitCodes.FailCrawl,
         );
         return false;
       }
@@ -384,6 +387,7 @@ export class Browser {
         "Custom behavior load error, aborting",
         { filename, ...exceptionDetails },
         "behavior",
+        ExitCodes.FailCrawl,
       );
     }
   }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -59,13 +59,15 @@ export const DISPLAY = ":99";
 
 export enum ExitCodes {
   Success = 0,
-  GenericError = 1,
-  Failed = 9,
+  //GenericError = 1,
   OutOfSpace = 3,
+  CrawlFailed = 9,
   BrowserCrashed = 10,
   InterruptedGraceful = 11,
   InterruptedImmediate = 13,
-  Fatal = 17,
+  FatalError = 17,
+  RedisGone = 18,
+  UploadError = 19,
   ProxyError = 21,
 
   // used to indicate crawl should be failed, not just restarted

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -67,4 +67,7 @@ export enum ExitCodes {
   InterruptedImmediate = 13,
   Fatal = 17,
   ProxyError = 21,
+
+  // used to indicate crawl should be failed, not just restarted
+  FailCrawl = 1001,
 }

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -76,7 +76,7 @@ class Logger {
   crawlState?: RedisCrawlState | null = null;
   fatalExitCode: ExitCodes = ExitCodes.Fatal;
 
-  setDefaultFatalExitCode(exitCode: number) {
+  setDefaultFatalExitCode(exitCode: ExitCodes) {
     this.fatalExitCode = exitCode;
   }
 
@@ -184,9 +184,11 @@ class Logger {
     message: string,
     data = {},
     context: LogContext = "general",
-    exitCode = ExitCodes.Success,
+    exitCode?: ExitCodes | undefined,
   ) {
-    exitCode = exitCode || this.fatalExitCode;
+    if (!exitCode) {
+      exitCode = this.fatalExitCode;
+    }
     this.logAsJSON(`${message}. Quitting`, data, context, "fatal");
 
     if (this.crawlState) {

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -74,7 +74,7 @@ class Logger {
   contexts: LogContext[] = [];
   excludeContexts: LogContext[] = [];
   crawlState?: RedisCrawlState | null = null;
-  fatalExitCode: ExitCodes = ExitCodes.Fatal;
+  fatalExitCode: ExitCodes = ExitCodes.FatalError;
 
   setDefaultFatalExitCode(exitCode: ExitCodes) {
     this.fatalExitCode = exitCode;
@@ -184,9 +184,9 @@ class Logger {
     message: string,
     data = {},
     context: LogContext = "general",
-    exitCode?: ExitCodes | undefined,
+    exitCode: ExitCodes,
   ) {
-    if (!exitCode) {
+    if (exitCode === ExitCodes.FailCrawl) {
       exitCode = this.fatalExitCode;
     }
     this.logAsJSON(`${message}. Quitting`, data, context, "fatal");

--- a/src/util/redis.ts
+++ b/src/util/redis.ts
@@ -1,5 +1,6 @@
 import { Redis } from "ioredis";
 import { logger } from "./logger.js";
+import { ExitCodes } from "./constants.js";
 
 const error = console.error;
 
@@ -18,7 +19,12 @@ console.error = function (...args) {
 
     if (now - lastLogTime > REDIS_ERROR_LOG_INTERVAL_SECS) {
       if (lastLogTime && exitOnError) {
-        logger.fatal("Crawl interrupted, redis gone, exiting", {}, "redis");
+        logger.fatal(
+          "Crawl interrupted, redis gone, exiting",
+          {},
+          "redis",
+          ExitCodes.RedisGone,
+        );
       }
       logger.warn("ioredis error", { error: args[0] }, "redis");
       lastLogTime = now;

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -1,5 +1,5 @@
 import { logger } from "./logger.js";
-import { MAX_DEPTH } from "./constants.js";
+import { ExitCodes, MAX_DEPTH } from "./constants.js";
 
 type ScopeType =
   | "prefix"
@@ -219,6 +219,9 @@ export class ScopedSeed {
       default:
         logger.fatal(
           `Invalid scope type "${scopeType}" specified, valid types are: page, page-spa, prefix, host, domain, any`,
+          {},
+          "general",
+          ExitCodes.FailCrawl,
         );
     }
 

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { logger } from "./logger.js";
 
-import { MAX_DEPTH, DEFAULT_MAX_RETRIES } from "./constants.js";
+import { MAX_DEPTH, DEFAULT_MAX_RETRIES, ExitCodes } from "./constants.js";
 import { ScopedSeed } from "./seeds.js";
 import { Frame } from "puppeteer-core";
 import { interpolateFilename } from "./storage.js";
@@ -849,6 +849,12 @@ return inx;
     return await this.redis.llen(this.fkey);
   }
 
+  async numSeen() {
+    const seen = await this.redis.scard(this.skey);
+    const numExtraSeeds = await this.redis.llen(this.esKey);
+    return seen - numExtraSeeds;
+  }
+
   async getPendingList() {
     return await this.redis.hvals(this.pkey);
   }
@@ -932,6 +938,7 @@ return inx;
         "State load, original seed missing",
         { origSeedId },
         "state",
+        ExitCodes.FailCrawl,
       );
     }
     const redirectSeed: ExtraRedirectSeed = { origSeedId, newUrl };

--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -15,6 +15,7 @@ import { logger } from "./logger.js";
 import getFolderSize from "get-folder-size";
 
 import { WACZ } from "./wacz.js";
+import { ExitCodes } from "./constants.js";
 
 const DEFAULT_REGION = "us-east-1";
 
@@ -186,6 +187,7 @@ export class S3StorageSync {
             "redis webhook url must be in format: redis://<host>:<port>/<db>/<key>",
             {},
             "redis",
+            ExitCodes.FailCrawl,
           );
         }
         const redis = await initRedis(parts.slice(0, 4).join("/"));

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -7,6 +7,7 @@ import { rxEscape } from "./seeds.js";
 import { CDPSession, Page } from "puppeteer-core";
 import { PageState, WorkerId } from "./state.js";
 import { Crawler } from "../crawler.js";
+import { ExitCodes } from "./constants.js";
 
 const MAX_REUSE = 5;
 
@@ -235,6 +236,7 @@ export class PageWorker {
             "Unable to get new page, browser likely crashed",
             this.logDetails,
             "worker",
+            ExitCodes.BrowserCrashed,
           );
         }
 

--- a/tests/custom_driver.test.js
+++ b/tests/custom_driver.test.js
@@ -11,5 +11,5 @@ test("ensure custom driver creates PDF", async () => {
   }
 
   const pdfs = fs.readdirSync("test-crawls/collections/custom-driver-1").filter(x => x.endsWith(".pdf"));
-  expect(pdfs.length).toBe(1);
+  expect(pdfs.length).toBe(17);
 });

--- a/tests/http-auth.test.js
+++ b/tests/http-auth.test.js
@@ -23,7 +23,7 @@ test("run crawl without auth", () => {
   } catch (e) {
     status = e.status;
   }
-  expect(status).toBe(1);
+  expect(status).toBe(17);
 });
 
 test("run crawl with auth", () => {

--- a/tests/proxy.test.js
+++ b/tests/proxy.test.js
@@ -75,7 +75,7 @@ describe("socks5 + https proxy tests", () => {
         } catch (e) {
           status = e.status;
         }
-        expect(status).toBe(1);
+        expect(status).toBe(21);
       });
 
       test(`${scheme} proxy, ${type}, wrong protocol`, () => {
@@ -86,7 +86,7 @@ describe("socks5 + https proxy tests", () => {
         } catch (e) {
           status = e.status;
         }
-        expect(status).toBe(1);
+        expect(status).toBe(21);
       });
     }
 
@@ -98,7 +98,7 @@ describe("socks5 + https proxy tests", () => {
       } catch (e) {
         status = e.status;
       }
-      expect(status).toBe(1);
+      expect(status).toBe(21);
     });
   }
 });
@@ -116,7 +116,7 @@ test("http proxy set, but not running, separate env vars", () => {
   } catch (e) {
     status = e.status;
   }
-  expect(status).toBe(1);
+  expect(status).toBe(21);
 });
 
 test("http proxy set, but not running, cli arg", () => {
@@ -127,7 +127,7 @@ test("http proxy set, but not running, cli arg", () => {
   } catch (e) {
     status = e.status;
   }
-  expect(status).toBe(1);
+  expect(status).toBe(21);
 });
 
 

--- a/tests/retry-failed.test.js
+++ b/tests/retry-failed.test.js
@@ -132,7 +132,7 @@ test("run crawl with retries for 503, not enough retries, fail", async () => {
 
   await crawlFinished;
 
-  expect(status).toBe(1);
+  expect(status).toBe(17);
   // (1 + 1) * 3 requests == 6 requests
   expect(requests).toBe(6);
   expect(success).toBe(false);
@@ -158,7 +158,7 @@ test("run crawl with retries for 503, no retries, fail", async () => {
 
   await crawlFinished;
 
-  expect(status).toBe(1);
+  expect(status).toBe(17);
   // (1) * 3 requests == 3 requests
   expect(requests).toBe(3);
   expect(success).toBe(false);


### PR DESCRIPTION
Follow up to #753, ensure that:
- Use new 'FailCrawl' exit code explicitly when crawl should fail due to fatal(), not just restart, taking into account
- FailCrawl status will resolve to actual status set via setDefaultFatalExitCode(), which may be 0 for restartOnError on FatalError
- Browser crashes do not result in a failed crawl!
- Add additional exit codes: UploadError, RedisMissing, remove GenericError
- stats log: include failed stat in 'total', also include 'totalSeen'