### PR TITLE
support scope check for relative URLs using current page:

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -765,12 +765,14 @@ export class Crawler {
       depth,
       extraHops,
       noOOS,
+      pageUrl,
     }: {
       seedId: number;
       url: string;
       depth: number;
       extraHops: number;
       noOOS: boolean;
+      pageUrl?: string;
     },
     logDetails = {},
   ) {
@@ -780,6 +782,7 @@ export class Crawler {
       extraHops,
       logDetails,
       noOOS,
+      pageUrl,
     );
   }
 
@@ -788,8 +791,15 @@ export class Crawler {
       seedId,
       url,
       depth,
+      pageUrl,
       extraHops,
-    }: { seedId: number; url: string; depth: number; extraHops: number },
+    }: {
+      seedId: number;
+      url: string;
+      depth: number;
+      extraHops: number;
+      pageUrl?: string;
+    },
     logDetails = {},
   ): Promise<boolean> {
     const seed = await this.crawlState.getSeedAt(
@@ -798,7 +808,14 @@ export class Crawler {
       seedId,
     );
 
-    const res = seed.isIncluded(url, depth, extraHops, logDetails);
+    const res = seed.isIncluded(
+      url,
+      depth,
+      extraHops,
+      logDetails,
+      false,
+      pageUrl,
+    );
 
     if (!res) {
       this.writeSkippedPage(url, seedId, depth, SkippedReason.OutOfScope);
@@ -982,6 +999,7 @@ self.__bx_behaviors.selectMainBehavior();
             depth,
             extraHops,
             false,
+            url,
             logDetails,
           );
         });
@@ -2575,6 +2593,7 @@ self.__bx_behaviors.selectMainBehavior();
         depth,
         extraHops,
         false,
+        page.url(),
         logDetails,
       );
     };
@@ -2619,6 +2638,7 @@ self.__bx_behaviors.selectMainBehavior();
     depth: number,
     extraHops = 0,
     noOOS = false,
+    pageUrl?: string,
     logDetails: LogDetails = {},
   ) {
     try {
@@ -2629,7 +2649,14 @@ self.__bx_behaviors.selectMainBehavior();
 
       for (const possibleUrl of urls) {
         const res = this.getScope(
-          { url: possibleUrl, extraHops: newExtraHops, depth, seedId, noOOS },
+          {
+            url: possibleUrl,
+            extraHops: newExtraHops,
+            depth,
+            seedId,
+            noOOS,
+            pageUrl,
+          },
           logDetails,
         );
 

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -143,10 +143,10 @@ export class ScopedSeed {
     }
   }
 
-  parseUrl(url: string, logDetails = {}) {
+  parseUrl(url: string, pageUrl?: string, logDetails = {}) {
     let parsedUrl = null;
     try {
-      parsedUrl = new URL(url.trim());
+      parsedUrl = new URL(url.trim(), pageUrl);
     } catch (e) {
       logger.warn("Invalid Page - not a valid URL", { url, ...logDetails });
       return null;
@@ -250,8 +250,9 @@ export class ScopedSeed {
     extraHops = 0,
     logDetails = {},
     noOOS = false,
+    pageUrl?: string,
   ): { url: string; isOOS: boolean } | false {
-    const urlParsed = this.parseUrl(url, logDetails);
+    const urlParsed = this.parseUrl(url, pageUrl, logDetails);
     if (!urlParsed) {
       return false;
     }

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -405,3 +405,39 @@ scopeType: page
   expect(result).not.toBe(false);
   expect((result as Exclude<typeof result, false>).isOOS).toBe(false);
 });
+
+test("hashtag relative URL included", async () => {
+  const seeds = await getSeeds(`
+seeds:
+  - url: https://example.com/
+    allowHash: true
+
+scopeType: prefix
+`);
+
+  expect(seeds[0].scopeType).toEqual("prefix");
+  expect(seeds[0].allowHash).toEqual(true);
+
+  const result1 = seeds[0].isIncluded(
+    "#abc",
+    0,
+    0,
+    {},
+    false,
+    "https://example.com/",
+  );
+  expect(result1).not.toBe(false);
+  expect((result1 as Exclude<typeof result1, false>).url).toBe(
+    "https://example.com/#abc",
+  );
+
+  const result2 = seeds[0].isIncluded(
+    "#abc",
+    0,
+    0,
+    {},
+    false,
+    "https://example.org/",
+  );
+  expect(result2).toBe(false);
+});

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -416,10 +416,11 @@ scopeType: prefix
 `);
 
   expect(seeds[0].scopeType).toEqual("prefix");
-  expect(seeds[0].allowHash).toEqual(true);
+  //todo: update after #1025 is merged
+  //expect(seeds[0].allowHash).toEqual(true);
 
   const result1 = seeds[0].isIncluded(
-    "#abc",
+    "/abc",
     0,
     0,
     {},
@@ -428,7 +429,7 @@ scopeType: prefix
   );
   expect(result1).not.toBe(false);
   expect((result1 as Exclude<typeof result1, false>).url).toBe(
-    "https://example.com/#abc",
+    "https://example.com/abc",
   );
 
   const result2 = seeds[0].isIncluded(


### PR DESCRIPTION
Previously, the assumption was that only absolute URLs are provided from the link extraction.
However, with custom link selectors and user provided behaviors, relative URLs are possible.
This change ensures that relative URLs can be resolved to the current page:
- pass pageUrl to seed.isIncluded() to allow resolving scope of relative URLs to current page, if provided
- resolves any relative URLs found added from custom link extraction
- fixes part of #1023