### PR TITLE
qa: don't add pages from WACZ files that have fromDependency set

### DIFF
--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -183,6 +183,9 @@ export class ReplayCrawler extends Crawler {
       } else {
         // otherwise, parse pages from WACZ files
         for (const entry of json.resources) {
+          if (entry.fromDependency) {
+            continue;
+          }
           if (entry.path) {
             await this.loadPages(entry.path);
           }


### PR DESCRIPTION
Skip WACZ entries in the resources list that are dependencies, eg. have `fromDependency` set.
These WACZ files are used for replay when needed, but the pages should not be included in QA runs.
Fixes #1011 