### PR TITLE
rollover test: expect at least 5 WACZs, not 6, 

### DIFF
--- a/tests/rollover-writer.test.js
+++ b/tests/rollover-writer.test.js
@@ -19,8 +19,8 @@ test("set rollover to 500K and ensure individual WARCs rollover, including scree
     }
   }
 
-  // expect at least 6 main WARCs
-  expect(main).toBeGreaterThan(5);
+  // expect at least 5 main WARCs
+  expect(main).toBeGreaterThan(4);
 
   // expect at least 2 screenshot WARCs
   expect(screenshots).toBeGreaterThan(1);


### PR DESCRIPTION
with rollover fix in #974, which avoids an empty WACZ from being created, there may only be 5 WACZs with the test