### PR TITLE
Add OpenContainers labels to Dockerfile to support Dependabot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ ARG BROWSER_IMAGE_BASE=webrecorder/browsertrix-browser-base:brave-${BROWSER_VERS
 
 FROM ${BROWSER_IMAGE_BASE}
 
+LABEL org.opencontainers.image.vendor="Webrecorder <https://webrecorder.net/>"
+LABEL org.opencontainers.image.source="https://github.com/webrecorder/browsertrix-crawler"
+LABEL org.opencontainers.image.documentation="https://crawler.docs.browsertrix.com/"
+LABEL org.opencontainers.image.licenses="AGPL-3.0-or-later"
+
 # needed to add args to main build stage
 ARG BROWSER_VERSION
 


### PR DESCRIPTION
I recently made some changes to how I depend on Browsertrix Crawler’s Docker image (through a slightly customized Dockerfile) that had the nice side-effect of Dependabot being able to provide automated updates. However, those updates come with no release notes or other information (integrating those right in the PR description is, IMO, one of Dependabot’s nicest features):

<img width="788" height="291" alt="Screenshot of Dependabot PR to update Browsertrix Crawler that is missing release notes" src="https://github.com/user-attachments/assets/654ee883-bc07-406d-8070-1032b1967a71" />

It turns out that [Dependabot](https://github.blog/changelog/2023-04-13-dependabot-now-supports-fetching-release-notes-and-changelogs-for-docker-images/), [Renovate](https://docs.renovatebot.com/modules/datasource/docker/), etc. find this info by following the `org.opencontainers.image.source` label in an image, so this PR adds that. While I was at it, I figured I’d throw in a few other [standardized OCI labels](https://specs.opencontainers.org/image-spec/annotations/) that seemed obvious, although there might be others you want to add!