### PR TITLE
docs: fix formatting for behaviour docs

### DIFF
--- a/docs/docs/user-guide/behaviors.md
+++ b/docs/docs/user-guide/behaviors.md
@@ -89,6 +89,7 @@ docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --u
 ## Creating Custom Behaviors
 
 A custom behavior file can be in one of the following supported formats:
+
 - JSON User Flow
 - JavaScript / Typescript (compiled to JavaScript)
 


### PR DESCRIPTION
The missing newline meant this wasn't parsed as a bullet list:

<img width="890" height="114" alt="image" src="https://github.com/user-attachments/assets/a0298c9b-308d-44fd-9b5a-d55999867c47" />
