### PR TITLE
quickfix: WACZ upload retry support:

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1962,6 +1962,8 @@ self.__bx_behaviors.selectMainBehavior();
       logger.error("Error creating WACZ", e);
       if (!streaming) {
         logger.fatal("Unable to write WACZ successfully");
+      } else if (this.params.restartsOnError) {
+        await this.setStatusAndExit(ExitCodes.UploadFailed, "interrupted");
       }
     }
   }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -81,6 +81,7 @@ export enum ExitCodes {
   DiskUtilization = 16,
   Fatal = 17,
   ProxyError = 21,
+  UploadFailed = 22,
 }
 
 export enum InterruptReason {


### PR DESCRIPTION
- if a failure occurs on failed upload, and crawler restarts on error, exit with 'interrupt' to allow for automatic restart (eg. in Browsertrix app)
- otherwise, a failed upload will exit the crawl with no WACZ, resulting in overall crawl failure

### Testing
This is a bit tricky to test, but noticed at least one error in uploads in Browsertrix.

One way to test it is to
1) Add a `if (Math.random() > 0.5) { throw new Error("test"); }` within generateWACZ()
2) Run a crawl in Browsertrix, if the error condition is hit, error logs will be printed one or more times, but crawl will eventually succeed.