### PR TITLE
Fix allowHashUrls option and scope checking for hash URLs

### DIFF
--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -172,6 +172,7 @@ class ArgParser {
         allowHashUrls: {
           describe:
             "Allow Hashtag URLs, useful for single-page-application crawling or when different hashtags load dynamic content",
+          type: "boolean",
         },
 
         selectLinks: {

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -6,7 +6,7 @@ import { logger } from "./logger.js";
 import { type CrawlerArgs } from "./argParser.js";
 import { normalizeUrl } from "./normalize.js";
 
-type ScopeType =
+export type ScopeType =
   | "prefix"
   | "host"
   | "domain"
@@ -14,6 +14,18 @@ type ScopeType =
   | "page-spa"
   | "any"
   | "custom";
+
+export type ScopeSeedInitOpts = {
+  url: string;
+  scopeType: ScopeType | undefined;
+  include: string[];
+  exclude: string[];
+  allowHash?: boolean;
+  depth?: number;
+  sitemap?: string | boolean | null;
+  extraHops?: number;
+  auth?: string | null;
+};
 
 export class ScopedSeed {
   url: string;
@@ -43,17 +55,7 @@ export class ScopedSeed {
     sitemap = false,
     extraHops = 0,
     auth = null,
-  }: {
-    url: string;
-    scopeType: ScopeType | undefined;
-    include: string[];
-    exclude: string[];
-    allowHash?: boolean;
-    depth?: number;
-    sitemap?: string | boolean | null;
-    extraHops?: number;
-    auth?: string | null;
-  }) {
+  }: ScopeSeedInitOpts) {
     const parsedUrl = this.parseUrl(url);
     if (!parsedUrl) {
       throw new Error("Invalid URL");
@@ -84,7 +86,7 @@ export class ScopedSeed {
         parsedUrl,
       );
       this.include = [...includeNew, ...this.include];
-      allowHash = allowHashNew;
+      allowHash ||= allowHashNew;
     }
 
     // for page scope, the depth is set to extraHops, as no other
@@ -349,13 +351,14 @@ export async function parseSeeds(
     }
   }
 
-  const scopeOpts = {
+  const scopeOpts: Omit<ScopeSeedInitOpts, "url"> = {
     scopeType: params.scopeType as ScopeType | undefined,
     sitemap: params.sitemap,
     include: params.include,
     exclude: params.exclude,
     depth: params.depth,
     extraHops: params.extraHops,
+    allowHash: params.allowHashUrls,
   };
 
   for (const seed of seeds) {

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -15,7 +15,7 @@ export type ScopeType =
   | "any"
   | "custom";
 
-export type ScopeSeedInitOpts = {
+export type ScopedSeedInitOpts = {
   url: string;
   scopeType: ScopeType | undefined;
   include: string[];
@@ -55,7 +55,7 @@ export class ScopedSeed {
     sitemap = false,
     extraHops = 0,
     auth = null,
-  }: ScopeSeedInitOpts) {
+  }: ScopedSeedInitOpts) {
     const parsedUrl = this.parseUrl(url);
     if (!parsedUrl) {
       throw new Error("Invalid URL");
@@ -351,7 +351,7 @@ export async function parseSeeds(
     }
   }
 
-  const scopeOpts: Omit<ScopeSeedInitOpts, "url"> = {
+  const scopeOpts: Omit<ScopedSeedInitOpts, "url"> = {
     scopeType: params.scopeType as ScopeType | undefined,
     sitemap: params.sitemap,
     include: params.include,

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -453,3 +453,39 @@ scopeType: prefix
   );
   expect(result2).toBe(false);
 });
+
+test("hashtag relative URL included", async () => {
+  const seeds = await getSeeds(`
+seeds:
+  - url: https://example.com/
+    allowHash: true
+
+scopeType: prefix
+`);
+
+  expect(seeds[0].scopeType).toEqual("prefix");
+  expect(seeds[0].allowHash).toEqual(true);
+
+  const result1 = seeds[0].isIncluded(
+    "#abc",
+    0,
+    0,
+    {},
+    false,
+    "https://example.com/",
+  );
+  expect(result1).not.toBe(false);
+  expect((result1 as Exclude<typeof result1, false>).url).toBe(
+    "https://example.com/#abc",
+  );
+
+  const result2 = seeds[0].isIncluded(
+    "#abc",
+    0,
+    0,
+    {},
+    false,
+    "https://example.org/",
+  );
+  expect(result2).toBe(false);
+});

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -407,6 +407,17 @@ scopeType: page
   expect((result as Exclude<typeof result, false>).isOOS).toBe(false);
 });
 
+test("allowHashUrls global with scopeType prefix", async () => {
+  const seeds = await getSeeds(`
+allowHashUrls: true
+seeds:
+  - url: https://example.com/
+`);
+
+  expect(seeds[0].scopeType).toEqual("prefix");
+  expect(seeds[0].allowHash).toEqual(true);
+});
+
 test("allowHash with scopeType prefix", async () => {
   const seeds = await getSeeds(`
 seeds:
@@ -418,29 +429,6 @@ scopeType: prefix
 
   expect(seeds[0].scopeType).toEqual("prefix");
   expect(seeds[0].allowHash).toEqual(true);
-
-  const result1 = seeds[0].isIncluded(
-    "/abc",
-    0,
-    0,
-    {},
-    false,
-    "https://example.com/",
-  );
-  expect(result1).not.toBe(false);
-  expect((result1 as Exclude<typeof result1, false>).url).toBe(
-    "https://example.com/abc",
-  );
-
-  const result2 = seeds[0].isIncluded(
-    "#abc",
-    0,
-    0,
-    {},
-    false,
-    "https://example.org/",
-  );
-  expect(result2).toBe(false);
 });
 
 test("hashtag relative URL included", async () => {

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -465,4 +465,17 @@ scopeType: prefix
     "https://example.org/",
   );
   expect(result2).toBe(false);
+
+  const result3 = seeds[0].isIncluded(
+    "/abc",
+    0,
+    0,
+    {},
+    false,
+    "https://example.com/",
+  );
+  expect(result3).not.toBe(false);
+  expect((result3 as Exclude<typeof result1, false>).url).toBe(
+    "https://example.com/abc",
+  );
 });

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -407,7 +407,6 @@ scopeType: page
   expect((result as Exclude<typeof result, false>).isOOS).toBe(false);
 });
 
-<<<<<<< HEAD
 test("hashtag relative URL included", async () => {
   const seeds = await getSeeds(`
 allowHashUrls: true
@@ -428,6 +427,7 @@ seeds:
 scopeType: prefix
 `);
 
+  expect(seeds[0].scopeType).toEqual("prefix");
   expect(seeds[0].allowHash).toEqual(true);
 
   const result1 = seeds[0].isIncluded(

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -407,17 +407,6 @@ scopeType: page
   expect((result as Exclude<typeof result, false>).isOOS).toBe(false);
 });
 
-test("hashtag relative URL included", async () => {
-  const seeds = await getSeeds(`
-allowHashUrls: true
-seeds:
-  - url: https://example.com/
-`);
-
-  expect(seeds[0].scopeType).toEqual("prefix");
-  expect(seeds[0].allowHash).toEqual(true);
-});
-
 test("allowHash with scopeType prefix", async () => {
   const seeds = await getSeeds(`
 seeds:

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -34,6 +34,7 @@ seeds:
   expect(seeds[0].scopeType).toEqual("prefix");
   expect(seeds[0].include).toEqual([/^https?:\/\/example\.com\//]);
   expect(seeds[0].exclude).toEqual([]);
+  expect(seeds[0].allowHash).toEqual(false);
 });
 
 test("default scope + exclude", async () => {
@@ -406,7 +407,19 @@ scopeType: page
   expect((result as Exclude<typeof result, false>).isOOS).toBe(false);
 });
 
+<<<<<<< HEAD
 test("hashtag relative URL included", async () => {
+  const seeds = await getSeeds(`
+allowHashUrls: true
+seeds:
+  - url: https://example.com/
+`);
+
+  expect(seeds[0].scopeType).toEqual("prefix");
+  expect(seeds[0].allowHash).toEqual(true);
+});
+
+test("allowHash with scopeType prefix", async () => {
   const seeds = await getSeeds(`
 seeds:
   - url: https://example.com/
@@ -415,9 +428,7 @@ seeds:
 scopeType: prefix
 `);
 
-  expect(seeds[0].scopeType).toEqual("prefix");
-  //todo: update after #1025 is merged
-  //expect(seeds[0].allowHash).toEqual(true);
+  expect(seeds[0].allowHash).toEqual(true);
 
   const result1 = seeds[0].isIncluded(
     "/abc",


### PR DESCRIPTION
allow #-tag urls to be treated as distinct URLs for scope types other than custom:
- fix --allowHashUrls option being ignored altogether
- if --allowHashUrls global or --allowHash per seed is set, don't reset to false if scopeType != 'custom'
- tests: update scope tests to ensure --allowHash and --allowHashUrls now work as expected
- improve typing for ScopedSeed, add ScopedSeedInitOpts

fixes part of #1023