### PR TITLE
Tweaks for custom behavior loading

### DIFF
--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -127,6 +127,11 @@ async function collectLocalPathBehaviors(
     const stat = await fsp.stat(resolvedPath);
 
     if (stat.isFile() && ALLOWED_EXTS.includes(path.extname(resolvedPath))) {
+      logger.info(
+        "Custom behavior script added",
+        { filename },
+        "behavior"
+      );
       const contents = await fsp.readFile(resolvedPath);
       return [
         {

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -85,9 +85,6 @@ async function collectOnlineBehavior(url: string): Promise<FileSources> {
   const filename = crypto.randomBytes(4).toString("hex") + ".js";
   const behaviorFilepath = `/app/behaviors/${filename}`;
 
-  const fileUrl = new URL(url);
-  const originalFilename = path.basename(fileUrl.pathname);
-
   try {
     const res = await fetch(url, { dispatcher: getProxyDispatcher() });
     const fileContents = await res.text();
@@ -97,11 +94,7 @@ async function collectOnlineBehavior(url: string): Promise<FileSources> {
       { url, path: behaviorFilepath },
       "behavior",
     );
-    return await collectLocalPathBehaviors(
-      behaviorFilepath,
-      0,
-      originalFilename,
-    );
+    return await collectLocalPathBehaviors(behaviorFilepath, 0, url);
   } catch (e) {
     logger.fatal(
       "Error downloading custom behavior from URL",
@@ -115,7 +108,7 @@ async function collectOnlineBehavior(url: string): Promise<FileSources> {
 async function collectLocalPathBehaviors(
   fileOrDir: string,
   depth = 0,
-  originalFilename?: string,
+  source?: string,
 ): Promise<FileSources> {
   const resolvedPath = path.resolve(fileOrDir);
   const filename = path.basename(resolvedPath);
@@ -135,15 +128,8 @@ async function collectLocalPathBehaviors(
     const stat = await fsp.stat(resolvedPath);
 
     if (stat.isFile() && ALLOWED_EXTS.includes(path.extname(resolvedPath))) {
-      if (originalFilename) {
-        logger.info(
-          "Custom behavior script added",
-          { filename: originalFilename },
-          "behavior",
-        );
-      } else {
-        logger.info("Custom behavior script added", { filename }, "behavior");
-      }
+      source = source ?? filename;
+      logger.info("Custom behavior script added", { source }, "behavior");
       const contents = await fsp.readFile(resolvedPath);
       return [
         {

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -127,11 +127,7 @@ async function collectLocalPathBehaviors(
     const stat = await fsp.stat(resolvedPath);
 
     if (stat.isFile() && ALLOWED_EXTS.includes(path.extname(resolvedPath))) {
-      logger.info(
-        "Custom behavior script added",
-        { filename },
-        "behavior"
-      );
+      logger.info("Custom behavior script added", { filename }, "behavior");
       const contents = await fsp.readFile(resolvedPath);
       return [
         {

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -10,7 +10,7 @@ import { getProxyDispatcher } from "./proxy.js";
 
 const exec = util.promisify(execCallback);
 
-const MAX_DEPTH = 2;
+const MAX_DEPTH = 5;
 
 // Add .ts to allowed extensions when we can support it
 const ALLOWED_EXTS = [".js"];

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -110,6 +110,7 @@ async function collectLocalPathBehaviors(
   depth = 0,
 ): Promise<FileSources> {
   const resolvedPath = path.resolve(fileOrDir);
+  const filename = path.basename(resolvedPath);
 
   if (depth >= MAX_DEPTH) {
     logger.warn(
@@ -136,6 +137,11 @@ async function collectLocalPathBehaviors(
     }
 
     const isDir = stat.isDirectory();
+
+    // ignore .git directory of git repositories
+    if (isDir && filename === ".git") {
+      return [];
+    }
 
     if (!isDir && depth === 0) {
       logger.warn(


### PR DESCRIPTION
Follow-up to #712 

Fixes a few things I noticed while testing out https://github.com/webrecorder/browsertrix/pull/2520

- Ignore `.git` directory of git repositories when recursively walking cloned git repo to collect custom behaviors
- Increase MAX_DEPTH for collecting behaviors to 5 (previous limit of 2 was overly restrictive for Git repositories)
- Log name of custom behavior scripts added as info messages in `behavior` context