### PR TITLE
Update Puppeteer mobile device descriptor URL

### DIFF
--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -122,8 +122,8 @@ Options:
                                             d()    [string] [default: "/crawls"]
       --mobileDevice                        Emulate mobile device by name from:
                                             https://github.com/puppeteer/puppete
-                                            er/blob/main/src/common/DeviceDescri
-                                            ptors.ts                    [string]
+                                            er/blob/main/packages/puppeteer-core
+                                            /src/common/Device.ts       [string]
       --userAgent                           Override user-agent with specified s
                                             tring                       [string]
       --userAgentSuffix                     Append suffix to existing browser us

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -326,7 +326,7 @@ class ArgParser {
 
         mobileDevice: {
           describe:
-            "Emulate mobile device by name from: https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts",
+            "Emulate mobile device by name from: https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/common/Device.ts",
           type: "string",
         },
 


### PR DESCRIPTION
The previous URL no longer exists, Puppeteer has reorganized their code it seems.