### PR TITLE
Config Policy Update

### DIFF
--- a/config/policies/chromium.json
+++ b/config/policies/chromium.json
@@ -7,5 +7,6 @@
     "URLBlocklist": [
         "file://*"
     ],
-    "DownloadDirectory": "/dev/null"
+    "DownloadDirectory": "/dev/null",
+    "SpellcheckEnabled": false
 }

--- a/config/policies/chromium.json
+++ b/config/policies/chromium.json
@@ -8,5 +8,6 @@
         "file://*"
     ],
     "DownloadDirectory": "/dev/null",
-    "SpellcheckEnabled": false
+    "SpellcheckEnabled": false,
+    "HttpsUpgradesEnabled": false
 }


### PR DESCRIPTION
Fixes webrecorder/replayweb.page#416

Update enterprise policy to:
- Disable Spellcheck, which should include downloading spellcheck dictionary, possibly issue raised in #817 
- Disable automatic http->https redirects, which insert an extra 307 response, as raised in: webrecorder/replayweb.page#416