### PR TITLE
Check page URLs for extension before direct fetch attempt

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1012,6 +1012,24 @@ self.__bx_behaviors.selectMainBehavior();
     return "";
   }
 
+  skipDirectFetchByExt(url: string) {
+    const urlFull = new URL(url);
+    const extParts = urlFull.pathname.split(".");
+    if (extParts.length <= 1) {
+      return true;
+    }
+    const ext = extParts[1];
+    if (["html", "htm", "asp", "php"].includes(ext)) {
+      return true;
+    }
+
+    if (["pdf", "xml", "jpg", "webm", "docx", "mp4", "zip"].includes(ext)) {
+      return false;
+    }
+
+    return false;
+  }
+
   async crawlPage(opts: WorkerState): Promise<void> {
     await this.writeStats();
 
@@ -1033,7 +1051,7 @@ self.__bx_behaviors.selectMainBehavior();
     data.logDetails = logDetails;
     data.workerid = workerid;
 
-    if (recorder) {
+    if (recorder && !this.skipDirectFetchByExt(url)) {
       try {
         const headers = auth
           ? { Authorization: auth, ...this.headers }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -47,6 +47,7 @@ import {
   ExitCodes,
   InterruptReason,
   BxFunctionBindings,
+  DIRECT_FETCH_EXT,
 } from "./util/constants.js";
 
 import { AdBlockRules, BlockRuleDecl, BlockRules } from "./util/blockrules.js";
@@ -1012,19 +1013,17 @@ self.__bx_behaviors.selectMainBehavior();
     return "";
   }
 
-  skipDirectFetchByExt(url: string) {
+  shouldDirectFetchByExt(url: string) {
     const urlFull = new URL(url);
     const extParts = urlFull.pathname.split(".");
     if (extParts.length <= 1) {
-      return true;
+      return false;
     }
     const ext = extParts[1];
-    if (["html", "htm", "asp", "php"].includes(ext)) {
-      return true;
-    }
 
-    if (["pdf", "xml", "jpg", "webm", "docx", "mp4", "zip"].includes(ext)) {
-      return false;
+    // known files that should be direct fetched
+    if (DIRECT_FETCH_EXT.includes(ext)) {
+      return true;
     }
 
     return false;
@@ -1051,7 +1050,7 @@ self.__bx_behaviors.selectMainBehavior();
     data.logDetails = logDetails;
     data.workerid = workerid;
 
-    if (recorder && !this.skipDirectFetchByExt(url)) {
+    if (recorder && this.shouldDirectFetchByExt(url)) {
       try {
         const headers = auth
           ? { Authorization: auth, ...this.headers }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -22,6 +22,16 @@ export const DETECT_SITEMAP = "<detect>";
 
 export const EXTRACT_TEXT_TYPES = ["to-pages", "to-warc", "final-to-warc"];
 
+export const DIRECT_FETCH_EXT = [
+  "pdf",
+  "xml",
+  "jpg",
+  "webm",
+  "docx",
+  "mp4",
+  "zip",
+];
+
 export enum BxFunctionBindings {
   BehaviorLogFunc = "__bx_log",
   AddLinkFunc = "__bx_addLink",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1361,7 +1361,11 @@ export class Recorder extends EventEmitter {
       url &&
       method === "GET" &&
       !isRedirectStatus(status) &&
-      !(await this.crawlState.addIfNoDupe(WRITE_DUPE_KEY, url, status))
+      !(await this.crawlState.addIfNoDupe(
+        WRITE_DUPE_KEY,
+        url,
+        status === 206 || !status ? 200 : status,
+      ))
     ) {
       logNetwork("Skipping dupe", { url, status, ...this.logDetails });
       return;
@@ -1515,7 +1519,11 @@ class AsyncFetcher {
       if (
         reqresp.method === "GET" &&
         url &&
-        !(await crawlState.addIfNoDupe(ASYNC_FETCH_DUPE_KEY, url, status))
+        !(await crawlState.addIfNoDupe(
+          ASYNC_FETCH_DUPE_KEY,
+          url,
+          status === 206 || !status ? 200 : status,
+        ))
       ) {
         if (!this.ignoreDupe) {
           this.reqresp.asyncLoading = false;


### PR DESCRIPTION
Fixes #829

- Only attempt direct fetch (non-browser fetch()) of page URLs with known non-HTML extensions, otherwise attempt loading in the browser. (Can perhaps further optimize to discover new non-HTML extensions)
- Also: Async fetch dedup: treat unknown status / 206 same as 200 for dedup purposes, to avoid duplicate loading

