### PR TITLE
follow-up to #915, add --allow-brave-component-update flag

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -777,7 +777,8 @@ export const defaultArgs = [
   "--disable-breakpad",
   "--disable-client-side-phishing-detection",
   "--disable-component-extensions-with-background-pages",
-  //"--disable-component-update", // now required for chrome/brave
+  "--disable-component-update",
+  "--allow-brave-component-update", // disable general update, but allow brave update
   "--no-default-browser-check",
   "--disable-default-apps",
   "--disable-dev-shm-usage",


### PR DESCRIPTION
can still disable most other component updates, but enable brave components, including shields, based on:
https://github.com/webrecorder/browsertrix-crawler/pull/915#issuecomment-3689772878
