### PR TITLE
Update replaywebpage version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ADD config/ /app/
 
 ADD html/ /app/html/
 
-ARG RWP_VERSION=2.4.3
+ARG RWP_VERSION=2.4.4
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/ui.js /app/html/rwp/
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/sw.js /app/html/rwp/
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/adblock/adblock.gz /app/html/rwp/adblock.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ADD config/ /app/
 
 ADD html/ /app/html/
 
-ARG RWP_VERSION=2.4.4
+ARG RWP_VERSION=2.4.6
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/ui.js /app/html/rwp/
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/sw.js /app/html/rwp/
 ADD https://cdn.jsdelivr.net/npm/replaywebpage@${RWP_VERSION}/adblock/adblock.gz /app/html/rwp/adblock.gz


### PR DESCRIPTION
`2.4.3` → `2.4.4`

## What's Changed
* deps: bump wabac.js to 2.26.0-beta.0 for testing by @ikreymer in https://github.com/webrecorder/replayweb.page/pull/498
* ui: ensure iso string 'ts' is parsed into timestamp ts + wabac.js 2.26.0 by @ikreymer in https://github.com/webrecorder/replayweb.page/pull/501


**Full Changelog**: https://github.com/webrecorder/replayweb.page/compare/v2.4.3...v2.4.4