### PR TITLE
Validate Autoclick selector, fail crawl if invalid

### DIFF
--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -700,6 +700,9 @@ class ArgParser {
     argv.crawlId = argv.crawlId || process.env.CRAWL_ID || os.hostname();
     argv.collection = interpolateFilename(argv.collection, argv.crawlId);
 
+    // css selector parser
+    const parser = createParser();
+
     // Check that the collection name is valid.
     if (argv.collection.search(/^[\w][\w-]*$/) === -1) {
       logger.fatal(
@@ -710,6 +713,16 @@ class ArgParser {
     // background behaviors to apply
     const behaviorOpts: { [key: string]: string | boolean } = {};
     if (argv.behaviors.length > 0) {
+      if (argv.clickSelector) {
+        try {
+          parser(argv.clickSelector);
+        } catch (e) {
+          logger.fatal("Invalid Autoclick CSS Selector", {
+            selector: argv.clickSelector,
+          });
+        }
+      }
+
       argv.behaviors.forEach((x: string) => {
         if (BEHAVIOR_TYPES.includes(x)) {
           behaviorOpts[x] = true;
@@ -760,8 +773,6 @@ class ArgParser {
     }
 
     let selectLinks: ExtractSelector[];
-
-    const parser = createParser();
 
     if (argv.selectLinks) {
       selectLinks = argv.selectLinks.map((x: string) => {

--- a/tests/custom_selector.test.js
+++ b/tests/custom_selector.test.js
@@ -58,11 +58,27 @@ test("test invalid selector, crawl fails", async () => {
     child_process.execSync(
       "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --collection custom-sel-invalid --selectLinks \"script[\"",
     );
-  } catch (error) {
-    failed = true;
+  } catch (e) {
+    status = e.status;
   }
 
-  expect(failed).toBe(true);
+  // logger fatal exit code
+  expect(status).toBe(17);
 });
 
+
+test("test invalid autoclick selector, crawl fails", async () => {
+  let status = 0;
+
+  try {
+    child_process.execSync(
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://example.com/ --clickSelector \",\" --scopeType page",
+    );
+  } catch (e) {
+    status = e.status;
+  }
+
+  // logger fatal exit code
+  expect(status).toBe(17);
+});
  

--- a/tests/custom_selector.test.js
+++ b/tests/custom_selector.test.js
@@ -77,7 +77,7 @@ test("test valid autoclick selector passes validation", async () => {
     failed = true;
   }
 
-  // logger fatal exit code
+  // valid clickSelector
   expect(failed).toBe(false);
 });
 

--- a/tests/custom_selector.test.js
+++ b/tests/custom_selector.test.js
@@ -53,7 +53,7 @@ test("test custom selector crawls JS files as pages", async () => {
 
 
 test("test invalid selector, crawl fails", async () => {
-  let failed = false;
+  let status = 0;
   try {
     child_process.execSync(
       "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.iana.org/ --collection custom-sel-invalid --selectLinks \"script[\"",
@@ -66,8 +66,23 @@ test("test invalid selector, crawl fails", async () => {
   expect(status).toBe(17);
 });
 
+test("test valid autoclick selector passes validation", async () => {
+  let failed = false;
 
-test("test invalid autoclick selector, crawl fails", async () => {
+  try {
+    child_process.execSync(
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://example.com/ --clickSelector button --scopeType page",
+    );
+  } catch (e) {
+    failed = true;
+  }
+
+  // logger fatal exit code
+  expect(failed).toBe(false);
+});
+
+
+test("test invalid autoclick selector fails validation, crawl fails", async () => {
   let status = 0;
 
   try {


### PR DESCRIPTION
Fixes #798 

Also modifies the existing test for link selector validation to check 17 status code on exit when link selectors fail validation.