### PR TITLE
dismiss js dialog popups

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -854,7 +854,7 @@ self.__bx_behaviors.selectMainBehavior();
 
     // Handle JS dialogs:
     // - Ensure off-page navigation is canceled while behavior is running
-    // - accept close all other dialogs if not blocking unload
+    // - dismiss close all other dialogs if not blocking unload
     page.on("dialog", async (dialog) => {
       let accepted = true;
       if (dialog.type() === "beforeunload") {
@@ -865,8 +865,8 @@ self.__bx_behaviors.selectMainBehavior();
           await dialog.accept();
         }
       } else {
-        // other JS dialog, just accept
-        await dialog.accept();
+        // other JS dialog, just dismiss
+        await dialog.dismiss();
       }
       logger.debug("JS Dialog", {
         accepted,


### PR DESCRIPTION
move the JS dialog handler to not be only for autoclick, dismiss all JS dialogs (alert(), prompt()) to avoid blocking page
fixes #891