### PR TITLE
Add option to push behavior + behavior script logs to Redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@novnc/novnc": "1.4.0",
     "@webrecorder/wabac": "^2.22.9",
-    "browsertrix-behaviors": "^0.8.2",
+    "browsertrix-behaviors": "^0.8.3",
     "client-zip": "^2.4.5",
     "css-selector-parser": "^3.0.5",
     "fetch-socks": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@novnc/novnc": "1.4.0",
     "@webrecorder/wabac": "^2.22.9",
-    "browsertrix-behaviors": "^0.8.1",
+    "browsertrix-behaviors": "^0.8.2",
     "client-zip": "^2.4.5",
     "css-selector-parser": "^3.0.5",
     "fetch-socks": "^1.3.0",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -407,7 +407,7 @@ export class Crawler {
       logger.setLogBehaviorsToRedis(true);
     }
 
-    if (this.param.logErrorsToRedis || this.params.logBehaviorsToRedis) {
+    if (this.params.logErrorsToRedis || this.params.logBehaviorsToRedis) {
       logger.setCrawlState(this.crawlState);
     }
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1502,7 +1502,6 @@ self.__bx_behaviors.selectMainBehavior();
   async setStatusAndExit(exitCode: ExitCodes, status: string) {
     logger.info(`Exiting, Crawl status: ${status}`);
 
-
     await this.closeLog();
 
     if (this.crawlState && status) {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1477,6 +1477,10 @@ self.__bx_behaviors.selectMainBehavior();
   async setStatusAndExit(exitCode: ExitCodes, status: string) {
     logger.info(`Exiting, Crawl status: ${status}`);
 
+    // TODO: Remove before merging, just for testing
+    const behaviorsLoggedToRedis = await this.crawlState.getBehaviorList();
+    logger.info("Behavior lines logged to Redis", { behaviorsLoggedToRedis });
+
     await this.closeLog();
 
     if (this.crawlState && status) {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1502,9 +1502,6 @@ self.__bx_behaviors.selectMainBehavior();
   async setStatusAndExit(exitCode: ExitCodes, status: string) {
     logger.info(`Exiting, Crawl status: ${status}`);
 
-    // TODO: Remove before merging, just for testing
-    const behaviorsLoggedToRedis = await this.crawlState.getBehaviorList();
-    logger.info("Behavior lines logged to Redis", { behaviorsLoggedToRedis });
 
     await this.closeLog();
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -656,7 +656,16 @@ export class Crawler {
       message = data;
       details = logDetails;
     } else {
-      message = type === "info" ? "Behavior log" : "Behavior debug";
+      switch (type) {
+        case "error":
+          message = "Behavior error";
+          break;
+        case "debug":
+          message = "Behavior debug";
+          break;
+        default:
+          message = "Behavior log";
+      }
       details =
         typeof data === "object"
           ? { ...(data as object), ...logDetails }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -401,6 +401,13 @@ export class Crawler {
 
     if (this.params.logErrorsToRedis) {
       logger.setLogErrorsToRedis(true);
+    }
+
+    if (this.params.logBehaviorsToRedis) {
+      logger.setLogBehaviorsToRedis(true);
+    }
+
+    if (this.param.logErrorsToRedis || this.params.logBehaviorsToRedis) {
       logger.setCrawlState(this.crawlState);
     }
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -678,6 +678,7 @@ export class Crawler {
         const objData = data as any;
         if (objData.siteSpecific) {
           context = "behaviorScriptCustom";
+          delete objData.siteSpecific;
         }
         message = objData.msg || message;
         delete objData.msg;

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -542,6 +542,12 @@ class ArgParser {
           default: false,
         },
 
+        logBehaviorsToRedis: {
+          describe: "If set, write behavior script messages to redis",
+          type: "boolean",
+          default: false,
+        },
+
         writePagesToRedis: {
           describe: "If set, write page objects to redis",
           type: "boolean",

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -70,6 +70,7 @@ class Logger {
   logStream: Writable | null = null;
   debugLogging = false;
   logErrorsToRedis = false;
+  logBehaviorsToRedis = false;
   logLevels: string[] = [];
   contexts: LogContext[] = [];
   excludeContexts: LogContext[] = [];
@@ -90,6 +91,10 @@ class Logger {
 
   setLogErrorsToRedis(logErrorsToRedis: boolean) {
     this.logErrorsToRedis = logErrorsToRedis;
+  }
+
+  setLogBehaviorsToRedis(logBehaviorsToRedis: boolean) {
+    this.logBehaviorsToRedis = logBehaviorsToRedis;
   }
 
   setLogLevel(logLevels: string[]) {
@@ -152,13 +157,23 @@ class Logger {
       //
     }
 
-    const toLogToRedis = ["error", "fatal"];
+    const redisErrorLogLevels = ["error", "fatal"];
     if (
       this.logErrorsToRedis &&
       this.crawlState &&
-      toLogToRedis.includes(logLevel)
+      redisErrorLogLevels.includes(logLevel)
     ) {
       this.crawlState.logError(string).catch(() => {});
+    }
+
+    const redisBehaviorLogLevels = ["info", "error"];
+    if (
+      this.logBehaviorsToRedis &&
+      this.crawlState &&
+      context == "behaviorScript" &&
+      redisBehaviorLogLevels.includes(logLevel)
+    ) {
+      this.crawlState.logBehavior(string).catch(() => {});
     }
   }
 

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -168,7 +168,11 @@ class Logger {
     }
 
     const redisBehaviorLogLevels = ["info", "warn", "error"];
-    const behaviorContexts = ["behavior", "behaviorScript"];
+    const behaviorContexts = [
+      "behavior",
+      "behaviorScript",
+      "behaviorScriptCustom",
+    ];
     if (
       this.logBehaviorsToRedis &&
       this.crawlState &&

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -166,11 +166,12 @@ class Logger {
       this.crawlState.logError(string).catch(() => {});
     }
 
-    const redisBehaviorLogLevels = ["info", "error"];
+    const redisBehaviorLogLevels = ["info", "warn", "error"];
+    const behaviorContexts = ["behavior", "behaviorScript"];
     if (
       this.logBehaviorsToRedis &&
       this.crawlState &&
-      context == "behaviorScript" &&
+      behaviorContexts.includes(context) &&
       redisBehaviorLogLevels.includes(logLevel)
     ) {
       this.crawlState.logBehavior(string).catch(() => {});

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -45,6 +45,7 @@ export const LOG_CONTEXT_TYPES = [
   "blocking",
   "behavior",
   "behaviorScript",
+  "behaviorScriptCustom",
   "jsError",
   "fetch",
   "pageStatus",

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -168,16 +168,14 @@ class Logger {
     }
 
     const redisBehaviorLogLevels = ["info", "warn", "error"];
-    const behaviorContexts = [
-      "behavior",
-      "behaviorScript",
-      "behaviorScriptCustom",
-    ];
+    const behaviorContexts = ["behavior", "behaviorScript"];
     if (
       this.logBehaviorsToRedis &&
       this.crawlState &&
-      behaviorContexts.includes(context) &&
-      redisBehaviorLogLevels.includes(logLevel)
+      ((behaviorContexts.includes(context) &&
+        redisBehaviorLogLevels.includes(logLevel)) ||
+        //always include behaviorScriptCustom
+        context === "behaviorScriptCustom")
     ) {
       this.crawlState.logBehavior(string).catch(() => {});
     }

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -181,6 +181,7 @@ export class RedisCrawlState {
   dkey: string;
   fkey: string;
   ekey: string;
+  bkey: string;
   pageskey: string;
   esKey: string;
   esMap: string;
@@ -212,6 +213,8 @@ export class RedisCrawlState {
     this.fkey = this.key + ":f";
     // crawler errors
     this.ekey = this.key + ":e";
+    // crawler behavior script messages
+    this.bkey = this.key + ":b";
     // pages
     this.pageskey = this.key + ":pages";
 
@@ -929,6 +932,10 @@ return inx;
 
   async logError(error: string) {
     return await this.redis.lpush(this.ekey, error);
+  }
+
+  async logBehavior(behaviorLog: string) {
+    return await this.redis.lpush(this.bkey, behaviorLog);
   }
 
   async writeToPagesQueue(

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -878,6 +878,11 @@ return inx;
     return await this.redis.lrange(this.ekey, 0, -1);
   }
 
+  // TODO: Remove before merging, just for testing
+  async getBehaviorList() {
+    return await this.redis.lrange(this.bkey, 0, -1);
+  }
+
   async clearOwnPendingLocks() {
     try {
       const pendingUrls = await this.redis.hkeys(this.pkey);

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -878,11 +878,6 @@ return inx;
     return await this.redis.lrange(this.ekey, 0, -1);
   }
 
-  // TODO: Remove before merging, just for testing
-  async getBehaviorList() {
-    return await this.redis.lrange(this.bkey, 0, -1);
-  }
-
   async clearOwnPendingLocks() {
     try {
       const pendingUrls = await this.redis.hkeys(this.pkey);

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -199,7 +199,6 @@ test("test pushing behavior logs to redis", async () => {
       expect(["https://specs.webrecorder.net/", "https://old.webrecorder.net/"]).toContain(json.details.page);
       customLogLineCount++;
     }
-    break;
   }
 
   expect(customLogLineCount).toEqual(2);

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -10,21 +10,21 @@ test("test custom behaviors from local filepath", async () => {
   // custom behavior ran for specs.webrecorder.net
   expect(
     log.indexOf(
-      '"message":"test-stat,{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // but not for example.org
   expect(
     log.indexOf(
-      '"message":"test-stat",{"state":{},"page":"https://example.org/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://example.org","workerid":0}}',
     ) > 0,
   ).toBe(false);
 
   // another custom behavior ran for old.webrecorder.net
   expect(
     log.indexOf(
-      '"message":"test-stat-2",{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -38,7 +38,7 @@ test("test custom behavior from URL", async () => {
 
   expect(
     log.indexOf(
-      '"message":"test-stat-2",{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -53,14 +53,14 @@ test("test mixed custom behavior sources", async () => {
 
   expect(
     log.indexOf(
-      '"message":"test-stat",{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // test custom behavior from local file ran
   expect(
     log.indexOf(
-      '"message":"test-stat",{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -75,21 +75,21 @@ test("test custom behaviors from git repo", async () => {
   // custom behavior ran for specs.webrecorder.net
   expect(
     log.indexOf(
-      '"message":"test-stat",{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // but not for example.org
   expect(
     log.indexOf(
-      '"message":"test-stat",{"state":{},"page":"https://example.org/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://example.org/","workerid":0}}',
     ) > 0,
   ).toBe(false);
 
   // another custom behavior ran for old.webrecorder.net
   expect(
     log.indexOf(
-      '"message":"test-stat-2",{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -162,7 +162,7 @@ test("test crawl exits if not custom behaviors collected from local path", async
 });
 
 test("test pushing behavior logs to redis", async () => {
-  const child = child_process.exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/custom-behaviors/:/custom-behaviors/ -e CRAWL_ID=behavior-logs-redis-test -p 36399:6379 --rm webrecorder/browsertrix-crawler crawl --url https://specs.webrecorder.net/ --url https://old.webrecorder.net/ --customBehaviors https://raw.githubusercontent.com/webrecorder/browsertrix-crawler/refs/heads/main/tests/custom-behaviors/custom-2.js --customBehaviors /custom-behaviors/custom.js --scopeType page --logBehaviorsToRedis");
+  const child = child_process.exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/custom-behaviors/:/custom-behaviors/ -e CRAWL_ID=behavior-logs-redis-test -p 36399:6379 --rm webrecorder/browsertrix-crawler crawl --debugAccessRedis --url https://specs.webrecorder.net/ --url https://old.webrecorder.net/ --customBehaviors https://raw.githubusercontent.com/webrecorder/browsertrix-crawler/refs/heads/main/tests/custom-behaviors/custom-2.js --customBehaviors /custom-behaviors/custom.js --scopeType page --logBehaviorsToRedis");
 
   let resolve = null;
   const crawlFinished = new Promise(r => resolve = r);

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -190,12 +190,12 @@ test("test pushing behavior logs to redis", async () => {
     }
     const json = JSON.parse(res);
     expect(json).toHaveProperty("timestamp");
-    expect(json.logLevel).toBe("info")
+    expect(json.logLevel).toBe("info");
     expect(json.context).toBe("behaviorScriptCustom")
-    expect(["test-stat", "test-stat-2"]).toContain(json.message)
-    expect(["TestBehavior", "TestBehavior2"]).toContain(json.details.behavior)
-    expect(["https://specs.webrecorder.net/", "https://old.webrecorder.net/"]).toContain(json.details.page)
-    logLineCount++
+    expect(["test-stat", "test-stat-2"]).toContain(json.message);
+    expect(["TestBehavior", "TestBehavior2"]).toContain(json.details.behavior);
+    expect(["https://specs.webrecorder.net/", "https://old.webrecorder.net/"]).toContain(json.details.page);
+    logLineCount++;
     break;
   }
 

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -180,7 +180,7 @@ test("test pushing behavior logs to redis", async () => {
 
   await redis.connect({ maxRetriesPerRequest: 50 });
 
-  let logLineCount = 0;
+  let customLogLineCount = 0;
 
   while (!crawler_exited) {
     const res = await redis.lpop("behavior-logs-redis-test:b");
@@ -191,13 +191,16 @@ test("test pushing behavior logs to redis", async () => {
     const json = JSON.parse(res);
     expect(json).toHaveProperty("timestamp");
     expect(json.logLevel).toBe("info");
-    expect(json.context).toBe("behaviorScriptCustom")
-    expect(["test-stat", "test-stat-2"]).toContain(json.message);
-    expect(["TestBehavior", "TestBehavior2"]).toContain(json.details.behavior);
-    expect(["https://specs.webrecorder.net/", "https://old.webrecorder.net/"]).toContain(json.details.page);
-    logLineCount++;
+    expect(["behavior", "behaviorScript", "behaviorScriptCustom"]).toContain(json.context)
+
+    if (json.context === "behaviorScriptCustom") {
+      expect(["test-stat", "test-stat-2"]).toContain(json.message);
+      expect(["TestBehavior", "TestBehavior2"]).toContain(json.details.behavior);
+      expect(["https://specs.webrecorder.net/", "https://old.webrecorder.net/"]).toContain(json.details.page);
+      customLogLineCount++;
+    }
     break;
   }
 
-  expect(logLineCount).toEqual(2);
+  expect(customLogLineCount).toEqual(2);
 });

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -183,23 +183,28 @@ test("test pushing behavior logs to redis", async () => {
   let customLogLineCount = 0;
 
   while (!crawler_exited) {
-    const res = await redis.lpop("behavior-logs-redis-test:b");
-    if (!res) {
-      await sleep(100);
-      continue;
-    }
-    const json = JSON.parse(res);
-    expect(json).toHaveProperty("timestamp");
-    expect(json.logLevel).toBe("info");
-    expect(["behavior", "behaviorScript", "behaviorScriptCustom"]).toContain(json.context)
+    try {
+      const res = await redis.lpop("behavior-logs-redis-test:b");
+      if (!res) {
+        await sleep(100);
+        continue;
+      }
+      const json = JSON.parse(res);
+      expect(json).toHaveProperty("timestamp");
+      expect(json.logLevel).toBe("info");
+      expect(["behavior", "behaviorScript", "behaviorScriptCustom"]).toContain(json.context)
 
-    if (json.context === "behaviorScriptCustom") {
-      expect(["test-stat", "test-stat-2", "done!"]).toContain(json.message);
-      expect(["TestBehavior", "TestBehavior2"]).toContain(json.details.behavior);
-      expect(["https://specs.webrecorder.net/", "https://old.webrecorder.net/"]).toContain(json.details.page);
-      customLogLineCount++;
+      if (json.context === "behaviorScriptCustom") {
+        expect(["test-stat", "test-stat-2", "done!"]).toContain(json.message);
+        expect(["TestBehavior", "TestBehavior2"]).toContain(json.details.behavior);
+        expect(["https://specs.webrecorder.net/", "https://old.webrecorder.net/"]).toContain(json.details.page);
+        customLogLineCount++;
+      }
+    } catch (e) {
+      break;
     }
+    
   }
 
-  expect(customLogLineCount).toEqual(4);
+  expect(customLogLineCount).toBeGreaterThanOrEqual(2);
 });

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -10,21 +10,21 @@ test("test custom behaviors from local filepath", async () => {
   // custom behavior ran for specs.webrecorder.net
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // but not for example.org
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://example.org","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://example.org","workerid":0}}',
     ) > 0,
   ).toBe(false);
 
   // another custom behavior ran for old.webrecorder.net
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -38,7 +38,7 @@ test("test custom behavior from URL", async () => {
 
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior"2,"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -53,14 +53,14 @@ test("test mixed custom behavior sources", async () => {
 
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // test custom behavior from local file ran
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -75,21 +75,21 @@ test("test custom behaviors from git repo", async () => {
   // custom behavior ran for specs.webrecorder.net
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // but not for example.org
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"page":"https://example.org/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://example.org/","workerid":0}}',
     ) > 0,
   ).toBe(false);
 
   // another custom behavior ran for old.webrecorder.net
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -45,7 +45,7 @@ test("test custom behavior from URL", async () => {
 
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior"2,"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -10,27 +10,21 @@ test("test custom behaviors from local filepath", async () => {
   // custom behavior ran for specs.webrecorder.net
   expect(
     log.indexOf(
-      '{"state":{},"msg":"test-stat","page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"message":"test-stat,{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // but not for example.org
   expect(
     log.indexOf(
-      '{"state":{},"msg":"test-stat","page":"https://example.org/","workerid":0}}',
+      '"message":"test-stat",{"state":{},"page":"https://example.org/","workerid":0}}',
     ) > 0,
   ).toBe(false);
-
-  expect(
-    log.indexOf(
-      '{"state":{"segments":1},"msg":"Skipping autoscroll, page seems to not be responsive to scrolling events","page":"https://example.org/","workerid":0}}',
-    ) > 0,
-  ).toBe(true);
 
   // another custom behavior ran for old.webrecorder.net
   expect(
     log.indexOf(
-      '{"state":{},"msg":"test-stat-2","page":"https://old.webrecorder.net/","workerid":0}}',
+      '"message":"test-stat-2",{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -44,7 +38,7 @@ test("test custom behavior from URL", async () => {
 
   expect(
     log.indexOf(
-      '{"state":{},"msg":"test-stat-2","page":"https://old.webrecorder.net/","workerid":0}}',
+      '"message":"test-stat-2",{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -59,14 +53,14 @@ test("test mixed custom behavior sources", async () => {
 
   expect(
     log.indexOf(
-      '{"state":{},"msg":"test-stat","page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"message":"test-stat",{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // test custom behavior from local file ran
   expect(
     log.indexOf(
-      '{"state":{},"msg":"test-stat-2","page":"https://old.webrecorder.net/","workerid":0}}',
+      '"message":"test-stat",{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -81,27 +75,21 @@ test("test custom behaviors from git repo", async () => {
   // custom behavior ran for specs.webrecorder.net
   expect(
     log.indexOf(
-      '{"state":{},"msg":"test-stat","page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"message":"test-stat",{"state":{},"page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // but not for example.org
   expect(
     log.indexOf(
-      '{"state":{},"msg":"test-stat","page":"https://example.org/","workerid":0}}',
+      '"message":"test-stat",{"state":{},"page":"https://example.org/","workerid":0}}',
     ) > 0,
   ).toBe(false);
-
-  expect(
-    log.indexOf(
-      '{"state":{"segments":1},"msg":"Skipping autoscroll, page seems to not be responsive to scrolling events","page":"https://example.org/","workerid":0}}',
-    ) > 0,
-  ).toBe(true);
 
   // another custom behavior ran for old.webrecorder.net
   expect(
     log.indexOf(
-      '{"state":{},"msg":"test-stat-2","page":"https://old.webrecorder.net/","workerid":0}}',
+      '"message":"test-stat-2",{"state":{},"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -1,4 +1,11 @@
 import child_process from "child_process";
+import Redis from "ioredis";
+
+
+async function sleep(time) {
+  await new Promise((resolve) => setTimeout(resolve, time));
+}
+
 
 test("test custom behaviors from local filepath", async () => {
   const res = child_process.execSync(
@@ -10,21 +17,21 @@ test("test custom behaviors from local filepath", async () => {
   // custom behavior ran for specs.webrecorder.net
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // but not for example.org
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://example.org","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://example.org","workerid":0}}',
     ) > 0,
   ).toBe(false);
 
   // another custom behavior ran for old.webrecorder.net
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -38,7 +45,7 @@ test("test custom behavior from URL", async () => {
 
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior"2,"page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior"2,"page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -53,14 +60,14 @@ test("test mixed custom behavior sources", async () => {
 
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // test custom behavior from local file ran
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -75,21 +82,21 @@ test("test custom behaviors from git repo", async () => {
   // custom behavior ran for specs.webrecorder.net
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://specs.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://specs.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 
   // but not for example.org
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://example.org/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat","details":{"state":{},"behavior":"TestBehavior","page":"https://example.org/","workerid":0}}',
     ) > 0,
   ).toBe(false);
 
   // another custom behavior ran for old.webrecorder.net
   expect(
     log.indexOf(
-      '"logLevel":"info","context":"behaviorScript","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
+      '"logLevel":"info","context":"behaviorScriptCustom","message":"test-stat-2","details":{"state":{},"behavior":"TestBehavior2","page":"https://old.webrecorder.net/","workerid":0}}',
     ) > 0,
   ).toBe(true);
 });
@@ -152,4 +159,45 @@ test("test crawl exits if not custom behaviors collected from local path", async
 
   // logger fatal exit code
   expect(status).toBe(17);
+});
+
+test("test pushing behavior logs to redis", async () => {
+  const child = child_process.exec("docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/custom-behaviors/:/custom-behaviors/ -e CRAWL_ID=behavior-logs-redis-test -p 36399:6379 --rm webrecorder/browsertrix-crawler crawl --url https://specs.webrecorder.net/ --url https://old.webrecorder.net/ --customBehaviors https://raw.githubusercontent.com/webrecorder/browsertrix-crawler/refs/heads/main/tests/custom-behaviors/custom-2.js --customBehaviors /custom-behaviors/custom.js --scopeType page --logBehaviorsToRedis");
+
+  let resolve = null;
+  const crawlFinished = new Promise(r => resolve = r);
+
+  // detect crawler exit
+  let crawler_exited = false;
+  child.on("exit", function () {
+    crawler_exited = true;
+    resolve();
+  });
+
+  const redis = new Redis("redis://127.0.0.1:36399/0", { lazyConnect: true, retryStrategy: () => null });
+
+  await sleep(3000);
+
+  await redis.connect({ maxRetriesPerRequest: 50 });
+
+  let logLineCount = 0;
+
+  while (!crawler_exited) {
+    const res = await redis.lpop("behavior-logs-redis-test:b");
+    if (!res) {
+      await sleep(100);
+      continue;
+    }
+    const json = JSON.parse(res);
+    expect(json).toHaveProperty("timestamp");
+    expect(json.logLevel).toBe("info")
+    expect(json.context).toBe("behaviorScriptCustom")
+    expect(["test-stat", "test-stat-2"]).toContain(json.message)
+    expect(["TestBehavior", "TestBehavior2"]).toContain(json.details.behavior)
+    expect(["https://specs.webrecorder.net/", "https://old.webrecorder.net/"]).toContain(json.details.page)
+    logLineCount++
+    break;
+  }
+
+  expect(logLineCount).toEqual(2);
 });

--- a/tests/custom-behavior.test.js
+++ b/tests/custom-behavior.test.js
@@ -194,12 +194,12 @@ test("test pushing behavior logs to redis", async () => {
     expect(["behavior", "behaviorScript", "behaviorScriptCustom"]).toContain(json.context)
 
     if (json.context === "behaviorScriptCustom") {
-      expect(["test-stat", "test-stat-2"]).toContain(json.message);
+      expect(["test-stat", "test-stat-2", "done!"]).toContain(json.message);
       expect(["TestBehavior", "TestBehavior2"]).toContain(json.details.behavior);
       expect(["https://specs.webrecorder.net/", "https://old.webrecorder.net/"]).toContain(json.details.page);
       customLogLineCount++;
     }
   }
 
-  expect(customLogLineCount).toEqual(2);
+  expect(customLogLineCount).toEqual(4);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,10 +1460,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.1"
 
-browsertrix-behaviors@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.8.1.tgz#21d2726d32ca23f94efd2c3e9a0b8b98c42482bb"
-  integrity sha512-bG5KA/9fF60slakycvbJZ4COo/nD9GKflNEhEk3yQQTy3C0ikRVOpueG9XfvAgq2r4Ji1NMY9pesJRpQqtHKXg==
+browsertrix-behaviors@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.8.2.tgz#77dfbde8cecdd28c66b839bbfb7daa52f588fd9b"
+  integrity sha512-uecs3jo1qhpgUhqXr6nzuw95HBlWVjHCLZP0IsuuGNTViOBs0gBb5OzhnpNI94EkCUoHo3hElnSHViYQ3PQxBg==
   dependencies:
     query-selector-shadow-dom "^1.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,10 +1460,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.1"
 
-browsertrix-behaviors@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.8.2.tgz#77dfbde8cecdd28c66b839bbfb7daa52f588fd9b"
-  integrity sha512-uecs3jo1qhpgUhqXr6nzuw95HBlWVjHCLZP0IsuuGNTViOBs0gBb5OzhnpNI94EkCUoHo3hElnSHViYQ3PQxBg==
+browsertrix-behaviors@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.8.3.tgz#3710f8d778c09ab4f46d5b7e1d4ebbfcbc1a8f02"
+  integrity sha512-ie+fsa45K1kZ2PWvt8ISObgFto9AXzbDB92ts+vgvVJ8erRA9pUKUyOVnK/B/qdNbYO0EQJiSP24GRqNp702tQ==
   dependencies:
     query-selector-shadow-dom "^1.0.1"
 


### PR DESCRIPTION
Fixes #804 

Noisy logs from built-in behaviors like autoscroll are now logged to debug in https://github.com/webrecorder/browsertrix-behaviors/pull/92 and so won't be pushed to Redis for newer versions of the crawler.

Also updates browsertrix-behaviors to 0.8.3 and makes some changes to log format in tests accordingly.