### PR TITLE
Remove hardcoded /tmp prefix from path

### DIFF
--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -90,7 +90,7 @@ async function collectOnlineBehavior(url: string): Promise<FileSources> {
   const filename = path.basename(new URL(url).pathname);
   const tmpDir = path.join(
     os.tmpdir(),
-    `/tmp/behaviors-${crypto.randomBytes(4).toString("hex")}`,
+    `behaviors-${crypto.randomBytes(4).toString("hex")}`,
   );
   await fsp.mkdir(tmpDir, { recursive: true });
   const behaviorFilepath = path.join(tmpDir, filename);


### PR DESCRIPTION
Fast-follow to https://github.com/webrecorder/browsertrix-crawler/pull/842 to catch a mistake I missed in review