### PR TITLE
Apply pageExtraDelay after successful direct fetch

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1154,6 +1154,7 @@ self.__bx_behaviors.selectMainBehavior();
           "fetch",
         );
       } else {
+        await this.awaitPageExtraDelay(opts);
         return;
       }
     }


### PR DESCRIPTION
fixes #957

also apply page extra delay when if direct fetch succeeded to enforce consistent rate limiting