### PR TITLE
Disable disk utilization check by default

### DIFF
--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -475,7 +475,7 @@ class ArgParser {
           describe:
             "If set, save state and exit if disk utilization exceeds this percentage value",
           type: "number",
-          default: 90,
+          default: 0,
         },
 
         timeLimit: {


### PR DESCRIPTION
Related to https://github.com/webrecorder/browsertrix-crawler/issues/848

Several users have had issues with disk utilization checks, including the values reported by `df` inside the crawler container having unexpected results for mounted volumes. The commonly recommended solution to this is to use `docker system ps`, but that is of course not available within the Docker container itself.

This PR changes disk utilization checks to be an opt-in feature by setting the default value to `0` (disabled).