### PR TITLE
profiles: add singleton lock removal on startup to avoid any issues

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -230,6 +230,7 @@ export class Browser {
         child_process.execSync("tar xvfz " + profileFilename, {
           cwd: this.profileDir,
         });
+        this.removeSingletons();
         return true;
       } catch (e) {
         logger.error(`Profile filename ${profileFilename} not a valid tar.gz`);
@@ -237,6 +238,16 @@ export class Browser {
     }
 
     return false;
+  }
+
+  removeSingletons() {
+    try {
+      child_process.execSync("rm ./Singleton*", {
+        cwd: this.profileDir,
+      });
+    } catch (e) {
+      // ignore
+    }
   }
 
   async saveProfile(


### PR DESCRIPTION
If the SingletonLock (and SingletonPort, SingletonSocket) files somehow made it into the profile, the browser will refuse to start. This will ensure that it is cleared.
(Could also do it before saving it as well, but this will catch it for any existing profiles).