### PR TITLE
behavior logging: remove last line dupe check for behavior logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@novnc/novnc": "1.4.0",
     "@puppeteer/replay": "^3.1.1",
     "@webrecorder/wabac": "^2.23.8",
-    "browsertrix-behaviors": "^0.9.1",
+    "browsertrix-behaviors": "^0.9.2",
     "client-zip": "^2.4.5",
     "css-selector-parser": "^3.0.5",
     "fetch-socks": "^1.3.0",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -667,7 +667,6 @@ export class Crawler {
     pageUrl: string,
     workerid: WorkerId,
   ) {
-    let behaviorLine;
     let message;
     let details;
 
@@ -711,10 +710,9 @@ export class Crawler {
 
     switch (type) {
       case "info":
-        behaviorLine = JSON.stringify(data);
-        if (behaviorLine !== this.behaviorLastLine) {
+        if (message !== this.behaviorLastLine) {
           logger.info(message, details, context);
-          this.behaviorLastLine = behaviorLine;
+          this.behaviorLastLine = message;
         }
         break;
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -178,7 +178,6 @@ export class Crawler {
 
   customBehaviors = "";
   behaviorsChecked = false;
-  behaviorLastLine?: string;
 
   browser: Browser;
   storage: S3StorageSync | null = null;
@@ -710,10 +709,7 @@ export class Crawler {
 
     switch (type) {
       case "info":
-        if (message !== this.behaviorLastLine) {
-          logger.info(message, details, context);
-          this.behaviorLastLine = message;
-        }
+        logger.info(message, details, context);
         break;
 
       case "error":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,10 +1595,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.1"
 
-browsertrix-behaviors@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.9.1.tgz#55bf51e43ddd88b3261e5ca570019415542fa0cc"
-  integrity sha512-NcEcg0sQmKlIy4PesZa9Vr7HRmjCLGF7I278SamQE54WiHyNzKiRQnYVA2A/MloGoSM1mQQq/oPXQ0znx1gUXQ==
+browsertrix-behaviors@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.9.2.tgz#b5bee47d15014a05a873d8cc6ea8917bfa61d5c8"
+  integrity sha512-d7rLNKXaiD83S4uXKBUf2x9UzmMjbrqKoO820KVqzWtlpzqnXFUsqN/wKvMSiNbDzmL1+G9Um7Gwb1AjD0djCw==
   dependencies:
     query-selector-shadow-dom "^1.0.1"
 


### PR DESCRIPTION
Shouldn't skip multiple log messages, as this is unexpected behavior for user-defined behaviors.