### PR TITLE
fix: Skip proxy for seed file downloads in Self-Hosting environments

### DIFF
--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -40,8 +40,9 @@ async function writeUrlContentsToFile(
   url: string,
   pathPrefix: string,
   pathDefaultExt: string,
+  useProxy: boolean = false,
 ) {
-  const res = await fetch(url, { dispatcher: getProxyDispatcher(url) });
+  const res = await fetch(url, { dispatcher: useProxy ? getProxyDispatcher(url) : undefined });
   const fileContents = await res.text();
 
   const filename =


### PR DESCRIPTION
When proxy is enabled in Self-Hosting deployments, seed file downloads may fail if the seed file URL is hosted on the internal network or local server. This change ensures that seed file downloads bypass the proxy configuration and connect directly to the source.

The proxy configuration (as documented in
https://docs.browsertrix.com/deploy/proxies/) is designed for crawling traffic, not for downloading seed files which are typically accessed from internal or local resources during the crawl initialization phase.

Changes:
- Modified collectOnlineSeedFile() to pass useProxy=false when downloading seed files from URLs
- Seed file downloads now use direct connection instead of proxy