### PR TITLE
Don't trim to limit if limit is default of 0

### DIFF
--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -458,6 +458,10 @@ return inx;
   }
 
   async trimToLimit(limit: number) {
+    if (limit === 0) {
+      return;
+    }
+
     const totalComplete =
       (await this.numPending()) +
       (await this.numDone()) +


### PR DESCRIPTION
Fixes #872 

Fix for restarting crawl from saved state, where the default `--limit` value of 0 was incorrectly preventing any URLs from being re-queued.

## Testing instructions (problem)

1. Create a crawl from latest main branch of crawler with default limit
2. Interrupt the crawl early on
3. Restart crawl from saved state with `--config <FILE>`
4. Verify crawler exists with the queued pages from saved state not re-queued

## Testing instructions (fix)

1. Create a new crawl from this branch with default limit
2. Interrupt the crawl early on
3. Restart crawl from saved state with `--config <FILE>`
4. Verify crawler successfully re-queues pages and continues from where it left off