### PR TITLE
feat: add extraChromeArgs support for passing custom Chrome flags

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -600,6 +600,11 @@ export class Crawler {
         args.push(`--accept-lang=${this.params.lang}`);
       }
     }
+
+    if (Array.isArray(this.params.extraChromeArgs) && this.params.extraChromeArgs.length > 0) {
+      args.push(...this.params.extraChromeArgs);
+    }
+
     return args;
   }
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -669,6 +669,13 @@ class ArgParser {
             "path to SSH known hosts file for SOCKS5 over SSH proxy connection",
           type: "string",
         },
+
+        extraChromeArgs: {
+          describe:
+            "Extra arguments to pass directly to the Chrome instance (space-separated or multiple --extraChromeArgs)",
+          type: "array",
+          default: [],
+        },
       });
   }
 


### PR DESCRIPTION
This change introduces a new CLI option --extraChromeArgs to Browsertrix Crawler, allowing users to pass arbitrary Chrome flags without modifying the codebase.

This approach is future-proof: any Chrome flag can be provided at runtime, avoiding the need for hard-coded allowlists.
Maintains backward compatibility: if no extraChromeArgs are passed, behavior remains unchanged.