### PR TITLE
redis config tweaks:

### DIFF
--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -5,7 +5,7 @@ import { formatErr, logger } from "./util/logger.js";
 import { getFileOrUrlJson, getInfoString } from "./util/file_reader.js";
 import { WACZLoader } from "./util/wacz.js";
 import { ExitCodes } from "./util/constants.js";
-import { initRedisWaitForSuccess } from "./util/redis.js";
+import { initRedisWaitForSuccess, setExitOnRedisError } from "./util/redis.js";
 import { RedisDedupeIndex } from "./util/state.js";
 import { basename } from "node:path";
 import { Readable } from "node:stream";
@@ -352,6 +352,8 @@ export class CrawlIndexer {
   handleInterrupt(signame: string) {
     logger.info(`Got signal ${signame}, interrupting after this file`);
     this.interrupted = true;
+    // if redis no longer available, interrupt immediately as well
+    setExitOnRedisError();
   }
 }
 

--- a/src/util/redis.ts
+++ b/src/util/redis.ts
@@ -30,7 +30,10 @@ console.error = function (...args) {
 };
 
 export async function initRedis(url: string) {
-  const redis = new Redis(url, { lazyConnect: true });
+  const redis = new Redis(url, {
+    lazyConnect: true,
+    maxRetriesPerRequest: null,
+  });
   await redis.connect();
   return redis;
 }


### PR DESCRIPTION
- indexer: after receiving an interrupt signal, set setExitOnRedisError() to ensure immediate exit on redis errors, as likely shutting down. similar behavior to main crawler
- redis config: set 'maxRetriesPerRequest: null' to ensure each redis command is retried indefinitely before continuing, instead of only 20 times, to avoid data loss. Will still abort immediately in case setExitOnRedisError() is set. This applies to both indexer and crawling.