### PR TITLE
Add option to respect robots.txt disallows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "pixelmatch": "^5.3.0",
     "pngjs": "^7.0.0",
     "puppeteer-core": "^24.22.0",
+    "robots-parser": "^3.0.1",
     "sax": "^1.3.0",
     "sharp": "^0.32.6",
     "tsc": "^2.0.4",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1289,11 +1289,9 @@ self.__bx_behaviors.selectMainBehavior();
     url: string,
     logDetails: LogDetails,
   ): Promise<Robot | null> {
-    // Fetch robots.txt for url's host and return parser, caching robots
-    // bodies in Redis by their URL
-    // TODO: Consider using an LRU cache/only cache so many robots responses
-    // in Redis at one time and re-fetch if no longer in cache to avoid
-    // exhausting memory on very large crawls across many hosts
+    // Fetch robots.txt for url's host and return parser.
+    // Results are cached by robots.txt URL in Redis using an LRU cache
+    // implementation that retains the 100 most recently used values.
     const urlParser = new URL(url);
     const robotsUrl = `${urlParser.origin}/robots.txt`;
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -3,6 +3,8 @@ import path from "path";
 import fs, { WriteStream } from "fs";
 import os from "os";
 import fsp from "fs/promises";
+import { fetch as undiciFetch } from "undici";
+import robotsParser, { Robot } from "robots-parser";
 
 import {
   RedisCrawlState,
@@ -36,6 +38,7 @@ import { logger, formatErr, LogDetails, LogContext } from "./util/logger.js";
 import { WorkerState, closeWorkers, runWorkers } from "./util/worker.js";
 import { sleep, timedRun, secondsElapsed } from "./util/timing.js";
 import { collectCustomBehaviors, getInfoString } from "./util/file_reader.js";
+import { getProxyDispatcher } from "./util/proxy.js";
 
 import { Browser } from "./util/browser.js";
 
@@ -1249,6 +1252,98 @@ self.__bx_behaviors.selectMainBehavior();
     }
   }
 
+  async _fetchRobots(url: string) {
+    while (true) {
+      const resp = await undiciFetch(url, {
+        headers: this.headers,
+        dispatcher: getProxyDispatcher(url),
+      });
+
+      if (resp.ok) {
+        return resp;
+      }
+
+      const retry = resp.headers.get("retry-after");
+
+      if (retry) {
+        logger.debug(
+          "Robots.txt fetch: Retry after",
+          { url, retrySeconds: retry },
+          "robots",
+        );
+        await sleep(parseInt(retry));
+        continue;
+      }
+
+      logger.debug(
+        "Robots.txt not fetched",
+        { url, status: resp.status },
+        "robots",
+      );
+      return null;
+    }
+    return null;
+  }
+
+  async fetchAndParseRobots(
+    url: string,
+    logDetails: LogDetails,
+  ): Promise<Robot | null> {
+    // Fetch robots.txt for url's host and return parser, caching robots
+    // bodies in Redis by their URL
+    // TODO: Consider using an LRU cache/only cache so many robots responses
+    // in Redis at one time and re-fetch if no longer in cache to avoid
+    // exhausting memory on very large crawls across many hosts
+    const urlParser = new URL(url);
+    const robotsUrl = `${urlParser.origin}/robots.txt`;
+
+    const cachedRobots = await this.crawlState.getCachedRobots(robotsUrl);
+    if (cachedRobots) {
+      logger.debug(
+        "Using cached robots.txt body",
+        {
+          url: robotsUrl,
+          ...logDetails,
+        },
+        "robots",
+      );
+      return robotsParser(robotsUrl, cachedRobots);
+    }
+
+    try {
+      logger.debug(
+        "Fetching robots.txt",
+        { url: robotsUrl, ...logDetails },
+        "robots",
+      );
+      const resp = await this._fetchRobots(robotsUrl);
+      if (!resp) {
+        return null;
+      }
+      const content = await resp.text();
+
+      logger.debug(
+        "Caching robots.txt body",
+        { url: robotsUrl, ...logDetails },
+        "robots",
+      );
+      await this.crawlState.setCachedRobots(robotsUrl, content);
+
+      return robotsParser(robotsUrl, content);
+    } catch (e) {
+      // ignore
+    }
+    logger.warn(
+      "Failed to fetch robots.txt",
+      {
+        url: robotsUrl,
+        ...logDetails,
+      },
+      "robots",
+    );
+    return null;
+  }
+
   async awaitPageExtraDelay(opts: WorkerState) {
     if (this.params.pageExtraDelay) {
       const {
@@ -2460,6 +2555,18 @@ self.__bx_behaviors.selectMainBehavior();
   ) {
     if (this.limitHit) {
       return false;
+    }
+
+    if (this.params.robots) {
+      const robots = await this.fetchAndParseRobots(url, logDetails);
+      if (robots && robots.isDisallowed(url, "Browsertrix/1.0")) {
+        logger.debug(
+          "Page URL not queued, disallowed by robots.txt",
+          { url, ...logDetails },
+          "links",
+        );
+        return false;
+      }
     }
 
     const result = await this.crawlState.addToQueue(

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -683,6 +683,13 @@ class ArgParser {
             "path to SSH known hosts file for SOCKS5 over SSH proxy connection",
           type: "string",
         },
+
+        robots: {
+          describe:
+            "If set, fetch and respect page disallows specified in per-host robots.txt",
+          type: "boolean",
+          default: false,
+        },
       });
   }
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -41,6 +41,8 @@ export const FETCH_HEADERS_TIMEOUT_SECS = 30;
 export const PAGE_OP_TIMEOUT_SECS = 5;
 export const SITEMAP_INITIAL_FETCH_TIMEOUT_SECS = 30;
 
+export const ROBOTS_CACHE_LIMIT = 100;
+
 export type ExtractSelector = {
   selector: string;
   extract: string;

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -57,6 +57,7 @@ export const LOG_CONTEXT_TYPES = [
   "replay",
   "proxy",
   "scope",
+  "robots",
 ] as const;
 
 export type LogContext = (typeof LOG_CONTEXT_TYPES)[number];

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -200,7 +200,9 @@ export class RedisCrawlState {
   fkey: string;
   ekey: string;
   bkey: string;
+  rkey: string;
   pageskey: string;
+
   esKey: string;
   esMap: string;
 
@@ -233,6 +235,8 @@ export class RedisCrawlState {
     this.ekey = this.key + ":e";
     // crawler behavior script messages
     this.bkey = this.key + ":b";
+    // cached robots.txt bodies (per-origin)
+    this.rkey = this.key + ":r";
     // pages
     this.pageskey = this.key + ":pages";
 
@@ -1023,6 +1027,16 @@ return inx;
 
   async logBehavior(behaviorLog: string) {
     return await this.redis.lpush(this.bkey, behaviorLog);
+  }
+
+  async setCachedRobots(robotsUrl: string, body: string) {
+    const urlKey = `${this.rkey}:${robotsUrl}`;
+    return await this.redis.set(urlKey, body);
+  }
+
+  async getCachedRobots(robotsUrl: string) {
+    const urlKey = `${this.rkey}:${robotsUrl}`;
+    return await this.redis.get(urlKey);
   }
 
   async writeToPagesQueue(

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -1052,6 +1052,11 @@ return inx;
       const keysToDelete = await this.redis.zrange(this.lkey, 0, diff - 1);
 
       for (const keyToDelete of keysToDelete) {
+        logger.debug(
+          "Deleting cached robots.txt, over cache limit",
+          { url: keyToDelete },
+          "robots",
+        );
         await this.redis.del(`${this.rkey}:${keyToDelete}`);
         await this.redis.zrem(this.lkey, keyToDelete);
       }

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -3,7 +3,11 @@ import { v4 as uuidv4 } from "uuid";
 
 import { logger } from "./logger.js";
 
-import { MAX_DEPTH, DEFAULT_MAX_RETRIES } from "./constants.js";
+import {
+  MAX_DEPTH,
+  DEFAULT_MAX_RETRIES,
+  ROBOTS_CACHE_LIMIT,
+} from "./constants.js";
 import { ScopedSeed } from "./seeds.js";
 import { Frame } from "puppeteer-core";
 import { interpolateFilename } from "./storage.js";
@@ -201,6 +205,7 @@ export class RedisCrawlState {
   ekey: string;
   bkey: string;
   rkey: string;
+  lkey: string;
   pageskey: string;
 
   esKey: string;
@@ -237,6 +242,8 @@ export class RedisCrawlState {
     this.bkey = this.key + ":b";
     // cached robots.txt bodies (per-origin)
     this.rkey = this.key + ":r";
+    // LRU cache of robots.txt keys
+    this.lkey = this.key + ":l";
     // pages
     this.pageskey = this.key + ":pages";
 
@@ -1029,14 +1036,31 @@ return inx;
     return await this.redis.lpush(this.bkey, behaviorLog);
   }
 
+  async _updateRobotsAccessTime(robotsUrl: string) {
+    const accessTime = Date.now();
+    await this.redis.zadd(this.lkey, accessTime, robotsUrl);
+  }
+
   async setCachedRobots(robotsUrl: string, body: string) {
-    const urlKey = `${this.rkey}:${robotsUrl}`;
-    return await this.redis.set(urlKey, body);
+    await this._updateRobotsAccessTime(robotsUrl);
+    await this.redis.set(`${this.rkey}:${robotsUrl}`, body);
+
+    // prune least-recently used items in zset and robots cache if over limit
+    const cacheCount = await this.redis.zcard(this.lkey);
+    if (cacheCount > ROBOTS_CACHE_LIMIT) {
+      const diff = cacheCount - ROBOTS_CACHE_LIMIT;
+      const keysToDelete = await this.redis.zrange(this.lkey, 0, diff - 1);
+
+      for (const keyToDelete of keysToDelete) {
+        await this.redis.del(`${this.rkey}:${keyToDelete}`);
+        await this.redis.zrem(this.lkey, keyToDelete);
+      }
+    }
   }
 
   async getCachedRobots(robotsUrl: string) {
-    const urlKey = `${this.rkey}:${robotsUrl}`;
-    return await this.redis.get(urlKey);
+    await this._updateRobotsAccessTime(robotsUrl);
+    return await this.redis.get(`${this.rkey}:${robotsUrl}`);
   }
 
   async writeToPagesQueue(

--- a/tests/robots_txt.test.js
+++ b/tests/robots_txt.test.js
@@ -1,0 +1,35 @@
+import child_process from "child_process";
+
+test("test robots.txt is fetched and cached", async () => {
+  const res = child_process.execSync(
+    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://specs.webrecorder.net/ --url https://webrecorder.net/ --scopeType page --robots --logging debug",
+  );
+
+  const log = res.toString();
+
+  // robots.txt not found
+  expect(
+    log.indexOf(
+      '"logLevel":"debug","context":"robots","message":"Fetching robots.txt","details":{"url":"https://specs.webrecorder.net/robots.txt"}}',
+    ) > 0,
+  ).toBe(true);
+
+  expect(
+    log.indexOf(
+      '"logLevel":"debug","context":"robots","message":"Robots.txt not fetched","details":{"url":"https://specs.webrecorder.net/robots.txt","status":404}}',
+    ) > 0,
+  ).toBe(true);
+
+  // robots.txt found and cached
+  expect(
+    log.indexOf(
+      '"logLevel":"debug","context":"robots","message":"Fetching robots.txt","details":{"url":"https://webrecorder.net/robots.txt"}}',
+    ) > 0,
+  ).toBe(true);
+
+  expect(
+    log.indexOf(
+      '"logLevel":"debug","context":"robots","message":"Caching robots.txt body","details":{"url":"https://webrecorder.net/robots.txt"}}',
+    ) > 0,
+  ).toBe(true);
+});


### PR DESCRIPTION
Fixes #631 

This PR introduces a `--robots` CLI flag to the crawler. When enabled, the crawler will attempt to fetch robots.txt for each host encountered during crawling, and if found will check if pages are disallowed before adding them to the crawl queue.

Fetched robots.txt bodies are cached by their URL in Redis using an LRU cache mechanism which retains the 100 most recently accessed ones in the cache to prevent memory usage from getting out of control.

Robots.txt bodies are parsed and checked for page allow/disallow status using the https://github.com/samclarke/robots-parser library, which is the most active and well-maintained implementation I could find with TypeScript types.

I have added basic tests that check the log lines to ensure robots.txt is being fetched and cached, but **I haven't been able to find a robots.txt on a Webrecorder-managed domain with disallows to test that disallowed URLs are not actually queued.** Maybe we could set up a single disallow on our website's robots.txt for this purpose?

## Manual testing

1. In `util/constants.ts`, set `ROBOTS_CACHE_LIMIT` to 2
2. Re-build the crawler image and run a crawl across multiple hosts, with `--robots` and `--logging debug` enabled and a mixture of URLs that do and do not have a robots.txt specified, and for those that do, a mixture of URLs that will be allowed and disallowed, e.g.:

```sh
docker compose build
docker compose run crawler crawl --url https://forums.gentoo.org --url https://forums.gentoo.org/search.php --url https://forums.gentoo.org/statistics.php --url https://forums.gentoo.org/viewforum-f-33.html\?sid\=ed69503a6d2b866c8bcc28307f8e7d59 --url https://webrecorder.net/browsertrix --url https://webrecorder.net --url https://bl.uk --url https://bl.uk/collection --url https://bl.uk/visit --url https://www.kb.dk --url https://www.kb.dk/README.txt --url https://www.kb.dk/search/ --url https://www.kb.dk/en/find-materials --url https://bitarchivist.net --limit 20 --scopeType page --collection robots-cache --robots --generateWACZ --logging debug,errors
```
3. Inspect the crawl log for relevant messages with `robots` and `links` context. What should be present:

*Log lines for fetching and caching robots.txt*

```json
{"timestamp":"2025-09-30T14:45:03.888Z","logLevel":"debug","context":"robots","message":"Fetching robots.txt","details":{"url":"https://forums.gentoo.org/robots.txt"}}
{"timestamp":"2025-09-30T14:45:04.226Z","logLevel":"debug","context":"robots","message":"Caching robots.txt body","details":{"url":"https://forums.gentoo.org/robots.txt"}}
```
*Log lines for using cached robots.txt*

```json
"timestamp":"2025-09-30T14:45:04.234Z","logLevel":"debug","context":"robots","message":"Using cached robots.txt body","details":{"url":"https://forums.gentoo.org/robots.txt"}}
```

*Log lines for not queueing page URLs disallowed by robots*

```json
{"timestamp":"2025-09-30T14:45:04.235Z","logLevel":"debug","context":"links","message":"Page URL not queued, disallowed by robots.txt","details":{"url":"https://forums.gentoo.org/search.php"}}
```

*Log lines for deleting least-recently accessed cached robots.txt when over cache limit*

```json
{"timestamp":"2025-09-30T14:45:04.843Z","logLevel":"debug","context":"robots","message":"Deleting cached robots.txt, over cache limit","details":{"url":"https://forums.gentoo.org/robots.txt"}}
```

*Log lines for hosts where robots.txt cannot be found or fetched*

```json
{"timestamp":"2025-09-30T14:45:05.619Z","logLevel":"debug","context":"robots","message":"Robots.txt not fetched","details":{"url":"https://bitarchivist.net/robots.txt","status":404}}
```