### PR TITLE
tmpdir: use os.tmpdir() instead of hardcoded '/tmp'

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -469,7 +469,7 @@ export class Crawler {
     }
 
     return child_process.spawn("redis-server", redisArgs, {
-      cwd: "/tmp/",
+      cwd: os.tmpdir(),
       stdio: redisStdio,
       detached: RUN_DETACHED,
     });

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -181,7 +181,7 @@ export class Browser {
   }
 
   async loadProfile(profileFilename: string): Promise<boolean> {
-    const targetFilename = "/tmp/profile.tar.gz";
+    const targetFilename = path.join(os.tmpdir(), "profile.tar.gz");
 
     if (
       profileFilename &&

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -1,5 +1,6 @@
 import fsp from "fs/promises";
 import path from "path";
+import os from "os";
 import crypto from "crypto";
 import { fetch } from "undici";
 import util from "util";
@@ -51,7 +52,10 @@ async function collectGitBehaviors(gitUrl: string): Promise<FileSources> {
   const relPath = params.get("path") || "";
   const urlStripped = url.split("?")[0];
 
-  const tmpDir = `/tmp/behaviors-repo-${crypto.randomBytes(4).toString("hex")}`;
+  const tmpDir = path.join(
+    os.tmpdir(),
+    `behaviors-repo-${crypto.randomBytes(4).toString("hex")}`,
+  );
 
   let cloneCommand = "git clone ";
   if (branch) {
@@ -84,7 +88,10 @@ async function collectGitBehaviors(gitUrl: string): Promise<FileSources> {
 
 async function collectOnlineBehavior(url: string): Promise<FileSources> {
   const filename = path.basename(new URL(url).pathname);
-  const tmpDir = `/tmp/behaviors-${crypto.randomBytes(4).toString("hex")}`;
+  const tmpDir = path.join(
+    os.tmpdir(),
+    `/tmp/behaviors-${crypto.randomBytes(4).toString("hex")}`,
+  );
   await fsp.mkdir(tmpDir, { recursive: true });
   const behaviorFilepath = path.join(tmpDir, filename);
 


### PR DESCRIPTION
allows for customizing tmp directory with TMPDIR env var