### PR TITLE
follow-up to #781:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.5.6",
+  "version": "1.5.6.1",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -10,7 +10,7 @@ import { Crawler } from "../crawler.js";
 
 const MAX_REUSE = 5;
 
-const NEW_WINDOW_TIMEOUT = 20000;
+const NEW_WINDOW_TIMEOUT = 20;
 const TEARDOWN_TIMEOUT = 10;
 const FINISHED_TIMEOUT = 60;
 


### PR DESCRIPTION
- undo accidentally setting window timeout to 20000 seconds instead of 20 for debugging!
- follow up to #781
- bump to 1.5.6.1
- should hopefully fix crawls stuck in this way..