### PR TITLE
support archiving websocket data

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -160,6 +160,8 @@ export class Crawler {
 
   crawlIdsDir: string;
 
+  wsDir: string;
+
   downloadsDir: string;
 
   screenshotWriter: WARCWriter | null;
@@ -301,6 +303,9 @@ export class Crawler {
     // indexes dirs
     this.warcCdxDir = path.join(this.collDir, "warc-cdx");
     this.indexesDir = path.join(this.collDir, "indexes");
+
+    // ws data directory
+    this.wsDir = path.join(this.collDir, "ws-data");
 
     // crawl ids dir
     this.crawlIdsDir = path.join(this.collDir, "crawlIds");

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -34,6 +34,7 @@ export const LOG_CONTEXT_TYPES = [
   "recorder",
   "recorderNetwork",
   "writer",
+  "websocket",
   "state",
   "redis",
   "storage",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -20,7 +20,7 @@ import {
 
 import { WARCRecord, multiValueHeader } from "warcio";
 import { TempFileBuffer, WARCSerializer } from "warcio/node";
-import { WARCWriter } from "./warcwriter.js";
+import { streamFinish, WARCWriter } from "./warcwriter.js";
 import { LoadState, PageState, RedisCrawlState, WorkerId } from "./state.js";
 import { CDPSession, Protocol } from "puppeteer-core";
 import { Crawler } from "../crawler.js";
@@ -29,6 +29,9 @@ import { ScopedSeed } from "./seeds.js";
 import EventEmitter from "events";
 import { DEFAULT_MAX_RETRIES, WARC_REFERS_TO_CONTAINER } from "./constants.js";
 import { Readable } from "stream";
+import path from "path";
+import fs from "fs";
+import fsp from "fs/promises";
 
 const MAX_BROWSER_DEFAULT_FETCH_SIZE = 5_000_000;
 const MAX_TEXT_REWRITE_SIZE = 25_000_000;
@@ -281,6 +284,94 @@ export class Recorder extends EventEmitter {
     });
 
     await cdp.send("Console.enable");
+
+    // WEBSOCKET
+    cdp.on("Network.webSocketCreated", (params) => {
+      const { requestId, url } = params;
+      const reqresp = this.pendingReqResp(requestId);
+      if (reqresp) {
+        reqresp.isWS = true;
+        reqresp.url = url;
+        logger.debug(
+          "Archiving websocket data",
+          { url, requestId, ...this.logDetails },
+          "websocket",
+        );
+      }
+    });
+
+    cdp.on("Network.webSocketWillSendHandshakeRequest", (params) => {
+      const { requestId, timestamp, request } = params;
+      const reqresp = this.pendingReqResp(requestId);
+      if (reqresp) {
+        reqresp.fillWSRequest(request, timestamp);
+      }
+    });
+
+    cdp.on("Network.webSocketHandshakeResponseReceived", (params) => {
+      const { requestId, timestamp, response } = params;
+      const reqresp = this.pendingReqResp(requestId);
+
+      fs.mkdirSync(this.crawler.wsDir, { recursive: true });
+
+      const filename = path.join(this.crawler.wsDir, `ws-${requestId}.jsonl`);
+
+      if (reqresp) {
+        reqresp.fillWSResponse(response, timestamp, filename);
+      }
+    });
+
+    cdp.on("Network.webSocketFrameSent", (params) =>
+      this.wsFrame(params, "send"),
+    );
+
+    cdp.on("Network.webSocketFrameReceived", (params) =>
+      this.wsFrame(params, "recv"),
+    );
+
+    cdp.on("Network.webSocketClosed", async (params) => {
+      const { requestId } = params;
+      const reqresp = this.pendingReqResp(requestId, true);
+      if (reqresp) {
+        logger.debug(
+          "Websocket Closed",
+          { url: reqresp.url, requestId, ...this.logDetails },
+          "websocket",
+        );
+        await this.serializeWebsocketToWARC(reqresp);
+      }
+    });
+
+    cdp.on("Network.webSocketFrameError", (params) => {
+      const { requestId, errorMessage } = params;
+      logger.warn(
+        "Websocket Frame error, data not recorded",
+        { requestId, errorMessage, ...this.logDetails },
+        "websocket",
+      );
+    });
+  }
+
+  wsFrame(
+    params: Protocol.Network.WebSocketFrameSentEvent,
+    type: "recv" | "send",
+  ) {
+    const { requestId, timestamp, response } = params;
+
+    const reqresp = this.pendingReqResp(requestId);
+    if (reqresp && reqresp.addWSData(timestamp, type, response)) {
+      logger.debug(
+        "Websocket frame saved",
+        { url: reqresp.url, type, requestId, ...this.logDetails },
+        "websocket",
+      );
+    } else {
+      logger.warn(
+        "Not writing additional WS data, likely already closed",
+        { requestId, ...this.logDetails },
+        "websocket",
+      );
+    }
   }
 
   hasFrame(frameId: string) {
@@ -1070,6 +1161,9 @@ export class Recorder extends EventEmitter {
       if (reqresp.payload && !reqresp.asyncLoading) {
         this.removeReqResp(requestId);
         await this.serializeToWARC(reqresp);
+        // finish WS stream here
+      } else if (reqresp.isWS) {
+        await this.serializeWebsocketToWARC(reqresp);
         // if no url, and not fetch intercept or async loading,
         // drop this request, as it was not being loaded
       } else if (
@@ -1192,7 +1286,7 @@ export class Recorder extends EventEmitter {
       return true;
     }
 
-    if (["EventSource", "WebSocket", "Ping"].includes(resourceType || "")) {
+    if (["EventSource", "Ping"].includes(resourceType || "")) {
       return true;
     }
 
@@ -1380,7 +1474,13 @@ export class Recorder extends EventEmitter {
   }
 
   isValidUrl(url?: string) {
-    return url && (url.startsWith("https:") || url.startsWith("http:"));
+    return (
+      url &&
+      (url.startsWith("https:") ||
+        url.startsWith("http:") ||
+        url.startsWith("ws:") ||
+        url.startsWith("wss:"))
+    );
   }
 
   pendingReqResp(requestId: string, reuseOnly = false) {
@@ -1647,6 +1747,80 @@ export class Recorder extends EventEmitter {
     }
 
     return true;
+  }
+
+  async serializeWebsocketToWARC(reqresp: RequestResponseInfo) {
+    this.removeReqResp(reqresp.requestId);
+    let size = 0;
+    reqresp.wsOutDone = true;
+
+    const { url, wsOut, wsOutFilename } = reqresp;
+
+    if (wsOut) {
+      await streamFinish(wsOut);
+      size = wsOut.bytesWritten;
+      reqresp.wsOut = null;
+    } else if (!wsOut || !wsOutFilename) {
+      logger.warn(
+        "WS stream missing",
+        { requestId: reqresp.requestId, url, ...this.logDetails },
+        "websocket",
+      );
+      return;
+    }
+
+    const resourceWARCHeaders = {
+      "Content-Type": 'application/jsonl; format="cdp"',
+      "Content-Length": size + "",
+      "WARC-Resource": "websocket",
+      "WARC-Page-ID": this.pageid,
+    };
+
+    const resource = WARCRecord.create(
+      {
+        url,
+        date: new Date().toISOString(),
+        type: "resource",
+        warcVersion: "WARC/1.1",
+        warcHeaders: resourceWARCHeaders,
+      },
+      fs.createReadStream(reqresp.wsOutFilename),
+    );
+
+    const resID = resource.warcHeader("WARC-Record-ID");
+
+    this.writer.writeSingleRecord(resource);
+
+    const removeFile = async () => {
+      try {
+        await fsp.unlink(reqresp.wsOutFilename);
+      } catch (e) {
+        // ignore
+      }
+    };
+
+    reqresp.truncated = "payloadNotAvailable";
+    // set URL back to http/https for response/request records
+    reqresp.url = reqresp.url.replace(/^ws/, "http");
+
+    const responseRecord = createResponse(reqresp, this.pageid);
+    const requestRecord = createRequest(reqresp, responseRecord, this.pageid);
+
+    const respHeaders = responseRecord.warcHeaders.headers;
+    const reqHeaders = requestRecord.warcHeaders.headers;
+    respHeaders.set("WARC-Truncated", reqresp.truncated);
+    reqHeaders.set("WARC-Truncated", reqresp.truncated);
+    if (resID) {
+      respHeaders.append("WARC-Concurrent-To", resID);
+      reqHeaders.append("WARC-Concurrent-To", resID);
+    }
+
+    this.writer.writeRecordPair(
+      responseRecord,
+      requestRecord,
+      undefined,
+      removeFile,
+    );
   }
 
   async serializeToWARC(

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -4,6 +4,7 @@ import {
   ExtraOpts,
 } from "@webrecorder/wabac";
 
+import fs from "fs";
 import { Protocol } from "puppeteer-core";
 import { postToGetUrl } from "warcio";
 import { HTML_TYPES } from "./constants.js";
@@ -19,6 +20,15 @@ export const MAX_URL_LENGTH = 4096;
 
 // max length for single query arg for post/put converted URLs
 const MAX_ARG_LEN = 512;
+
+// ===========================================================================
+export type WSData = {
+  ts: number;
+  type: "send" | "recv";
+  opcode: number;
+  mask: boolean;
+  payloadData: string;
+};
 
 // ===========================================================================
 export class RequestResponseInfo {
@@ -68,6 +78,12 @@ export class RequestResponseInfo {
   frameId?: string;
 
   resourceType?: string;
+
+  isWS = false;
+  wsStart = 0;
+  wsOut: fs.WriteStream | null = null;
+  wsOutFilename = "";
+  wsOutDone = false;
 
   extraOpts: ExtraOpts = {};
 
@@ -178,6 +194,55 @@ export class RequestResponseInfo {
           : "0";
       this.extraOpts.cert = { issuer, ctc };
     }
+  }
+
+  fillWSRequest(request: Protocol.Network.WebSocketRequest, timestamp: number) {
+    this.isWS = true;
+    this.requestHeaders = request.headers;
+    this.wsStart = timestamp;
+    this.method = "GET";
+  }
+
+  fillWSResponse(
+    response: Protocol.Network.WebSocketResponse,
+    timestamp: number,
+    wsOutFilename: string,
+  ) {
+    this.isWS = true;
+    this.setStatus(response.status, response.statusText);
+    this.resourceType = "websocket";
+
+    if (response.requestHeaders) {
+      this.requestHeaders = response.requestHeaders;
+    }
+    if (response.requestHeadersText) {
+      this.requestHeadersText = response.requestHeadersText;
+    }
+
+    this.responseHeaders = response.headers;
+
+    if (response.headersText) {
+      this.responseHeadersText = response.headersText;
+    }
+    this.wsStart = timestamp;
+    this.wsOutFilename = wsOutFilename;
+    this.wsOut = fs.createWriteStream(wsOutFilename, { flags: "a" });
+    this.wsOutDone = false;
+  }
+
+  addWSData(
+    ts: number,
+    type: "send" | "recv",
+    frame: Protocol.Network.WebSocketFrame,
+  ) {
+    if (!this.wsOut || this.wsOutDone) {
+      return false;
+    }
+
+    const entry: WSData = { ts: ts - this.wsStart, type, ...frame };
+
+    this.wsOut.write(JSON.stringify(entry) + "\n");
+    return true;
   }
 
   isRedirectStatus() {


### PR DESCRIPTION
- saving WS frames from CDP to a temp file as jsonl data
- generate separate 'resource' record with jsonl data
- generate request/response data with headers only, set warc-truncated header
- should match evolving iipc/warc-specifications#115 spec
- fixes #1019 