### PR TITLE
profiles: use a fixed profile dir instead of creating a new temp dir on each load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -76,7 +76,11 @@ export class Browser {
   screenWHRatio: number;
 
   constructor() {
-    this.profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "profile-"));
+    this.profileDir = path.join(os.tmpdir(), "btrixProfile");
+    if (fs.existsSync(this.profileDir)) {
+      fs.rmSync(this.profileDir, { recursive: true, force: true });
+    }
+    fs.mkdirSync(this.profileDir);
 
     // must be provided, part of Dockerfile
     assert(process.env.GEOMETRY);


### PR DESCRIPTION
- Avoid accumulation of temp profile dirs if crawler is restarted multiple times, eg. if tmp dir is mapped to `/crawls` (as is in Browsertrix now), this prevents a proliferation of `/crawls/tmp/profile-*` dirs for each crawler restart.
- Since profile is loaded each time, clear out existing profile dir.
- bump to 1.6.4