### PR TITLE
fix issues related to profile directory placed in /profile:

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -218,7 +218,7 @@ export class Browser {
       await this.loadProfile(profileUrl, tmpProfileDest, tmpProfileDir);
 
       // replace old profile dir with new profile dir
-      await replaceDir(tmpProfileDir, this.profileDir, exists);
+      await replaceDir(tmpProfileDir, this.profileDir);
 
       // replace old tarball with new tarball
       await fsp.rename(tmpProfileDest, profileTarGz);

--- a/src/util/file_reader.ts
+++ b/src/util/file_reader.ts
@@ -33,16 +33,16 @@ async function getTempFile(
   );
 }
 
-export async function replaceDir(
-  sourceDir: string,
-  destDir: string,
-  exists: boolean,
-) {
+export async function replaceDir(sourceDir: string, destDir: string) {
+  // remove destDir if it exists
+  try {
+    await fsp.rm(destDir, { force: true, recursive: true });
+  } catch (e) {
+    // ignore
+  }
+
   // Move new dir to new location
   try {
-    if (exists) {
-      await fsp.rm(destDir, { force: true, recursive: true });
-    }
     //await exec(`mv ${sourceDir} ${destDir}`);
     await fsp.rename(sourceDir, destDir);
   } catch (e) {
@@ -218,7 +218,7 @@ async function collectGitBehaviors(
     }
   }
 
-  await replaceDir(pathToCollect, behaviorsDir, exists);
+  await replaceDir(pathToCollect, behaviorsDir);
 
   // remove the rest of the repo that we're not using
   if (relPath) {

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -337,7 +337,7 @@ export class RequestResponseInfo {
   }
 
   isCached() {
-    return this.fromCache && !this.payload;
+    return (this.fromCache && !this.payload) || this.status === 304;
   }
 
   deleteRange() {
@@ -369,7 +369,7 @@ export class RequestResponseInfo {
       );
       const contentRange = headers.get(CONTENT_RANGE);
       if (contentRange !== `bytes 0-${contentLength - 1}/${contentLength}`) {
-        return false;
+        return true;
       }
     }
 


### PR DESCRIPTION
- always attempt to delete existing profile dir before moving new one in its place, fixes #968
- treat 304 (eg. if recrawling with existing profile) as cached resource, don't attempt to write/check size
- fix typo in shouldSkipSave() for incomplete 206 responses