### PR TITLE
Profile Saving Improvements

### DIFF
--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -339,7 +339,11 @@ async function createProfile(
   cdp: CDPSession,
   targetFilename = "",
 ) {
-  await cdp.send("Network.clearBrowserCache");
+  try {
+    await cdp.send("Network.clearBrowserCache");
+  } catch (e) {
+    logger.warn("Error clearing cache", e, "browser");
+  }
 
   await browser.close();
 

--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -546,7 +546,8 @@ class InteractiveBrowser {
         return;
       }
 
-      const cookies = await this.browser.getCookies(this.page);
+      const cookies = await this.browser.getCookies();
+
       for (const cookieOrig of cookies) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const cookie = cookieOrig as any;

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -616,14 +616,14 @@ export class Browser {
     await page.setViewport(params);
   }
 
-  async getCookies(page: Page) {
-    return await page.cookies();
+  async getCookies() {
+    return (await this.browser?.cookies()) || [];
   }
 
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async setCookies(page: Page, cookies: any) {
-    return await page.setCookie(...cookies);
+    return await this.browser?.setCookie(...cookies);
   }
 }
 

--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -153,13 +153,6 @@ export async function initProxy(
     privateKeyFile = privateKeyFile || sshProxyPrivateKeyFile;
     publicHostsFile = publicHostsFile || sshProxyKnownHostsFile;
 
-    logger.debug("Initing proxy", {
-      url: getSafeProxyString(proxyUrl),
-      localPort,
-      privateKeyFile,
-      publicHostsFile,
-    });
-
     const entry = await initSingleProxy(
       proxyUrl,
       localPort++,
@@ -200,6 +193,13 @@ export async function initSingleProxy(
   sshProxyPrivateKeyFile?: string,
   sshProxyKnownHostsFile?: string,
 ): Promise<{ proxyUrl: string; dispatcher: Dispatcher }> {
+  logger.debug("Initing proxy", {
+    url: getSafeProxyString(proxyUrl),
+    localPort,
+    sshProxyPrivateKeyFile,
+    sshProxyKnownHostsFile,
+  });
+
   if (proxyUrl && proxyUrl.startsWith("ssh://")) {
     proxyUrl = await runSSHD(
       proxyUrl,


### PR DESCRIPTION
fix some observed errors that occur when saving profile:
- use browser.cookies instead of page.cookies to get all cookies, not just from page
- catch exception when clearing cache and ignore
- logging: log when proxy init is happening on all paths, in case error in proxy connection