### PR TITLE
fix --overwrite option:

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -474,6 +474,16 @@ export class Crawler {
   }
 
   async bootstrap() {
+    // check first before disk space check, in case this clears up disk space
+    if (this.params.overwrite) {
+      logger.debug(`Clearing ${this.collDir} before starting`);
+      try {
+        fs.rmSync(this.collDir, { recursive: true, force: true });
+      } catch (e) {
+        logger.error(`Unable to clear ${this.collDir}`, e);
+      }
+    }
+
     if (await isDiskFull(this.params.cwd)) {
       await logger.interrupt(
         "Out of disk space, exiting",
@@ -530,15 +540,6 @@ export class Crawler {
 
     if (this.params.profile) {
       logger.info("With Browser Profile", { url: this.params.profile });
-    }
-
-    if (this.params.overwrite) {
-      logger.debug(`Clearing ${this.collDir} before starting`);
-      try {
-        fs.rmSync(this.collDir, { recursive: true, force: true });
-      } catch (e) {
-        logger.error(`Unable to clear ${this.collDir}`, e);
-      }
     }
 
     if (this.params.customBehaviors) {

--- a/tests/crawl_overwrite.test.js
+++ b/tests/crawl_overwrite.test.js
@@ -1,7 +1,7 @@
 import child_process from "child_process";
 import fs from "fs";
 
-test("ensure --overwrite with existing collection results in a successful crawl", async () => {
+test("ensure --overwrite with existing collection results in a successful crawl", () => {
   child_process.execSync(
     "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://www.example.com/ --generateWACZ  --collection overwrite",
   );
@@ -25,7 +25,7 @@ test("check that the WACZ file exists in the collection", () => {
 
 //-----------
 
-test("ensure --overwrite results in a successful crawl even if collection didn't exist", async () => {
+test("ensure --overwrite results in a successful crawl even if collection didn't exist", () => {
   child_process.execSync(
     "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url http://www.example.com/ --generateWACZ  --collection overwrite-nothing --overwrite",
   );


### PR DESCRIPTION
- fixes #997
- move removing existing crawl dir before disk space check, in case clearing existing crawls frees up more space
- also removes existing crawl dir before creating dirs
- tests: overwrite tests were named incorrectly and were not running, rename