### PR TITLE
flow behaviors: add scrolling into view

### DIFF
--- a/src/util/flowbehavior.ts
+++ b/src/util/flowbehavior.ts
@@ -368,7 +368,7 @@ class Flow {
       case StepType.DoubleClick:
         await locator(step)
           .setTimeout(timeout * 1000)
-          //.on('action', () => startWaitingForEvents())
+          .setEnsureElementIsInTheViewport(true)
           .click({
             count: 2,
             button: step.button && mouseButtonMap.get(step.button),
@@ -392,7 +392,7 @@ class Flow {
 
         await locator(step)
           .setTimeout(timeout * 1000)
-          //.on('action', () => startWaitingForEvents())
+          .setEnsureElementIsInTheViewport(true)
           .click({
             delay: step.duration,
             button: step.button && mouseButtonMap.get(step.button),
@@ -410,7 +410,7 @@ class Flow {
       case StepType.Hover:
         await locator(step)
           .setTimeout(timeout * 1000)
-          //.on('action', () => startWaitingForEvents())
+          .setEnsureElementIsInTheViewport(true)
           .hover();
         break;
 
@@ -426,15 +426,14 @@ class Flow {
 
       case StepType.Change:
         await locator(step)
-          //.on('action', () => startWaitingForEvents())
           .setTimeout(timeout * 1000)
+          .setEnsureElementIsInTheViewport(true)
           .fill(step.value);
         break;
 
       case StepType.Scroll: {
         if ("selectors" in step) {
           await locator(step)
-            //.on('action', () => startWaitingForEvents())
             .setTimeout(timeout * 1000)
             .scroll({
               scrollLeft: step.x || 0,

--- a/tests/custom_selector.test.js
+++ b/tests/custom_selector.test.js
@@ -43,8 +43,8 @@ test("test custom selector crawls JS files as pages", async () => {
   ]);
 
   const expectedExtraPages = new Set([
-    "https://www.iana.org/_js/jquery.js",
-    "https://www.iana.org/_js/iana.js",
+    "https://www.iana.org/static/_js/jquery.js",
+    "https://www.iana.org/static/_js/iana.js",
   ]);
 
   expect(pages).toEqual(expectedPages);


### PR DESCRIPTION
Some page elements don't quite respond correctly if the element is not in view, so should add the setEnsureElementIsInTheViewport() to click, doubleclick, hover and change step locators.

Testing:
- This happens on the https://illuminateduniverse.org/ behavior at: https://github.com/webrecorder/custom-behaviors/blob/main/flow-behaviors/illuminated-universe/illuminated-universe.json
Without this change, the Older posts button stops being loaded, as the page is too far. This scrolls the page to each successive Older posts button.