### PR TITLE
Added extended auto-QA features

### DIFF
--- a/docs/docs/user-guide/qa.md
+++ b/docs/docs/user-guide/qa.md
@@ -78,3 +78,61 @@ This data indicates that:
 - When comparing `urn:view:<url>` records for crawl and replay, the screenshots are 95% similar.
 - When comparing `urn:text:<url>` records from crawl and replay WACZs, the text is 90% similar.
 - When comparing `urn:pageinfo:<url>` resource entries from crawl and replay, the crawl record had 10 good responses (2xx/3xx status code) and 0 bad responses (4xx/5xx status code), while replay had 9 good and 1 bad.
+
+## QA Policies and Additional Options
+
+A few additional options and policies exist in order to fine-tune the QA process. These are:
+
+  1. The ability to set a maximum page count for the QA,
+  2. The ability to choose between 3 different QA algorithms.
+  
+These algorithms are: *linear* (first come first serve), *regex* (define a regular expression to perform QA only on URLs that match it), and *random* (define a probability for each page to be QA'd).
+
+You can use the following CLI arguments for this:
+
+  - `qaMaxUrls`: the maximum number of pages to perform QA on,
+  - `qaPolicy`: can be one of `linear`, `regex` or `random`,
+  - `qaRegex`: if `qaPolicy` is `regex`, then you can define your regular expression here,
+  - `qaProbability`: if `qaPolicy` is `random`, you can define your per-page QA probability here. This is a floating-point number between 0 and 1.
+  
+### QA Policy: `linear`
+
+In this QA mode, the first `qaMaxUrls` pages in the `pages.jsonl` file(s) will be scanned. Example:
+
+    --qaPolicy "linear" --qaMaxUrls 50"
+    
+### QA Policy: `regex`
+
+In this QA mode, only the pages that match the regular expression in `qaRegex` will be scanned. Example:
+
+    --qaPolicy "regex" --qaRegex='^https:\/\/en\.wikipedia\.org\/wiki\/R.*$' --qaMaxUrls 50"
+    
+This will match all english Wikipedia articles that start with `R`.
+
+### QA policy: `random`
+
+In this QA mode, pages will be scanned with a probability equal to `qaProbability`. This is a floating-point number between `0` and `1`. Example:
+
+    --qaPolicy "random" --qaProbability 0.3 --qaMaxUrls 50"
+    
+This policy allows to get a good overall impression of a harvest by scanning a random sample of it.
+    
+### Maximum number of pages to scan
+
+In every case mentioned above, the number of pages that will be queued for scanning will be at most `qaMaxUrls`.
+
+## Usage with the Browsertrix UI
+
+You can easily use these features with Browsertrix UI (formerly *Browsertrix Cloud*) in the following manner:
+
+  1. Compile the crawler as usual,
+  2. Tag it as you wish and push it to local registry,
+  3. Adapt the `crawler_channels` in your deployment's `local-config.yaml` file so that it points to the crawler in your registry,
+  4. Add your QA policy and other parameters to the `crawler_extra_args` variable,
+  5. (optional) Clear your Kubernetes/microk8s cache with `microk8s ctr images rm localhost:32000/<your-crawler-image>`
+  6. Reload your deployment.
+
+Now whenever you will start a new QA workflow from the Browsertrix Cloud interface, the crawler instance that will be spawned will already be running the new QA workflow with your specified parameters.
+
+
+

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -17,6 +17,7 @@ import { CrawlerArgs, parseArgs } from "./util/argParser.js";
 import yaml from "js-yaml";
 
 import { WACZ, WACZInitOpts, mergeCDXJ } from "./util/wacz.js";
+import Redis from 'ioredis';
 
 import { HealthChecker } from "./util/healthcheck.js";
 import { TextExtractViaSnapshot } from "./util/textextract.js";
@@ -187,6 +188,8 @@ export class Crawler {
 
   proxyServer?: string;
   proxyPacUrl?: string;
+  
+  redis: Redis | null = null;
 
   driver:
     | ((opts: {
@@ -349,7 +352,7 @@ export class Crawler {
       );
     }
 
-    const redis = await initRedisWaitForSuccess(redisUrl);
+    this.redis = await initRedisWaitForSuccess(redisUrl);
 
     logger.debug(
       `Storing state via Redis ${redisUrl} @ key prefix "${this.crawlId}"`,
@@ -357,7 +360,7 @@ export class Crawler {
       "state",
     );
 
-    let dedupeRedis = redis;
+    let dedupeRedis = this.redis;
 
     if (redisUrl !== dedupeRedisUrl) {
       dedupeRedis = await initRedisWaitForSuccess(dedupeRedisUrl);
@@ -366,7 +369,7 @@ export class Crawler {
     logger.debug(`Max Page Time: ${this.maxPageTime} seconds`, {}, "state");
 
     this.crawlState = new RedisCrawlState(
-      redis,
+      this.redis,
       this.crawlId,
       this.maxPageTime,
       os.hostname(),
@@ -472,6 +475,13 @@ export class Crawler {
       detached: RUN_DETACHED,
     });
   }
+  
+  protected getRedis(): Redis {
+      if (!this.redis) {
+        throw new Error("Redis not initialized");
+      }
+      return this.redis;
+    }
 
   async bootstrap() {
     if (await isDiskFull(this.params.cwd)) {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -18,7 +18,7 @@ import { CrawlerArgs, parseArgs } from "./util/argParser.js";
 import yaml from "js-yaml";
 
 import { WACZ, WACZInitOpts, mergeCDXJ } from "./util/wacz.js";
-import Redis from 'ioredis';
+import Redis from "ioredis";
 
 import { HealthChecker } from "./util/healthcheck.js";
 import { TextExtractViaSnapshot } from "./util/textextract.js";
@@ -200,7 +200,7 @@ export class Crawler {
 
   proxyServer?: string;
   proxyPacUrl?: string;
-  
+
   redis: Redis | null = null;
 
   driver:
@@ -510,13 +510,13 @@ export class Crawler {
       detached: RUN_DETACHED,
     });
   }
-  
+
   protected getRedis(): Redis {
-      if (!this.redis) {
-        throw new Error("Redis not initialized");
-      }
-      return this.redis;
+    if (!this.redis) {
+      throw new Error("Redis not initialized");
     }
+    return this.redis;
+  }
 
   async bootstrap() {
     // check first before disk space check, in case this clears up disk space

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -18,6 +18,7 @@ import { CrawlerArgs, parseArgs } from "./util/argParser.js";
 import yaml from "js-yaml";
 
 import { WACZ, WACZInitOpts, mergeCDXJ } from "./util/wacz.js";
+import Redis from 'ioredis';
 
 import { HealthChecker } from "./util/healthcheck.js";
 import { TextExtractViaSnapshot } from "./util/textextract.js";
@@ -199,6 +200,8 @@ export class Crawler {
 
   proxyServer?: string;
   proxyPacUrl?: string;
+  
+  redis: Redis | null = null;
 
   driver:
     | ((opts: {
@@ -380,7 +383,7 @@ export class Crawler {
       );
     }
 
-    const redis = await initRedisWaitForSuccess(redisUrl);
+    this.redis = await initRedisWaitForSuccess(redisUrl);
 
     logger.debug(
       `Storing state via Redis ${redisUrl} @ key prefix "${this.crawlId}"`,
@@ -388,7 +391,7 @@ export class Crawler {
       "state",
     );
 
-    let dedupeRedis = redis;
+    let dedupeRedis = this.redis;
 
     if (redisUrl !== dedupeRedisUrl) {
       dedupeRedis = await initRedisWaitForSuccess(dedupeRedisUrl);
@@ -397,7 +400,7 @@ export class Crawler {
     logger.debug(`Max Page Time: ${this.maxPageTime} seconds`, {}, "state");
 
     this.crawlState = new RedisCrawlState(
-      redis,
+      this.redis,
       this.crawlId,
       this.maxPageTime,
       os.hostname(),
@@ -507,6 +510,13 @@ export class Crawler {
       detached: RUN_DETACHED,
     });
   }
+  
+  protected getRedis(): Redis {
+      if (!this.redis) {
+        throw new Error("Redis not initialized");
+      }
+      return this.redis;
+    }
 
   async bootstrap() {
     // check first before disk space check, in case this clears up disk space

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -70,6 +70,13 @@ export class ReplayCrawler extends Crawler {
 
   includeRx: RegExp[];
   excludeRx: RegExp[];
+  
+  // QA policies
+  qaPageCount: number = 0;
+  qaMaxUrls: number = Number.MAX_SAFE_INTEGER;;
+  qaPolicy: string = "";
+  qaRegex: RegExp = new RegExp("^https?:\\/\\/\\S+$");
+  qaProbability: number = 0.3;
 
   // for qaDebugImageDiff incremental file output
   counter: number = 0;
@@ -105,6 +112,20 @@ export class ReplayCrawler extends Crawler {
 
     this.includeRx = parseRx(this.params.scopeIncludeRx);
     this.excludeRx = parseRx(this.params.scopeExcludeRx);
+    
+    // Set the QA policies
+    if (this.params.qaMaxUrls) {
+    	this.qaMaxUrls = this.params.qaMaxUrls;
+	}
+	if (this.params.qaPolicy) {
+    	this.qaPolicy = this.params.qaPolicy;
+	}
+	if (this.params.qaRegex) {
+    	this.qaRegex = new RegExp(this.params.qaRegex);
+	}
+	if (this.params.qaProbability) {
+    	this.qaProbability = this.params.qaProbability;
+	}
   }
 
   async bootstrap(): Promise<void> {
@@ -249,7 +270,40 @@ export class ReplayCrawler extends Crawler {
       }
     }
 
-    await this.queueUrl(0, url, depth, 0, {}, ts, id);
+	// Apply the chosen auto-QA policy
+    // Have we reached the maximum amount of pages allowed?
+	let shouldQueue = false;
+
+	switch (this.qaPolicy) {
+	  case "linear":
+	    shouldQueue = true;
+	    break;
+	
+	  case "regex":
+	    shouldQueue = this.qaRegex.test(url);
+	    break;
+	
+	  case "random":
+	    shouldQueue = Math.random() < this.qaProbability;
+	    break;
+	
+	  default:
+	    // Default is identical to "linear"
+	    shouldQueue = true;
+	    break;
+	}
+
+    if (shouldQueue) {
+	  if (this.qaPageCount >= this.qaMaxUrls) {
+	    return;
+	  }
+	
+	  // Reserve the slot first to prevent races
+	  this.qaPageCount++;
+	
+	  // Queue it!
+	  await this.queueUrl(0, url, depth, 0, {}, ts, id);
+	}
   }
 
   async loadPagesDirect(pages: ReplayPage[]) {

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -72,7 +72,6 @@ export class ReplayCrawler extends Crawler {
   excludeRx: RegExp[];
   
   // QA policies
-  qaPageCount: number = 0;
   qaMaxUrls: number = Number.MAX_SAFE_INTEGER;;
   qaPolicy: string = "";
   qaRegex: RegExp = new RegExp("^https?:\\/\\/\\S+$");
@@ -294,12 +293,13 @@ export class ReplayCrawler extends Crawler {
 	}
 
     if (shouldQueue) {
-	  if (this.qaPageCount >= this.qaMaxUrls) {
-	    return;
-	  }
-	
-	  // Reserve the slot first to prevent races
-	  this.qaPageCount++;
+		// Have we reached the maximum amount of pages allowed?
+		const count = await  this.getRedis().incr(`qaPageCount-${this.crawlId}`);
+	    if (count > this.qaMaxUrls) {
+		  // Rollback
+		  await this.getRedis().decr(`qaPageCount-${this.crawlId}`);
+		  return;
+		}
 	
 	  // Queue it!
 	  await this.queueUrl(0, url, depth, 0, {}, ts, id);

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -70,9 +70,9 @@ export class ReplayCrawler extends Crawler {
 
   includeRx: RegExp[];
   excludeRx: RegExp[];
-  
+
   // QA policies
-  qaMaxUrls: number = Number.MAX_SAFE_INTEGER;;
+  qaMaxUrls: number = Number.MAX_SAFE_INTEGER;
   qaPolicy: string = "";
   qaRegex: RegExp = new RegExp("^https?:\\/\\/\\S+$");
   qaProbability: number = 0.3;
@@ -111,20 +111,20 @@ export class ReplayCrawler extends Crawler {
 
     this.includeRx = parseRx(this.params.scopeIncludeRx);
     this.excludeRx = parseRx(this.params.scopeExcludeRx);
-    
+
     // Set the QA policies
     if (this.params.qaMaxUrls) {
-    	this.qaMaxUrls = this.params.qaMaxUrls;
-	}
-	if (this.params.qaPolicy) {
-    	this.qaPolicy = this.params.qaPolicy;
-	}
-	if (this.params.qaRegex) {
-    	this.qaRegex = new RegExp(this.params.qaRegex);
-	}
-	if (this.params.qaProbability) {
-    	this.qaProbability = this.params.qaProbability;
-	}
+      this.qaMaxUrls = this.params.qaMaxUrls;
+    }
+    if (this.params.qaPolicy) {
+      this.qaPolicy = this.params.qaPolicy;
+    }
+    if (this.params.qaRegex) {
+      this.qaRegex = new RegExp(this.params.qaRegex);
+    }
+    if (this.params.qaProbability) {
+      this.qaProbability = this.params.qaProbability;
+    }
   }
 
   async bootstrap(): Promise<void> {
@@ -280,48 +280,48 @@ export class ReplayCrawler extends Crawler {
       }
     }
 
-	// Apply the chosen auto-QA policy
+    // Apply the chosen auto-QA policy
     // Have we reached the maximum amount of pages allowed?
-	let shouldQueue = false;
+    let shouldQueue = false;
 
-	switch (this.qaPolicy) {
-	  case "linear":
-	    shouldQueue = true;
-	    break;
-	
-	  case "regex":
-	    shouldQueue = this.qaRegex.test(url);
-	    break;
-	
-	  case "random":
-	    shouldQueue = Math.random() < this.qaProbability;
-	    break;
-	
-	  default:
-	    // Default is identical to "linear"
-	    shouldQueue = true;
-	    break;
-	}
+    switch (this.qaPolicy) {
+      case "linear":
+        shouldQueue = true;
+        break;
+
+      case "regex":
+        shouldQueue = this.qaRegex.test(url);
+        break;
+
+      case "random":
+        shouldQueue = Math.random() < this.qaProbability;
+        break;
+
+      default:
+        // Default is identical to "linear"
+        shouldQueue = true;
+        break;
+    }
 
     if (shouldQueue) {
-		// Have we reached the maximum amount of pages allowed?
-		const count = await  this.getRedis().incr(`qaPageCount-${this.crawlId}`);
-	    if (count > this.qaMaxUrls) {
-		  // Rollback
-		  await this.getRedis().decr(`qaPageCount-${this.crawlId}`);
-		  return;
-		}
-	
-	  // Queue it!
-    await this.queueUrl({
-      seedId: 0,
-      url,
-      depth,
-      extraHops: 0,
-      ts,
-      pageid: id,
-    });
-	}
+      // Have we reached the maximum amount of pages allowed?
+      const count = await this.getRedis().incr(`qaPageCount-${this.crawlId}`);
+      if (count > this.qaMaxUrls) {
+        // Rollback
+        await this.getRedis().decr(`qaPageCount-${this.crawlId}`);
+        return;
+      }
+
+      // Queue it!
+      await this.queueUrl({
+        seedId: 0,
+        url,
+        depth,
+        extraHops: 0,
+        ts,
+        pageid: id,
+      });
+    }
   }
 
   async loadPagesDirect(pages: ReplayPage[]) {

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -72,7 +72,6 @@ export class ReplayCrawler extends Crawler {
   excludeRx: RegExp[];
   
   // QA policies
-  qaPageCount: number = 0;
   qaMaxUrls: number = Number.MAX_SAFE_INTEGER;;
   qaPolicy: string = "";
   qaRegex: RegExp = new RegExp("^https?:\\/\\/\\S+$");
@@ -305,12 +304,13 @@ export class ReplayCrawler extends Crawler {
 	}
 
     if (shouldQueue) {
-	  if (this.qaPageCount >= this.qaMaxUrls) {
-	    return;
-	  }
-	
-	  // Reserve the slot first to prevent races
-	  this.qaPageCount++;
+		// Have we reached the maximum amount of pages allowed?
+		const count = await  this.getRedis().incr(`qaPageCount-${this.crawlId}`);
+	    if (count > this.qaMaxUrls) {
+		  // Rollback
+		  await this.getRedis().decr(`qaPageCount-${this.crawlId}`);
+		  return;
+		}
 	
 	  // Queue it!
     await this.queueUrl({

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -70,6 +70,13 @@ export class ReplayCrawler extends Crawler {
 
   includeRx: RegExp[];
   excludeRx: RegExp[];
+  
+  // QA policies
+  qaPageCount: number = 0;
+  qaMaxUrls: number = Number.MAX_SAFE_INTEGER;;
+  qaPolicy: string = "";
+  qaRegex: RegExp = new RegExp("^https?:\\/\\/\\S+$");
+  qaProbability: number = 0.3;
 
   // for qaDebugImageDiff incremental file output
   counter: number = 0;
@@ -105,6 +112,20 @@ export class ReplayCrawler extends Crawler {
 
     this.includeRx = parseRx(this.params.scopeIncludeRx);
     this.excludeRx = parseRx(this.params.scopeExcludeRx);
+    
+    // Set the QA policies
+    if (this.params.qaMaxUrls) {
+    	this.qaMaxUrls = this.params.qaMaxUrls;
+	}
+	if (this.params.qaPolicy) {
+    	this.qaPolicy = this.params.qaPolicy;
+	}
+	if (this.params.qaRegex) {
+    	this.qaRegex = new RegExp(this.params.qaRegex);
+	}
+	if (this.params.qaProbability) {
+    	this.qaProbability = this.params.qaProbability;
+	}
   }
 
   async bootstrap(): Promise<void> {
@@ -260,6 +281,38 @@ export class ReplayCrawler extends Crawler {
       }
     }
 
+	// Apply the chosen auto-QA policy
+    // Have we reached the maximum amount of pages allowed?
+	let shouldQueue = false;
+
+	switch (this.qaPolicy) {
+	  case "linear":
+	    shouldQueue = true;
+	    break;
+	
+	  case "regex":
+	    shouldQueue = this.qaRegex.test(url);
+	    break;
+	
+	  case "random":
+	    shouldQueue = Math.random() < this.qaProbability;
+	    break;
+	
+	  default:
+	    // Default is identical to "linear"
+	    shouldQueue = true;
+	    break;
+	}
+
+    if (shouldQueue) {
+	  if (this.qaPageCount >= this.qaMaxUrls) {
+	    return;
+	  }
+	
+	  // Reserve the slot first to prevent races
+	  this.qaPageCount++;
+	
+	  // Queue it!
     await this.queueUrl({
       seedId: 0,
       url,
@@ -268,6 +321,7 @@ export class ReplayCrawler extends Crawler {
       ts,
       pageid: id,
     });
+	}
   }
 
   async loadPagesDirect(pages: ReplayPage[]) {

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -703,6 +703,30 @@ class ArgParser {
             "if specified, will write crawl.png, replay.png and diff.png for each page where they're different",
           type: "boolean",
         },
+        
+        qaMaxUrls: {
+          describe:
+            "if specified, will set the maximum number of pages to include in the QA process",
+          type: "number",
+        },
+        
+        qaPolicy: {
+          describe:
+            "defines the kind of QA to perform, can be one of 'linear', 'regex' or 'random'",
+          type: "string",
+        },
+        
+        qaRegex: {
+          describe:
+            "if the QA policy is 'regex', then the regular expression is specified here",
+          type: "string",
+        },
+        
+        qaProbability: {
+          describe:
+            "if the QA policy is 'random', then the probability of processing a URL is specified here",
+          type: "number",
+        },
 
         sshProxyPrivateKeyFile: {
           describe:

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -726,6 +726,30 @@ class ArgParser {
             "if specified, will write crawl.png, replay.png and diff.png for each page where they're different",
           type: "boolean",
         },
+        
+        qaMaxUrls: {
+          describe:
+            "if specified, will set the maximum number of pages to include in the QA process",
+          type: "number",
+        },
+        
+        qaPolicy: {
+          describe:
+            "defines the kind of QA to perform, can be one of 'linear', 'regex' or 'random'",
+          type: "string",
+        },
+        
+        qaRegex: {
+          describe:
+            "if the QA policy is 'regex', then the regular expression is specified here",
+          type: "string",
+        },
+        
+        qaProbability: {
+          describe:
+            "if the QA policy is 'random', then the probability of processing a URL is specified here",
+          type: "number",
+        },
 
         sshProxyPrivateKeyFile: {
           describe:

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -726,25 +726,25 @@ class ArgParser {
             "if specified, will write crawl.png, replay.png and diff.png for each page where they're different",
           type: "boolean",
         },
-        
+
         qaMaxUrls: {
           describe:
             "if specified, will set the maximum number of pages to include in the QA process",
           type: "number",
         },
-        
+
         qaPolicy: {
           describe:
             "defines the kind of QA to perform, can be one of 'linear', 'regex' or 'random'",
           type: "string",
         },
-        
+
         qaRegex: {
           describe:
             "if the QA policy is 'regex', then the regular expression is specified here",
           type: "string",
         },
-        
+
         qaProbability: {
           describe:
             "if the QA policy is 'random', then the probability of processing a URL is specified here",

--- a/tests/qa_policies.test.js
+++ b/tests/qa_policies.test.js
@@ -1,0 +1,62 @@
+import child_process from "child_process";
+import fs from "fs";
+import { Redis } from "ioredis";
+
+const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
+
+test("run initial crawl with text and screenshots to prepare for QA", async () => {
+  fs.rmSync("./test-crawls/qa-wr-net", { recursive: true, force: true });
+
+  child_process.execSync(
+    "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://wikipedia.org --scopeType domain --limit 50 --collection qa-wr-net --text to-warc --screenshot view --generateWACZ",
+  );
+
+  expect(
+    fs.existsSync("test-crawls/collections/qa-wr-net/qa-wr-net.wacz"),
+  ).toBe(true);
+});
+
+test("run QA comparison, with write pages to redis", async () => {
+  fs.rmSync("./test-crawls/qa-wr-net-replay", { recursive: true, force: true });
+
+  const child = child_process.exec(
+    "docker run -p 36380:6379 -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler qa --qaSource /crawls/collections/qa-wr-net/qa-wr-net.wacz --collection qa-wr-net-replay --crawlId test --qaDebugImageDiff --writePagesToRedis --debugAccessRedis --exclude contact --qaPolicy 'linear' --qaMaxUrls 20",
+  );
+
+  // detect crawler exit
+  let crawler_exited = false;
+  child.on("exit", function () {
+    crawler_exited = true;
+  });
+
+  const redis = new Redis("redis://127.0.0.1:36380/0", { lazyConnect: true, retryStrategy: () => null });
+
+  await sleep(3000);
+
+  await redis.connect({ maxRetriesPerRequest: 50 });
+
+  let count = 0;
+
+  while (count < 50) {
+    const res = await redis.lpop("test:pages");
+    if (!res) {
+      if (crawler_exited) {
+        break;
+      }
+      await sleep(100);
+      continue;
+    }
+    const json = JSON.parse(res);
+    expect(json).toHaveProperty("id");
+    expect(json).toHaveProperty("url");
+
+    count++;
+  }
+
+  expect(count).toBe(20);
+
+  // wait for crawler exit
+  while (!crawler_exited) {
+    await sleep(100);
+  }
+});


### PR DESCRIPTION
# Introduction

In this fork, we introduce a few refinements to the default Browsertrix QA workflow:

  1. The ability to set a maximum page count for the QA,
  2. The ability to choose between 3 different QA algorithms.
  
These algorithms are: *linear* (first come first serve), *regex* (define a regular expression to perform QA only on URLs that match it), and *random* (define a probability for each page to be QA'd).
  
# New CLI arguments

We provide the following new CLI arguments for the crawler:

  - `qaMaxUrls`: the maximum number of pages to perform QA on,
  - `qaPolicy`: can be one of `linear`, `regex` or `random`,
  - `qaRegex`: if `qaPolicy` is `regex`, then you can define your regular expression here,
  - `qaProbability`: if `qaPolicy` is `random`, you can define your per-page QA probability here. This is a floating-point number between 0 and 1.
  
### QA Policy: `linear`

In this QA mode, the first `qaMaxUrls` pages in the `pages.jsonl` file(s) will be scanned. Example:

    --qaPolicy "linear" --qaMaxUrls 50"
    
### QA Policy: `regex`

In this QA mode, only the pages that match the regular expression in `qaRegex` will be scanned. Example:

    --qaPolicy "regex" --qaRegex='^https:\/\/en\.wikipedia\.org\/wiki\/R.*$' --qaMaxUrls 50"
    
This will match all english Wikipedia articles that start with `R`.

### QA policy: `random`

In this QA mode, pages will be scanned with a probability equal to `qaProbability`. This is a floating-point number between `0` and `1`. Example:

    --qaPolicy "random" --qaProbability 0.3 --qaMaxUrls 50"
    
This policy allows to get a good overall impression of a harvest by scanning a random sample of it.
    
### Maximum number of pages to scan

In every case mentioned above, the number of pages that will be queued for scanning will be at most `qaMaxUrls`.