### PR TITLE
browser crash handling, follow-up to #808:

### DIFF
--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -232,13 +232,12 @@ export class PageWorker {
         }
 
         if (retry >= 2) {
-          this.crawler.markBrowserCrashed();
-          if (this.crawler.params.restartsOnError) {
+          if (this.crawler.params.restartsOnError || retry >= 5) {
+            this.crawler.markBrowserCrashed();
             throw new Error("Unable to load new page, browser needs restart");
           } else {
+            // see if killing the browser may help, retry a couple more times
             this.crawler.browser.killBrowser();
-            // retry again after killing browser
-            retry = 0;
             await sleep(2.0);
           }
         }


### PR DESCRIPTION
- if not restartOnError, attempt to kill browser and try again, 3 more times
- if still unable to open window, mark browser as crashed an exit