### PR TITLE
remove fatal() on new window error + stats fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1883,7 +1883,7 @@ self.__bx_behaviors.selectMainBehavior();
     const pending = pendingPages.length;
     const crawled = await this.crawlState.numDone();
     const failed = await this.crawlState.numFailed();
-    const total = realSize + pendingPages.length + crawled;
+    const total = realSize + pendingPages.length + crawled + failed;
     const limit = { max: this.pageLimit || 0, hit: this.limitHit };
     const stats = {
       crawled,

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -7,7 +7,6 @@ import { rxEscape } from "./seeds.js";
 import { CDPSession, Page } from "puppeteer-core";
 import { PageState, WorkerId } from "./state.js";
 import { Crawler } from "../crawler.js";
-import { ExitCodes } from "./constants.js";
 
 const MAX_REUSE = 5;
 
@@ -232,12 +231,9 @@ export class PageWorker {
         }
 
         if (retry >= MAX_REUSE) {
-          logger.fatal(
-            "Unable to get new page, browser likely crashed",
-            this.logDetails,
-            "worker",
-            ExitCodes.BrowserCrashed,
-          );
+          this.crawler.browserCrashed = true;
+          this.crawler.interrupted = true;
+          throw new Error("Unable to load new page, browser needs restart");
         }
 
         await sleep(0.5);

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -157,6 +157,7 @@ export class PageWorker {
           "New Window Timed Out",
           { workerid },
           "worker",
+          true
         );
 
         if (!result) {

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -157,7 +157,7 @@ export class PageWorker {
           "New Window Timed Out",
           { workerid },
           "worker",
-          true
+          true,
         );
 
         if (!result) {

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -7,6 +7,7 @@ import { rxEscape } from "./seeds.js";
 import { CDPSession, Page } from "puppeteer-core";
 import { PageState, WorkerId } from "./state.js";
 import { Crawler } from "../crawler.js";
+import { ExitCodes } from "./constants.js";
 
 const MAX_REUSE = 5;
 
@@ -235,6 +236,7 @@ export class PageWorker {
             "Unable to get new page, browser likely crashed",
             this.logDetails,
             "worker",
+            ExitCodes.BrowserCrashed,
           );
         }
 


### PR DESCRIPTION
logging (#752): ensure failed included in totals
fatal rework: remove fatal() when failing to open new window, throw instead to ensure crawl is properly interrupted.
bump to 1.5.2
