### PR TITLE
Make sure all exit calls use ExitCodes enum

### DIFF
--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -147,7 +147,7 @@ function getDefaultWindowSize() {
 
 function handleTerminate(signame: string) {
   logger.info(`Got signal ${signame}, exiting`);
-  process.exit(ExitCodes.GenericError);
+  process.exit(ExitCodes.SignalInterrupted);
 }
 
 async function main() {

--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -299,7 +299,7 @@ async function automatedProfile(
     }
     logger.debug("Login form could not be found");
     await page.close();
-    process.exit(1);
+    process.exit(ExitCodes.GenericError);
     return;
   }
 
@@ -318,7 +318,7 @@ async function automatedProfile(
 
   await createProfile(params, browser, page, cdp);
 
-  process.exit(0);
+  process.exit(ExitCodes.Success);
 }
 
 async function createProfile(


### PR DESCRIPTION
Quick follow-up to #584 to make sure enum is used everywhere.

I debated modifying `create-login-profile.ts`'s handleTerminate method to return `ExitCodes.SignalInterrupted` or `ExitCodes.SignalInterruptedForce` depending on the signal received, but I'm not sure that's actually helpful in the case of profiles and the behavior doesn't match exactly what's documented for the crawler, so left that as-is as a `ExitCodes.GenericError`.