### PR TITLE
crash page on prompt dialog loop to continue:

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -47,6 +47,7 @@ import {
   ExitCodes,
   InterruptReason,
   BxFunctionBindings,
+  MAX_JS_DIALOG_PER_PAGE,
 } from "./util/constants.js";
 
 import { AdBlockRules, BlockRuleDecl, BlockRules } from "./util/blockrules.js";
@@ -890,9 +891,9 @@ self.__bx_behaviors.selectMainBehavior();
         } else {
           // other JS dialog, just dismiss
           accepted = false;
-          if (dialogCount >= 10) {
-            // dialog likely in a loop, just ignore
-            logger.warn(
+          if (dialogCount >= MAX_JS_DIALOG_PER_PAGE) {
+            // dialog likely in a loop, need to crash page to avoid being stuck
+            logger.error(
               "JS Dialog appears to be in a loop, crashing page to continue",
             );
             await cdp.send("Page.crash");

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -43,6 +43,9 @@ export const SITEMAP_INITIAL_FETCH_TIMEOUT_SECS = 30;
 
 export const ROBOTS_CACHE_LIMIT = 100;
 
+// max JS dialogs (alert/prompt) to allow per page
+export const MAX_JS_DIALOG_PER_PAGE = 10;
+
 export type ExtractSelector = {
   selector: string;
   extract: string;


### PR DESCRIPTION
- if a page is stuck in a window.alert / window.prompt loop, showing >10 or more consecutive dialogs (unrelated to unloading), call Page.crash() to more quickly move on to next page, as not much else can be done.
- add exception handling in dialog accept/dismiss to avoid crawler crash
- fixes #926

Tests:
- Can test with attempting to crawl: https://stadlparty.at/ which has such a loop.