### PR TITLE
Fix using cached WACZ filename if already set ahead of time.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1730,9 +1730,13 @@ self.__bx_behaviors.selectMainBehavior();
       await this.combineWARC();
     }
 
+    const generateFiles =
+      !this.params.dryRun &&
+      (!this.interruptReason || this.finalExit || this.uploadAndDeleteLocal);
+
     if (
       (this.params.generateCDX || this.params.generateWACZ) &&
-      !this.params.dryRun
+      generateFiles
     ) {
       logger.info("Merging CDX");
       await this.crawlState.setStatus(
@@ -1746,11 +1750,7 @@ self.__bx_behaviors.selectMainBehavior();
       );
     }
 
-    if (
-      this.params.generateWACZ &&
-      !this.params.dryRun &&
-      (!this.interruptReason || this.finalExit || this.uploadAndDeleteLocal)
-    ) {
+    if (this.params.generateWACZ && generateFiles) {
       const uploaded = await this.generateWACZ();
 
       if (uploaded && this.uploadAndDeleteLocal) {


### PR DESCRIPTION
- if <uid>:nextWacz filename already exists, actually get it and use that!
- don't merge cdx if not generating wacz yet, use same condition for both bump version to 1.5.8
- fix follow-up to #748, fix #747