### PR TITLE
feat: add extraChromeArgs support for passing custom Chrome flags

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -609,7 +609,7 @@ export class Crawler {
     const extra = this.params.extraChromeArgs;
     if (Array.isArray(extra) && extra.length > 0) {
       for (const v of extra) {
-        if (v !== undefined && v !== null && v !== "") {
+        if (v) {
           args.push(String(v));
         }
       }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -594,7 +594,7 @@ export class Crawler {
   }
 
   extraChromeArgs() {
-    const args = [];
+    const args: string[] = [];
     if (this.params.lang) {
       if (this.params.profile) {
         logger.warn(
@@ -605,6 +605,16 @@ export class Crawler {
         args.push(`--accept-lang=${this.params.lang}`);
       }
     }
+
+    const extra = this.params.extraChromeArgs;
+    if (Array.isArray(extra) && extra.length > 0) {
+      for (const v of extra) {
+        if (v !== undefined && v !== null && v !== "") {
+          args.push(String(v));
+        }
+      }
+    }
+
     return args;
   }
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -683,6 +683,13 @@ class ArgParser {
             "path to SSH known hosts file for SOCKS5 over SSH proxy connection",
           type: "string",
         },
+
+        extraChromeArgs: {
+          describe:
+            "Extra arguments to pass directly to the Chrome instance (space-separated or multiple --extraChromeArgs)",
+          type: "array",
+          default: [],
+        },
       });
   }
 


### PR DESCRIPTION
This change introduces a new CLI option --extraChromeArgs to Browsertrix Crawler, allowing users to pass arbitrary Chrome flags without modifying the codebase.

This approach is future-proof: any Chrome flag can be provided at runtime, avoiding the need for hard-coded allowlists.
Maintains backward compatibility: if no extraChromeArgs are passed, behavior remains unchanged.
