### PR TITLE
further fix to stuck on getting new window:

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -394,6 +394,18 @@ export class Browser {
     }
   }
 
+  killBrowser() {
+    // used when main browser process appears to be stalled
+    // puppeteer should still be able to continue, from initial testing
+    // and avoids interrupting crawler when not auto-restarting
+    if (this.browser) {
+      const proc = this.browser.process();
+      if (proc) {
+        proc.kill();
+      }
+    }
+  }
+
   async addInitScript(page: Page, script: string) {
     await page.evaluateOnNewDocument(script);
   }

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -231,7 +231,7 @@ export class PageWorker {
           break;
         }
 
-        if (retry >= 3) {
+        if (retry >= 2) {
           this.crawler.markBrowserCrashed();
           if (this.crawler.params.restartsOnError) {
             throw new Error("Unable to load new page, browser needs restart");

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -231,9 +231,13 @@ export class PageWorker {
           break;
         }
 
-        if (retry >= 1000000000) {
+        if (retry >= 3) {
           this.crawler.markBrowserCrashed();
-          throw new Error("Unable to load new page, browser needs restart");
+          if (this.crawler.params.restartsOnError) {
+            throw new Error("Unable to load new page, browser needs restart");
+          } else {
+            this.crawler.browser.killBrowser();
+          }
         }
 
         await sleep(0.5);


### PR DESCRIPTION
- set retries back to 3, was set high by mistake
- if will restart, throw exception to restart crawler
- otherwise, attempt to kill browser process that is stalled (appears to work in testing)
- follow-up to #766