### PR TITLE
instead of puppeteer.exposeFunction(), use cdp function bindings directly to avoid issues custom toJSON overrides:

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@novnc/novnc": "1.4.0",
     "@webrecorder/wabac": "^2.20.8",
-    "browsertrix-behaviors": "^0.7.0",
+    "browsertrix-behaviors": "^0.7.1",
     "client-zip": "^2.4.5",
     "css-selector-parser": "^3.0.5",
     "fetch-socks": "^1.3.0",

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -10,7 +10,6 @@ import { hideBin } from "yargs/helpers";
 import { createParser } from "css-selector-parser";
 
 import {
-  BEHAVIOR_LOG_FUNC,
   WAIT_UNTIL_OPTS,
   EXTRACT_TEXT_TYPES,
   SERVICE_WORKER_OPTS,
@@ -18,6 +17,7 @@ import {
   BEHAVIOR_TYPES,
   ExtractSelector,
   DEFAULT_MAX_RETRIES,
+  BxFunctionBindings,
 } from "./constants.js";
 import { ScopedSeed } from "./seeds.js";
 import { interpolateFilename } from "./storage.js";
@@ -721,7 +721,7 @@ class ArgParser {
           );
         }
       });
-      behaviorOpts.log = BEHAVIOR_LOG_FUNC;
+      behaviorOpts.log = BxFunctionBindings.BehaviorLogFunc;
       behaviorOpts.startEarly = true;
       behaviorOpts.clickSelector = argv.clickSelector;
       argv.behaviorOpts = JSON.stringify(behaviorOpts);

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -22,9 +22,12 @@ export const DETECT_SITEMAP = "<detect>";
 
 export const EXTRACT_TEXT_TYPES = ["to-pages", "to-warc", "final-to-warc"];
 
-export const BEHAVIOR_LOG_FUNC = "__bx_log";
-export const ADD_LINK_FUNC = "__bx_addLink";
-export const FETCH_FUNC = "__bx_fetch";
+export enum BxFunctionBindings {
+  BehaviorLogFunc = "__bx_log",
+  AddLinkFunc = "__bx_addLink",
+  FetchFunc = "__bx_fetch",
+  AddToSeenSet = "__bx_addSet",
+}
 
 export const MAX_DEPTH = 1000000;
 export const DEFAULT_MAX_RETRIES = 2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,10 +1460,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.1"
 
-browsertrix-behaviors@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.7.0.tgz#a08b7d3e9cd449d0d76b14a438e28472124fd1a4"
-  integrity sha512-t0X74puXJsH8sVkkVZwEdo8L5E1PYtzX/RkVXM4fwwBIL804bOB8WIV+5Dfwov/odaukhB67KZhM00hN60SiBA==
+browsertrix-behaviors@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.7.1.tgz#dcb30c038e4060ef2393eb001ce9f10e3ce71c39"
+  integrity sha512-tZ7Bv/IAWzLTNORf/yQqGHpPAQ4tP8sxql8YT491VHlCk939F1YIUrQ36XJOaSyfjmmm2WV9nCMXkDpCsw6zQg==
   dependencies:
     query-selector-shadow-dom "^1.0.1"
 


### PR DESCRIPTION
- add Runtime.addBinding for each exposed function, handle in one place with Runtime.bindingCalled
- convert binding names to BxFunctionBindings enum
- update to browsertrix-behaviors 0.7.1 to avoid waiting for return value
- fixes #770