### PR TITLE
Add option to save local/sessionStorage

### DIFF
--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -596,6 +596,12 @@ class ArgParser {
           default: [],
         },
 
+        saveStorage: {
+          describe:
+            "if set, will store the localStorage/sessionStorage data for each page as part of WARC-JSON-Metadata field",
+          type: "boolean",
+        },
+
         debugAccessRedis: {
           describe:
             "if set, runs internal redis without protected mode to allow external access (for debugging)",
@@ -868,6 +874,10 @@ class ArgParser {
 
     if (argv.diskUtilization < 0 || argv.diskUtilization > 99) {
       argv.diskUtilization = 90;
+    }
+
+    if (argv.saveStorage) {
+      logger.info("Saving localStorage and sessionStorage");
     }
 
     return true;

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -181,19 +181,22 @@ export class RequestResponseInfo {
     return isRedirectStatus(this.status);
   }
 
+  getRedirectUrl() {
+    try {
+      const headers = new Headers(this.getResponseHeadersDict());
+      const location = headers.get("location") || "";
+      return new URL(location, this.url).href;
+    } catch (e) {
+      return "";
+    }
+  }
+
   isSelfRedirect() {
     if (!this.isRedirectStatus()) {
       return false;
     }
 
-    try {
-      const headers = new Headers(this.getResponseHeadersDict());
-      const location = headers.get("location") || "";
-      const redirUrl = new URL(location, this.url).href;
-      return this.url === redirUrl;
-    } catch (e) {
-      return false;
-    }
+    return this.url === this.getRedirectUrl();
   }
 
   fillResponseReceivedExtraInfo(

--- a/tests/upload-wacz.test.js
+++ b/tests/upload-wacz.test.js
@@ -72,7 +72,7 @@ test("run crawl with upload", async () => {
   }
 
   // ensure bucket is public
-  execSync(`docker exec ${minioId.trim()} mc config host add local http://127.0.0.1:9000 minioadmin minioadmin`);
+  execSync(`docker exec ${minioId.trim()} mc alias set local http://127.0.0.1:9000 minioadmin minioadmin`);
   execSync(`docker exec ${minioId.trim()} mc anonymous set download local/test-bucket`);
 
   // wait for crawler to finish


### PR DESCRIPTION
If --saveStorage is set, localStorage and sessionStorage will be serialized with the WARC record for the page.
If a page redirects, track what the current page URL is and save storage as part of the page's WARC record.

Fixes #855 

Note: should this be an option or enabled by default?