### PR TITLE
deps: update to browsertrix-behaviors 0.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@novnc/novnc": "1.4.0",
     "@puppeteer/replay": "^3.1.3",
     "@webrecorder/wabac": "^2.24.1",
-    "browsertrix-behaviors": "^0.9.2",
+    "browsertrix-behaviors": "^0.9.4",
     "client-zip": "^2.4.5",
     "css-selector-parser": "^3.0.5",
     "fetch-socks": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1594,10 +1594,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.1"
 
-browsertrix-behaviors@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.9.2.tgz#b5bee47d15014a05a873d8cc6ea8917bfa61d5c8"
-  integrity sha512-d7rLNKXaiD83S4uXKBUf2x9UzmMjbrqKoO820KVqzWtlpzqnXFUsqN/wKvMSiNbDzmL1+G9Um7Gwb1AjD0djCw==
+browsertrix-behaviors@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.9.4.tgz#58759631372b6532630d706d48a54ae83b885088"
+  integrity sha512-Dh6rxjGyXvXOIUGjxYMyyddq6WclIgCX/D/41TrTL7ZbxcHwh7UNSKVtXXIQ+KyJTHUyJ1qwMmLIOM7PztWYFw==
   dependencies:
     query-selector-shadow-dom "^1.0.1"
 


### PR DESCRIPTION
Includes fixes for autoclick behavior:
- able to click on svgs
- don't navgiate back if click did not result in history stack change