### PR TITLE
Fail crawl with fatal message if custom behavior isn't loaded

### DIFF
--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -153,6 +153,14 @@ async function collectLocalPathBehaviors(
     }
   }
 
+  if (!behaviors && depth === 0) {
+    logger.fatal(
+      "No custom behaviors found at specified path",
+      { path: resolvedPath },
+      "behavior",
+    );
+  }
+
   return behaviors;
 }
 

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -120,37 +120,48 @@ async function collectLocalPathBehaviors(
     return [];
   }
 
-  const stat = await fsp.stat(resolvedPath);
-
-  if (stat.isFile() && ALLOWED_EXTS.includes(path.extname(resolvedPath))) {
-    const contents = await fsp.readFile(resolvedPath);
-    return [
-      {
-        path: resolvedPath,
-        contents: `/* src: ${resolvedPath} */\n\n${contents}`,
-      },
-    ];
-  }
-
   const behaviors: FileSources = [];
 
-  const isDir = stat.isDirectory();
+  try {
+    const stat = await fsp.stat(resolvedPath);
 
-  if (!isDir && depth === 0) {
-    logger.warn(
-      "The provided path is not a .js file or directory",
-      { path: resolvedPath },
+    if (stat.isFile() && ALLOWED_EXTS.includes(path.extname(resolvedPath))) {
+      const contents = await fsp.readFile(resolvedPath);
+      return [
+        {
+          path: resolvedPath,
+          contents: `/* src: ${resolvedPath} */\n\n${contents}`,
+        },
+      ];
+    }
+
+    const isDir = stat.isDirectory();
+
+    if (!isDir && depth === 0) {
+      logger.warn(
+        "The provided path is not a .js file or directory",
+        { path: resolvedPath },
+        "behavior",
+      );
+    }
+
+    if (isDir) {
+      const files = await fsp.readdir(resolvedPath);
+      for (const file of files) {
+        const filePath = path.join(resolvedPath, file);
+        const newBehaviors = await collectLocalPathBehaviors(
+          filePath,
+          depth + 1,
+        );
+        behaviors.push(...newBehaviors);
+      }
+    }
+  } catch (e) {
+    logger.fatal(
+      "Error fetching local custom behaviors",
+      { path: resolvedPath, error: e },
       "behavior",
     );
-  }
-
-  if (isDir) {
-    const files = await fsp.readdir(resolvedPath);
-    for (const file of files) {
-      const filePath = path.join(resolvedPath, file);
-      const newBehaviors = await collectLocalPathBehaviors(filePath, depth + 1);
-      behaviors.push(...newBehaviors);
-    }
   }
 
   if (!behaviors && depth === 0) {

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -72,7 +72,7 @@ async function collectGitBehaviors(gitUrl: string): Promise<FileSources> {
     );
     return await collectLocalPathBehaviors(pathToCollect);
   } catch (e) {
-    logger.error(
+    logger.fatal(
       "Error downloading custom behaviors from Git repo",
       { url: urlStripped, error: e },
       "behavior",
@@ -96,7 +96,7 @@ async function collectOnlineBehavior(url: string): Promise<FileSources> {
     );
     return await collectLocalPathBehaviors(behaviorFilepath);
   } catch (e) {
-    logger.error(
+    logger.fatal(
       "Error downloading custom behavior from URL",
       { url, error: e },
       "behavior",

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -150,3 +150,18 @@ test("test crawl exits if behavior not fetched from git repo", async () => {
   // logger fatal exit code
   expect(status).toBe(17);
 });
+
+test("test crawl exits if not custom behaviors collected from local path", async () => {
+  let status = 0;
+
+  try {
+    child_process.execSync(
+      "docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/invalid-behaviors/:/custom-behaviors/ webrecorder/browsertrix-crawler crawl --url https://example.com/ --url https://example.org/ --url https://old.webrecorder.net/ --customBehaviors /custom-behaviors/doesntexist --scopeType page",
+    );
+  } catch (e) {
+    status = e.status;
+  }
+
+  // logger fatal exit code
+  expect(status).toBe(17);
+});

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -120,3 +120,33 @@ test("test invalid behavior exit", async () => {
   // logger fatal exit code
   expect(status).toBe(17);
 });
+
+test("test crawl exits if behavior not fetched from url", async () => {
+  let status = 0;
+
+  try {
+    child_process.execSync(
+      "docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/invalid-behaviors/:/custom-behaviors/ webrecorder/browsertrix-crawler crawl --url https://example.com/ --url https://example.org/ --url https://old.webrecorder.net/ --customBehaviors https://webrecorder.net/doesntexist/custombehavior.js --scopeType page",
+    );
+  } catch (e) {
+    status = e.status;
+  }
+
+  // logger fatal exit code
+  expect(status).toBe(17);
+});
+
+test("test crawl exits if behavior not fetched from git repo", async () => {
+  let status = 0;
+
+  try {
+    child_process.execSync(
+      "docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/invalid-behaviors/:/custom-behaviors/ webrecorder/browsertrix-crawler crawl --url https://example.com/ --url https://example.org/ --url https://old.webrecorder.net/ --customBehaviors git+https://github.com/webrecorder/doesntexist --scopeType page",
+    );
+  } catch (e) {
+    status = e.status;
+  }
+
+  // logger fatal exit code
+  expect(status).toBe(17);
+});

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -126,7 +126,7 @@ test("test crawl exits if behavior not fetched from url", async () => {
 
   try {
     child_process.execSync(
-      "docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/invalid-behaviors/:/custom-behaviors/ webrecorder/browsertrix-crawler crawl --url https://example.com/ --url https://example.org/ --url https://old.webrecorder.net/ --customBehaviors https://webrecorder.net/doesntexist/custombehavior.js --scopeType page",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://example.com --customBehaviors https://webrecorder.net/doesntexist/custombehavior.js --scopeType page",
     );
   } catch (e) {
     status = e.status;
@@ -141,7 +141,7 @@ test("test crawl exits if behavior not fetched from git repo", async () => {
 
   try {
     child_process.execSync(
-      "docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/invalid-behaviors/:/custom-behaviors/ webrecorder/browsertrix-crawler crawl --url https://example.com/ --url https://example.org/ --url https://old.webrecorder.net/ --customBehaviors git+https://github.com/webrecorder/doesntexist --scopeType page",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://example.com --customBehaviors git+https://github.com/webrecorder/doesntexist --scopeType page",
     );
   } catch (e) {
     status = e.status;
@@ -156,7 +156,7 @@ test("test crawl exits if not custom behaviors collected from local path", async
 
   try {
     child_process.execSync(
-      "docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/invalid-behaviors/:/custom-behaviors/ webrecorder/browsertrix-crawler crawl --url https://example.com/ --url https://example.org/ --url https://old.webrecorder.net/ --customBehaviors /custom-behaviors/doesntexist --scopeType page",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://example.com --customBehaviors /custom-behaviors/doesntexist --scopeType page",
     );
   } catch (e) {
     status = e.status;


### PR DESCRIPTION
Fixes #797 

The crawler will now exit with a fatal log message and exit code 17 if:

- A Git repository specified with `--customBehavior` cannot be cloned successfully (new)
- A custom behavior file at a URL specified with `--customBehavior` is not fetched successfully (new)
- No custom behaviors are collected at a local filepath specified with `--customBehavior`, or if an error is thrown while attempting to collect files from a nonexistent path (new)
- Any custom behaviors collected fail `Browser.checkScript` validation (existing behavior)

Tests have also been added accordingly.