### PR TITLE
Strip credentials from proxy address in crawl logs

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -7,6 +7,7 @@ import os from "os";
 import path from "path";
 
 import { formatErr, LogContext, logger } from "./logger.js";
+import { getSafeProxyString } from "./proxy.js";
 import { initStorage } from "./storage.js";
 
 import {
@@ -250,7 +251,8 @@ export class Browser {
     ];
 
     if (proxy) {
-      logger.info("Using proxy", { proxy }, "browser");
+      const proxyString = getSafeProxyString(proxy);
+      logger.info("Using proxy", { proxy: proxyString }, "browser");
     }
 
     if (proxy) {

--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -28,6 +28,31 @@ export function getEnvProxyUrl() {
   return "";
 }
 
+export function getSafeProxyString(proxyString: string): string {
+  if (!proxyString) {
+    return "";
+  }
+
+  try {
+    const proxySplit = proxyString.split("://");
+    const prefix = proxySplit[0];
+    const remainder = proxySplit[1];
+
+    const credSplit = remainder.split("@");
+
+    let addressIndex = 1;
+    if (credSplit.length === 1) {
+      addressIndex = 0;
+    }
+
+    const addressNoCredentials = credSplit[addressIndex];
+
+    return `${prefix}://${addressNoCredentials}`;
+  } catch (e) {
+    return "";
+  }
+}
+
 export async function initProxy(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params: Record<string, any>,

--- a/tests/proxy.test.js
+++ b/tests/proxy.test.js
@@ -1,5 +1,7 @@
 import { execSync, exec } from "child_process";
 
+import { getSafeProxyString } from "../dist/util/proxy.js";
+
 const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
 
 const PROXY_IMAGE = "tarampampam/3proxy:1.9.1";
@@ -147,6 +149,18 @@ test("ssh socks proxy, wrong user", () => {
   expect(status).toBe(21);
 });
 
+
+test("ensure logged proxy string does not include any credentials", () => {
+  const testParams = [
+    // [input, expectedOutput]
+    ["socks5://username:password@proxy-host.example.com:9001", "socks5://proxy-host.example.com:9001"],
+    ["socks5://path-to-proxy-host.example.com:9001", "socks5://path-to-proxy-host.example.com:9001"],
+    ["ssh://localhost:9700", "ssh://localhost:9700"]
+  ];
+  for (const testParamSet of testParams) {
+    expect(getSafeProxyString(testParamSet[0])).toEqual(testParamSet[1]);
+  }
+});
 
 
 

--- a/tests/proxy.test.js
+++ b/tests/proxy.test.js
@@ -154,6 +154,7 @@ test("ensure logged proxy string does not include any credentials", () => {
   const testParams = [
     // [input, expectedOutput]
     ["socks5://username:password@proxy-host.example.com:9001", "socks5://proxy-host.example.com:9001"],
+    ["socks5://username@proxy-host.example.com:9001", "socks5://proxy-host.example.com:9001"],
     ["socks5://path-to-proxy-host.example.com:9001", "socks5://path-to-proxy-host.example.com:9001"],
     ["ssh://localhost:9700", "ssh://localhost:9700"]
   ];


### PR DESCRIPTION
Fixes https://github.com/webrecorder/security/issues/14

Adds routine to strip username and password from proxy string, and tests that cover our supported proxyServer input formats.