### PR TITLE
fix regression where behaviors are run prematurely in new pages due to remaining 'framenavigated' listener

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1275,9 +1275,6 @@ self.__bx_behaviors.selectMainBehavior();
           true,
         );
 
-        // in case runBehaviors() times out, remove all listeners here
-        page.removeAllListeners("framenavigated");
-
         data.contentCheckAllowed = false;
 
         await this.netIdle(page, logDetails);

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -138,6 +138,8 @@ export class PageWorker {
         { reuseCount: this.reuseCount, ...this.logDetails },
         "worker",
       );
+      // remove any frame listeners added in behaviors and page timed out and didn't remove them before
+      this.page!.removeAllListeners("framenavigated");
       this.opts!.data = pagestate;
       return this.opts!;
     } else if (this.page) {


### PR DESCRIPTION
- regression caused by detecting new iframes while behaviors are running, added in #964
- stop running behaviors in new iframes after behavior run has finished
- use page.off() and also page.removeAllListeners() even if runBehaviors() times out
- caused behaviors to scroll too early, also affecting QA tests

Testing:
Run: `docker run -p 9037:9037 -it webrecorder/browsertrix-crawler crawl --url https://old.webrecorder.net/ --screencastPort 9037  --postLoadDelay 10 --screenshot view --limit 5`
Observe in screencast that second page has already scrolled down after while waiting for the 10 seconds after load, before behaviors have run. With this fix, that does not happen.