### PR TITLE
Fix directory path in user guide for WACZ file

### DIFF
--- a/docs/docs/user-guide/index.md
+++ b/docs/docs/user-guide/index.md
@@ -14,7 +14,7 @@ the following commands. Replace `[URL]` with the website you'd like to crawl.
 1. Run `docker pull webrecorder/browsertrix-crawler`
 2. `docker run -v $PWD/crawls:/crawls/ -it webrecorder/browsertrix-crawler crawl --url [URL] --generateWACZ --text --collection test`
 3. The crawl will now run and logs in [JSON Lines](https://jsonlines.org/) format will be output to the console. Depending on the size of the site, this may take a bit!
-4. Once the crawl is finished, a WACZ file will be created in `crawls/collection/test/test.wacz` from the directory you ran the crawl!
+4. Once the crawl is finished, a WACZ file will be created in `crawls/collections/test/test.wacz` from the directory you ran the crawl!
 5. You can go to [ReplayWeb.page](https://replayweb.page) and open the generated WACZ file and browse your newly crawled archive!
 
 ## Getting Started with Command-Line Options


### PR DESCRIPTION
I found that the directory path in the user guide for the WACZ file is wrong. It should be `crawls/collections/test/test.wacz`.