### PR TITLE
better handling of net::ERR_HTTP_RESPONSE_CODE_FAILURE:

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -464,6 +464,16 @@ export class Recorder extends EventEmitter {
         }
         break;
 
+      case "net::ERR_HTTP_RESPONSE_CODE_FAILURE":
+        logger.warn("Recording empty non-200 status response", {
+          url,
+          status: reqresp.status,
+          errorText,
+          type,
+          ...this.logDetails,
+        });
+        return this.serializeToWARC(reqresp);
+
       default:
         this.lastErrorText = errorText;
         logger.warn(

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -89,6 +89,8 @@ export class PageState {
 
   skipBehaviors = false;
   pageSkipped = false;
+  noRetries = false;
+
   asyncLoading = false;
   filteredFrames: Frame[] = [];
   loadState: LoadState = LoadState.FAILED;


### PR DESCRIPTION
Fixes #789 

- http headers provided but no payload, record response
- record page as failed with status code provided, don't attempt to retry

Note: It's hard to set up a test case, as I think it only returns this for HTTP/2, but one example of this on an external site is:
https://www.cityofevanston.org/assets/PD%20Agenda%2010-22-12%20finalr.pdf

Without this fix, the URL is retried multiple times, even though it's a 404 with no response body. This just stores the 404 with empty response body and continues.