### PR TITLE
Support downloading seed file from URL

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -62,7 +62,7 @@ import {
 } from "puppeteer-core";
 import { Recorder } from "./util/recorder.js";
 import { SitemapReader } from "./util/sitemapper.js";
-import { ScopedSeed } from "./util/seeds.js";
+import { ScopedSeed, parseSeeds } from "./util/seeds.js";
 import {
   WARCWriter,
   createWARCInfo,
@@ -134,7 +134,7 @@ export class Crawler {
 
   maxPageTime: number;
 
-  seeds: ScopedSeed[];
+  seeds: ScopedSeed[] = [];
   numOriginalSeeds = 0;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -254,9 +254,6 @@ export class Crawler {
 
     this.saveStateFiles = [];
     this.lastSaveTime = 0;
-
-    this.seeds = this.params.scopedSeeds as ScopedSeed[];
-    this.numOriginalSeeds = this.seeds.length;
 
     // sum of page load + behavior timeouts + 2 x pageop timeouts (for cloudflare, link extraction) + extra page delay
     // if exceeded, will interrupt and move on to next page (likely behaviors or some other operation is stuck)
@@ -513,6 +510,9 @@ export class Crawler {
     logger.info(this.infoString);
 
     this.proxyServer = await initProxy(this.params, RUN_DETACHED);
+
+    this.seeds = await parseSeeds(this.params);
+    this.numOriginalSeeds = this.seeds.length;
 
     logger.info("Seeds", this.seeds);
 

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -96,8 +96,6 @@ export class ReplayCrawler extends Crawler {
     // skip text from first two frames, as they are RWP boilerplate
     this.skipTextDocs = SKIP_FRAMES;
 
-    this.params.scopedSeeds = [];
-
     this.params.screenshot = ["view"];
     this.params.text = ["to-warc"];
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -40,6 +40,10 @@ export type CrawlerArgs = ReturnType<typeof parseArgs> & {
 
   selectLinks: ExtractSelector[];
 
+  include: string[];
+  exclude: string[];
+  sitemap: boolean;
+
   crawlId: string;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -52,7 +52,7 @@ async function writeUrlContentsToFile(
   pathDefaultExt: string,
 ) {
   const res = await fetch(url, { dispatcher: getProxyDispatcher() });
-  const ct = (res.headers.get("content-type") || "").toLowerCase();
+  const ct = (res.headers.get("content-type") || "").toLowerCase().split(";")[0];
   if (!allowedMimes.includes(ct)) {
     throw new Error(
       `Invalid Content-Type: ${ct}, expected one of: ${allowedMimes.join(",")}`,

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -43,7 +43,7 @@ async function writeUrlContentsToFile(url: string, filepath: string) {
 }
 
 export async function collectOnlineSeedFile(url: string): Promise<string> {
-  const filename = path.basename(new URL(url).pathname);
+  const filename = path.basename(new URL(url).pathname) || "index.html";
   const filepath = await getTempFile(filename, "seeds-");
 
   try {
@@ -119,7 +119,7 @@ async function collectGitBehaviors(gitUrl: string): Promise<FileSources> {
 }
 
 async function collectOnlineBehavior(url: string): Promise<FileSources> {
-  const filename = path.basename(new URL(url).pathname);
+  const filename = path.basename(new URL(url).pathname) || "index.html";
   const behaviorFilepath = await getTempFile(filename, "behaviors-");
 
   try {

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -52,7 +52,9 @@ async function writeUrlContentsToFile(
   pathDefaultExt: string,
 ) {
   const res = await fetch(url, { dispatcher: getProxyDispatcher() });
-  const ct = (res.headers.get("content-type") || "").toLowerCase().split(";")[0];
+  const ct = (res.headers.get("content-type") || "")
+    .toLowerCase()
+    .split(";")[0];
   if (!allowedMimes.includes(ct)) {
     throw new Error(
       `Invalid Content-Type: ${ct}, expected one of: ${allowedMimes.join(",")}`,

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -17,15 +17,6 @@ const MAX_DEPTH = 5;
 // Add .ts to allowed extensions when we can support it
 const ALLOWED_EXTS = [".js", ".json"];
 
-const BEHAVIOR_MIMES = [
-  "application/json",
-  "text/javascript",
-  "application/javascript",
-  "application/x-javascript",
-];
-
-const SEED_LIST_MIMES = ["text/plain"];
-
 export type FileSource = {
   path: string;
   contents: string;
@@ -48,18 +39,10 @@ async function getTempFile(
 async function writeUrlContentsToFile(
   url: string,
   pathPrefix: string,
-  allowedMimes: string[],
   pathDefaultExt: string,
 ) {
   const res = await fetch(url, { dispatcher: getProxyDispatcher() });
-  const ct = (res.headers.get("content-type") || "")
-    .toLowerCase()
-    .split(";")[0];
-  if (!allowedMimes.includes(ct)) {
-    throw new Error(
-      `Invalid Content-Type: ${ct}, expected one of: ${allowedMimes.join(",")}`,
-    );
-  }
+
   const fileContents = await res.text();
 
   const filename =
@@ -72,12 +55,7 @@ async function writeUrlContentsToFile(
 
 export async function collectOnlineSeedFile(url: string): Promise<string> {
   try {
-    const filepath = await writeUrlContentsToFile(
-      url,
-      "seeds-",
-      SEED_LIST_MIMES,
-      ".txt",
-    );
+    const filepath = await writeUrlContentsToFile(url, "seeds-", ".txt");
     logger.info("Seed file downloaded", { url, path: filepath });
     return filepath;
   } catch (e) {
@@ -156,7 +134,6 @@ async function collectOnlineBehavior(url: string): Promise<FileSources> {
     const behaviorFilepath = await writeUrlContentsToFile(
       url,
       "behaviors-",
-      BEHAVIOR_MIMES,
       ".js",
     );
     logger.info(

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -42,7 +42,6 @@ async function writeUrlContentsToFile(
   pathDefaultExt: string,
 ) {
   const res = await fetch(url, { dispatcher: getProxyDispatcher() });
-
   const fileContents = await res.text();
 
   const filename =
@@ -174,7 +173,10 @@ async function collectLocalPathBehaviors(
   try {
     const stat = await fsp.stat(resolvedPath);
 
-    if (stat.isFile() && ALLOWED_EXTS.includes(path.extname(resolvedPath))) {
+    if (
+      stat.isFile() &&
+      ALLOWED_EXTS.includes(path.extname(resolvedPath))
+    ) {
       source = source ?? filename;
       logger.info("Custom behavior script added", { source }, "behavior");
       let contents = await fsp.readFile(resolvedPath, { encoding: "utf-8" });

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -173,10 +173,7 @@ async function collectLocalPathBehaviors(
   try {
     const stat = await fsp.stat(resolvedPath);
 
-    if (
-      stat.isFile() &&
-      ALLOWED_EXTS.includes(path.extname(resolvedPath))
-    ) {
+    if (stat.isFile() && ALLOWED_EXTS.includes(path.extname(resolvedPath))) {
       source = source ?? filename;
       logger.info("Custom behavior script added", { source }, "behavior");
       let contents = await fsp.readFile(resolvedPath, { encoding: "utf-8" });

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -28,7 +28,10 @@ async function getTempFile(
   filename: string,
   dirPrefix: string,
 ): Promise<string> {
-  const tmpDir = path.join(os.tmpdir(), `${dirPrefix}-${crypto.randomBytes(4).toString("hex")}`);
+  const tmpDir = path.join(
+    os.tmpdir(),
+    `${dirPrefix}-${crypto.randomBytes(4).toString("hex")}`,
+  );
   await fsp.mkdir(tmpDir, { recursive: true });
   return path.join(tmpDir, filename);
 }

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -52,7 +52,7 @@ async function writeUrlContentsToFile(
   pathDefaultExt: string,
 ) {
   const res = await fetch(url, { dispatcher: getProxyDispatcher() });
-  const ct = res.headers.get("content-type") || "";
+  const ct = (res.headers.get("content-type") || "").toLowerCase();
   if (!allowedMimes.includes(ct)) {
     throw new Error(
       `Invalid Content-Type: ${ct}, expected one of: ${allowedMimes.join(",")}`,

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -28,7 +28,7 @@ async function getTempFile(
   filename: string,
   dirPrefix: string,
 ): Promise<string> {
-  const tmpDir = `/tmp/${dirPrefix}-${crypto.randomBytes(4).toString("hex")}`;
+  const tmpDir = path.join(os.tmpdir(), `${dirPrefix}-${crypto.randomBytes(4).toString("hex")}`);
   await fsp.mkdir(tmpDir, { recursive: true });
   return path.join(tmpDir, filename);
 }

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -361,7 +361,7 @@ export async function parseSeeds(params: any): Promise<ScopedSeed[]> {
     }
   }
 
-  if (!scopedSeeds.length) {
+  if (!params.qaSource && !scopedSeeds.length) {
     logger.fatal("No valid seeds specified, aborting crawl");
   }
 

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -351,7 +351,7 @@ export class PageWorker {
     let loggedWaiting = false;
 
     while (await this.crawler.isCrawlRunning()) {
-      await crawlState.processMessage(this.crawler.params.scopedSeeds);
+      await crawlState.processMessage(this.crawler.seeds);
 
       const data = await crawlState.nextFromQueue();
 

--- a/tests/scopes.test.js
+++ b/tests/scopes.test.js
@@ -1,8 +1,9 @@
 import { parseArgs } from "../dist/util/argParser.js";
+import { parseSeeds } from "../dist/util/seeds.js";
 
 import fs from "fs";
 
-function getSeeds(config) {
+async function getSeeds(config) {
   const orig = fs.readFileSync;
 
   fs.readFileSync = (name, ...args) => {
@@ -12,12 +13,12 @@ function getSeeds(config) {
     return orig(name, ...args);
   };
 
-  const res = parseArgs(["node", "crawler", "--config", "stdinconfig"]);
-  return res.scopedSeeds;
+  const params = parseArgs(["node", "crawler", "--config", "stdinconfig"]);
+  return await parseSeeds(params);
 }
 
 test("default scope", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 seeds:
    - https://example.com/
 
@@ -30,7 +31,7 @@ seeds:
 });
 
 test("default scope + exclude", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 seeds:
    - https://example.com/
 
@@ -45,7 +46,7 @@ exclude: https://example.com/pathexclude
 });
 
 test("default scope + exclude is numeric", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 seeds:
    - https://example.com/
 
@@ -60,7 +61,7 @@ exclude: "2022"
 });
 
 test("prefix scope global + exclude", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 seeds:
    - https://example.com/
 
@@ -76,7 +77,7 @@ exclude: https://example.com/pathexclude
 });
 
 test("prefix scope per seed + exclude", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 seeds:
    - url: https://example.com/
      scopeType: prefix
@@ -92,7 +93,7 @@ exclude: https://example.com/pathexclude
 });
 
 test("host scope and domain scope", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 
 seeds:
    - url: https://example.com/
@@ -127,7 +128,7 @@ seeds:
 });
 
 test("domain scope drop www.", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 seeds:
    - url: https://www.example.com/
      scopeType: domain
@@ -139,7 +140,7 @@ seeds:
 });
 
 test("custom scope", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 seeds:
    - url: https://example.com/
      include: https?://example.com/(path|other)
@@ -153,7 +154,7 @@ seeds:
 });
 
 test("inherit scope", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 
 seeds:
    - url: https://example.com/1
@@ -177,7 +178,7 @@ exclude: https://example.com/pathexclude
 });
 
 test("override scope", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 
 seeds:
    - url: https://example.com/1
@@ -220,7 +221,7 @@ include: https://example.com/onlythispath
 });
 
 test("override scope with exclude", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 
 seeds:
    - url: https://example.com/1
@@ -275,7 +276,7 @@ exclude:
 });
 
 test("with exclude non-string types", async () => {
-  const seeds = getSeeds(`
+  const seeds = await getSeeds(`
 seeds:
    - url: https://example.com/
      exclude: "2023"

--- a/tests/url_file_list.test.js
+++ b/tests/url_file_list.test.js
@@ -38,3 +38,39 @@ test("check that URLs in seed-list are crawled", async () => {
   }
   expect(foundSeedUrl).toBe(true);
 });
+
+
+test("check that URLs in seed-list hosted at URL are crawled", async () => {
+  try {
+    await exec(
+      'docker run -v $PWD/test-crawls:/crawls -v $PWD/tests/fixtures:/tests/fixtures webrecorder/browsertrix-crawler crawl --collection onlinefilelisttest --urlFile "https://raw.githubusercontent.com/webrecorder/browsertrix-crawler/refs/heads/main/tests/fixtures/urlSeedFile.txt" --timeout 90000',
+    );
+  } catch (error) {
+    console.log(error);
+  }
+
+  let crawled_pages = fs.readFileSync(
+    "test-crawls/collections/onlinefilelisttest/pages/pages.jsonl",
+    "utf8",
+  );
+  let seed_file = fs
+    .readFileSync("tests/fixtures/urlSeedFile.txt", "utf8")
+    .split("\n")
+    .sort();
+
+  let seed_file_list = [];
+  for (var j = 0; j < seed_file.length; j++) {
+    if (seed_file[j] != undefined) {
+      seed_file_list.push(seed_file[j]);
+    }
+  }
+
+  let foundSeedUrl = true;
+
+  for (var i = 1; i < seed_file_list.length; i++) {
+    if (crawled_pages.indexOf(seed_file_list[i]) == -1) {
+      foundSeedUrl = false;
+    }
+  }
+  expect(foundSeedUrl).toBe(true);
+});


### PR DESCRIPTION
Fixes #841 

Crawler work toward long URL lists in Browsertrix. This PR moves seed handling from the arg parser's validation step to the crawler's bootstrap step in order to be able to async fetch the seed file from a URL.