### PR TITLE
url queueing: log skipped URLs as errors if depth === 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browsertrix-crawler",
-  "version": "1.7.0-beta.0",
+  "version": "1.7.0-beta.1",
   "main": "browsertrix-crawler",
   "type": "module",
   "repository": "https://github.com/webrecorder/browsertrix-crawler",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2459,25 +2459,35 @@ self.__bx_behaviors.selectMainBehavior();
       this.pageLimit,
     );
 
+    const logContext = depth === 0 ? "links" : "scope";
+    const logLevel = depth === 0 ? "error" : "debug";
+
     switch (result) {
       case QueueState.ADDED:
-        logger.debug("Queued new page url", { url, ...logDetails }, "links");
+        logger.logAsJSON(
+          "Queued new page url",
+          { url, ...logDetails },
+          logContext,
+          logLevel,
+        );
         return true;
 
       case QueueState.LIMIT_HIT:
-        logger.debug(
+        logger.logAsJSON(
           "Not queued page url, at page limit",
           { url, ...logDetails },
-          "links",
+          logContext,
+          logLevel,
         );
         this.limitHit = true;
         return false;
 
       case QueueState.DUPE_URL:
-        logger.debug(
+        logger.logAsJSON(
           "Not queued page url, already seen",
           { url, ...logDetails },
-          "links",
+          logContext,
+          logLevel,
         );
         return false;
     }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2459,7 +2459,7 @@ self.__bx_behaviors.selectMainBehavior();
       this.pageLimit,
     );
 
-    const logContext = depth === 0 ? "links" : "scope";
+    const logContext = depth === 0 ? "scope" : "links";
     const logLevel = depth === 0 ? "error" : "debug";
 
     switch (result) {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2464,12 +2464,7 @@ self.__bx_behaviors.selectMainBehavior();
 
     switch (result) {
       case QueueState.ADDED:
-        logger.logAsJSON(
-          "Queued new page url",
-          { url, ...logDetails },
-          logContext,
-          logLevel,
-        );
+        logger.debug("Queued new page url", { url, ...logDetails }, logContext);
         return true;
 
       case QueueState.LIMIT_HIT:

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2469,7 +2469,7 @@ self.__bx_behaviors.selectMainBehavior();
 
       case QueueState.LIMIT_HIT:
         logger.logAsJSON(
-          "Not queued page url, at page limit",
+          "Page url not queued, at page limit",
           { url, ...logDetails },
           logContext,
           logLevel,

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2479,7 +2479,7 @@ self.__bx_behaviors.selectMainBehavior();
 
       case QueueState.DUPE_URL:
         logger.logAsJSON(
-          "Not queued page url, already seen",
+          "Page url not queued, already seen",
           { url, ...logDetails },
           logContext,
           logLevel,

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -56,9 +56,12 @@ export const LOG_CONTEXT_TYPES = [
   "wacz",
   "replay",
   "proxy",
+  "scope",
 ] as const;
 
 export type LogContext = (typeof LOG_CONTEXT_TYPES)[number];
+
+export type LogLevel = "debug" | "info" | "warn" | "error" | "fatal";
 
 export const DEFAULT_EXCLUDE_LOG_CONTEXTS: LogContext[] = [
   "recorderNetwork",
@@ -118,7 +121,7 @@ class Logger {
     message: string,
     dataUnknown: unknown,
     context: LogContext,
-    logLevel = "info",
+    logLevel: LogLevel,
   ) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: Record<string, any> = formatErr(dataUnknown);
@@ -182,7 +185,7 @@ class Logger {
   }
 
   info(message: string, data: unknown = {}, context: LogContext = "general") {
-    this.logAsJSON(message, data, context);
+    this.logAsJSON(message, data, context, "info");
   }
 
   error(message: string, data: unknown = {}, context: LogContext = "general") {


### PR DESCRIPTION
- will ensure sees from URL list are reported as errors if skipped
- also set logging context to 'scope' instead of 'links'
- fixes #866