### PR TITLE
useSHA1 Parameter for generating SHA1 record hashes (#532)

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2808,6 +2808,7 @@ self.__bx_behaviors.selectMainBehavior();
     logDetails: Record<string, string>,
   ) {
     const filenameTemplate = `${filenameBase}.warc${gzip ? ".gz" : ""}`;
+    const useSHA1 = this.params.useSHA1;
 
     return new WARCWriter({
       archivesDir: this.archivesDir,
@@ -2815,6 +2816,7 @@ self.__bx_behaviors.selectMainBehavior();
       filenameTemplate,
       rolloverSize: this.params.rolloverSize,
       gzip,
+      useSHA1,
       logDetails,
     });
   }

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -256,6 +256,13 @@ class ArgParser {
           default: false,
         },
 
+        useSHA1: {
+          describe:
+            "If set, sha-1 instead of sha-256 hashes will be used for creating records",
+          type: "boolean",
+          default: false,
+        },
+
         logging: {
           describe:
             "Logging options for crawler, can include: stats (enabled by default), jserrors, debug",

--- a/src/util/warcwriter.ts
+++ b/src/util/warcwriter.ts
@@ -28,6 +28,7 @@ export class WARCWriter implements IndexerOffsetLength {
   filenameTemplate: string;
   filename?: string;
   gzip: boolean;
+  useSHA1: boolean;
   logDetails: Record<string, string>;
 
   offset = 0;
@@ -49,6 +50,7 @@ export class WARCWriter implements IndexerOffsetLength {
     filenameTemplate,
     rolloverSize = DEFAULT_ROLLOVER_SIZE,
     gzip,
+    useSHA1,
     logDetails,
   }: {
     archivesDir: string;
@@ -56,12 +58,14 @@ export class WARCWriter implements IndexerOffsetLength {
     filenameTemplate: string;
     rolloverSize?: number;
     gzip: boolean;
+    useSHA1: boolean;
     logDetails: Record<string, string>;
   }) {
     this.archivesDir = archivesDir;
     this.warcCdxDir = warcCdxDir;
     this.logDetails = logDetails;
     this.gzip = gzip;
+    this.useSHA1 = useSHA1;
     this.rolloverSize = rolloverSize;
 
     this.filenameTemplate = filenameTemplate;
@@ -145,7 +149,18 @@ export class WARCWriter implements IndexerOffsetLength {
     requestRecord: WARCRecord,
     responseSerializer: WARCSerializer | undefined = undefined,
   ) {
-    const opts = { gzip: this.gzip };
+    const opts = this.useSHA1
+      ? {
+          gzip: this.gzip,
+          digest: {
+            algo: "sha-1",
+            prefix: "sha1:",
+            base32: true,
+          },
+        }
+      : {
+          gzip: this.gzip,
+        };
 
     if (!responseSerializer) {
       responseSerializer = new WARCSerializer(responseRecord, opts);


### PR DESCRIPTION
By using the useSHA1 flag, the payload digest in records will use SHA-1 with Base32 encoding instead of the default SHA-256