### PR TITLE
remove early serialization which may result in missing WARC-Protocol and security metadata

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -577,11 +577,11 @@ export class Browser {
       }
 
       if (!foundRecorder) {
-        logger.warn(
-          "Skipping URL from unknown frame",
-          { url, frameId },
-          "recorder",
-        );
+        // logger.warn(
+        //   "Skipping URL from unknown frame",
+        //   { url, frameId },
+        //   "recorder",
+        // );
 
         try {
           await this.firstCDP.send("Fetch.continueResponse", { requestId });

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -806,15 +806,15 @@ export class Recorder extends EventEmitter {
 
     // if in browser context, and not also intercepted in page context
     // serialize here, as won't be getting a loadingFinished message for it
-    if (
-      isBrowserContext &&
-      !reqresp.inPageContext &&
-      !reqresp.asyncLoading &&
-      reqresp.payload
-    ) {
-      this.removeReqResp(networkId);
-      await this.serializeToWARC(reqresp);
-    }
+    // if (
+    //   isBrowserContext &&
+    //   !reqresp.inPageContext &&
+    //   !reqresp.asyncLoading &&
+    //   reqresp.payload
+    // ) {
+    //   this.removeReqResp(networkId);
+    //   await this.serializeToWARC(reqresp);
+    // }
 
     // not rewritten, and not streaming, return false to continue
     if (!rewritten && !streamingConsume) {


### PR DESCRIPTION
- drop early serialization in handleFetchResponse(), can result in writing WARC record too early, before the WARC-Protocol and other data is available. (Added previously requests loaded via browser context / service worker which did not get a 'loadingFinished' message, but now these will still be closed in awaitPageResources())
- don't log 'skipping URL from unknown frame' warning since it is often spurious, since frame can be added in subsequent message and response is *not* skipped.