### PR TITLE
make sure direct-fetched pages are not double-counted:

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1319,16 +1319,7 @@ self.__bx_behaviors.selectMainBehavior();
     }
   }
 
-  async pageFinished(
-    data: PageState,
-    lastErrorText = "",
-    fromDirectFetch = false,
-  ) {
-    // allow only direct fetched, or only regular pages depending on where
-    // this is called from
-    if (fromDirectFetch !== data.directFetch) {
-      return;
-    }
+  async pageFinished(data: PageState, lastErrorText = "") {
     // if page loaded, considered page finished successfully
     // (even if behaviors timed out)
     const { loadState, logDetails, depth, url, pageSkipped, noRetries } = data;

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1464,7 +1464,7 @@ export class Recorder extends EventEmitter {
       return false;
     }
     if (!this.stopping) {
-      state.directFetch = true;
+      state.isDirectFetched = true;
       void this.asyncFetchQ.add(() => fetcher.loadDirectPage(state, crawler));
     }
     return true;
@@ -2122,7 +2122,7 @@ class AsyncFetcher {
         "fetch",
       );
     }
-    await crawler.pageFinished(state, undefined, true);
+    await crawler.pageFinished(state);
   }
 }
 

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -98,7 +98,8 @@ export class PageState {
   pageSkipped = false;
   noRetries = false;
 
-  directFetch = false;
+  isDirectFetched = false;
+
   filteredFrames: Frame[] = [];
   loadState: LoadState = LoadState.FAILED;
   contentCheckAllowed = false;

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -313,13 +313,15 @@ export class PageWorker {
         );
       }
 
-      await timedRun(
-        this.crawler.pageFinished(data, this.recorder?.lastErrorText),
-        FINISHED_TIMEOUT,
-        "Page Finished Timed Out",
-        this.logDetails,
-        "worker",
-      );
+      if (!data.isDirectFetched) {
+        await timedRun(
+          this.crawler.pageFinished(data, this.recorder?.lastErrorText),
+          FINISHED_TIMEOUT,
+          "Page Finished Timed Out",
+          this.logDetails,
+          "worker",
+        );
+      }
     }
   }
 


### PR DESCRIPTION
- track 'directFetch' bool, not async loading on the state
- call pageFinished() when direct fetch is finished
- add check in pageFinished() to allow fromDirectFetch or regular page finished
- don't reset the directFetch bool after calling pageFinished
- fixes #995