### PR TITLE
cleanup: remove dead pywb code from argparser and docs

### DIFF
--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -161,8 +161,6 @@ Options:
                                             econds) after behaviors before movin
                                             g on to next page
                                                            [number] [default: 0]
-      --dedupPolicy                         Deduplication policy
-                 [string] [choices: "skip", "revisit", "keep"] [default: "skip"]
       --profile                             Path or HTTP(S) URL to tar.gz file w
                                             hich contains the browser profile di
                                             rectory                     [string]

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -392,13 +392,6 @@ class ArgParser {
           type: "number",
         },
 
-        dedupPolicy: {
-          describe: "Deduplication policy",
-          default: "skip",
-          type: "string",
-          choices: ["skip", "revisit", "keep"],
-        },
-
         profile: {
           describe:
             "Path or HTTP(S) URL to tar.gz file which contains the browser profile directory",


### PR DESCRIPTION
The value of `--dedupPolicy` was once passed to pywb (see https://pywb.readthedocs.io/en/latest/manual/configuring.html#dedup-options-for-recording). Now that pywb has been dropped, there is no need to keep this option around.

In fact, I know multiple users that have been confused by the mention of this option in the docs (myself included). 

(for historical context, see https://github.com/webrecorder/browsertrix-crawler/pull/332)