### PR TITLE
Improved handling of SSO-based crawling

### DIFF
--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -450,7 +450,7 @@ export class ReplayCrawler extends Crawler {
     // optionally reload (todo: reevaluate if this is needed)
     // await page.reload();
 
-    await this.awaitPageLoad(replayFrame, logDetails);
+    await this.awaitPageLoad(replayFrame, 0, logDetails);
 
     data.isHTMLPage = true;
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -38,6 +38,7 @@ export const DEFAULT_MAX_RETRIES = 2;
 export const FETCH_HEADERS_TIMEOUT_SECS = 30;
 export const PAGE_OP_TIMEOUT_SECS = 5;
 export const SITEMAP_INITIAL_FETCH_TIMEOUT_SECS = 30;
+export const SEED_REDIRECT_ADD_DELAY = 20;
 
 export type ExtractSelector = {
   selector: string;

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1404,7 +1404,7 @@ export class Recorder extends EventEmitter {
         mime = ct.split(";")[0];
       }
 
-      const result = !isHTMLMime(mime);
+      const result = !!mime && !isHTMLMime(mime);
 
       if (result) {
         logger.info(


### PR DESCRIPTION
- If a seed page redirects, and then redirects back, it is likely doing some sort of SSO-check, and the initial capture should not be included.
- Also add a delay after initial redirect, in case page redirects back
- Don't store resource with no mime type, likely from SSO
- If a page response has no mime type / non HTML, allow it to be captured again (possibly SSO 403 error that may work on second try)
- Don't consider pages with no mime type as HTML
- Don't add `--lang` when using profiles, may interfere with language expected in profile.