### PR TITLE
state: add trimqueue() redis command to trim queue / seen list

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -585,6 +585,8 @@ export class Crawler {
     }
 
     await this.loadCrawlState();
+
+    await this.crawlState.trimToLimit(this.pageLimit);
   }
 
   extraChromeArgs() {


### PR DESCRIPTION
useful to support dynamically lowering pageLimit when restarting a crawl
fixes issue raised in webrecorder/browsertrix#2514