### PR TITLE
Add flag to disable content deduplication

### DIFF
--- a/docs/docs/user-guide/dedupe.md
+++ b/docs/docs/user-guide/dedupe.md
@@ -3,6 +3,11 @@
 With version 1.12, the crawler includes full support for deduplication ("dedupe") of crawled content by content hash,
 avoiding saving the same content multuple times. When a duplicate is encountered, the crawler saves a reference to the original content, instead of the full response. The crawler supports deduplication in several ways.
 
+To disable content-based deduplication entirely, pass `--no-dedupe`. When
+disabled, the crawler will not write `revisit` records and will ignore
+dedupe-specific options such as `--redisDedupeUrl` and
+`--dedupePagesMinDepth`.
+
 ## Automatic deduplication within a single crawl
 
 By default, the crawler applies the following deduplication automatically:

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -266,7 +266,9 @@ export class Crawler {
     // and additional pages needed from the queue
     // otherwise, queuePageLimit == pagesLimit
     this.queuePageLimit =
-      this.params.dedupePagesMinDepth >= 0 ? 0 : this.pageLimit;
+      this.params.dedupe && this.params.dedupePagesMinDepth >= 0
+        ? 0
+        : this.pageLimit;
 
     this.saveStateFiles = [];
     this.lastSaveTime = 0;
@@ -363,7 +365,9 @@ export class Crawler {
 
   async initCrawlState() {
     const redisUrl = this.params.redisStoreUrl || "redis://localhost:6379/0";
-    const dedupeRedisUrl = this.params.redisDedupeUrl || redisUrl;
+    const dedupeRedisUrl = this.params.dedupe
+      ? this.params.redisDedupeUrl || redisUrl
+      : redisUrl;
 
     this.isExternalDedupeStore = dedupeRedisUrl !== redisUrl;
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -457,6 +457,13 @@ class ArgParser {
           type: "string",
         },
 
+        dedupe: {
+          describe:
+            "If set, enable content-based deduplication and WARC revisit records",
+          type: "boolean",
+          default: true,
+        },
+
         dedupePagesMinDepth: {
           describe:
             "If set >= 0, minimum depth at which duplicate pages can be skipped. -1 means never skip duplicate pages",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -167,6 +167,7 @@ export class Recorder extends EventEmitter {
   pageSeed?: ScopedSeed;
   pageSeedDepth = 0;
   dedupePagesMinDepth = -1;
+  dedupeEnabled = true;
 
   frameIdToExecId: Map<string, number> | null;
 
@@ -190,7 +191,10 @@ export class Recorder extends EventEmitter {
 
     this.shouldSaveStorage = !!crawler.params.saveStorage;
 
-    this.dedupePagesMinDepth = crawler.params.dedupePagesMinDepth;
+    this.dedupeEnabled = crawler.params.dedupe;
+    this.dedupePagesMinDepth = this.dedupeEnabled
+      ? crawler.params.dedupePagesMinDepth
+      : -1;
 
     this.writer = writer;
 
@@ -1776,7 +1780,7 @@ export class Recorder extends EventEmitter {
 
     let origRecSize = 0;
 
-    if (!isEmpty && url) {
+    if (this.dedupeEnabled && !isEmpty && url) {
       const res = await this.crawlState.getHashDupe(hash);
 
       // if only writing revisit, ensure it's a revisit and hash
@@ -1843,7 +1847,9 @@ export class Recorder extends EventEmitter {
 
     const addStatsCallback = async (size: number) => {
       try {
-        await this.crawlState.addHashNew(hash, url, date, size, origRecSize);
+        if (this.dedupeEnabled) {
+          await this.crawlState.addHashNew(hash, url, date, size, origRecSize);
+        }
       } catch (e) {
         logger.warn("Error adding dupe hash", e, "recorder");
       }

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -361,7 +361,9 @@ export class PageWorker {
       const data = await crawlState.nextFromQueue();
 
       const limit = this.crawler.pageLimit;
-      const isDedupePages = this.crawler.params.dedupePagesMinDepth >= 0;
+      const isDedupePages =
+        this.crawler.params.dedupe &&
+        this.crawler.params.dedupePagesMinDepth >= 0;
 
       // see if any work data in the queue
       if (data) {

--- a/tests/dedupe-basic.test.ts
+++ b/tests/dedupe-basic.test.ts
@@ -26,14 +26,17 @@ afterAll(async () => {
   execSync("docker network rm dedupe");
 });
 
-function runCrawl(name: string, { db = 0, limit = 4, wacz = true } = {}) {
+function runCrawl(
+  name: string,
+  { db = 0, limit = 4, wacz = true, extraArgs = "" } = {},
+) {
   fs.rmSync(`./test-crawls/collections/${name}`, {
     recursive: true,
     force: true,
   });
 
   const crawler = exec(
-    `docker run -v $PWD/test-crawls:/crawls --network=dedupe -e CRAWL_ID=${name} webrecorder/browsertrix-crawler crawl --url https://old.webrecorder.net/ --limit ${limit} --exclude community --collection ${name} --redisDedupeUrl redis://dedupe-redis:6379/${db} ${
+    `docker run -v $PWD/test-crawls:/crawls --network=dedupe -e CRAWL_ID=${name} webrecorder/browsertrix-crawler crawl --url https://old.webrecorder.net/ --limit ${limit} --exclude community --collection ${name} --redisDedupeUrl redis://dedupe-redis:6379/${db} ${extraArgs} ${
       wacz ? "--generateWACZ" : ""
     }`,
   );
@@ -163,6 +166,43 @@ test("check revisit records written on duplicate crawl, same collection, no wacz
   numResponses = response;
 
   await checkSizeStats(numResponses, "allcounts", 0, 77000);
+});
+
+test("no dedupe disables revisit records even with redisDedupeUrl set", async () => {
+  const collName = "dedupe-test-disabled";
+
+  expect(
+    await runCrawl(collName, {
+      limit: 1,
+      wacz: false,
+      extraArgs: "--no-dedupe",
+    }),
+  ).toBe(0);
+  deleteFirstWARC(collName);
+
+  expect(
+    await runCrawl(collName, {
+      limit: 1,
+      wacz: false,
+      extraArgs: "--no-dedupe",
+    }),
+  ).toBe(0);
+
+  let revisit = 0;
+
+  const parser = loadFirstWARC(collName);
+
+  for await (const record of parser) {
+    if (record.warcTargetURI && record.warcTargetURI.startsWith("urn:")) {
+      continue;
+    }
+
+    if (record.warcType === "revisit") {
+      revisit++;
+    }
+  }
+
+  expect(revisit).toBe(0);
 });
 
 test("dedupe same collection, with wacz, no external waczs referenced", async () => {


### PR DESCRIPTION
This adds a new boolean crawl option, dedupe, which defaults to true and can be disabled on the CLI with --no-dedupe.

When deduplication is disabled, the crawler no longer writes WARC revisit records and ignores dedupe-specific behavior such as cross-crawl dedupe via --redisDedupeUrl and page-level dedupe via
  --dedupePagesMinDepth.

The change is intentionally scoped to dedupe behavior only:

- content hash lookup for revisits is skipped
- dedupe hash state is not written
- page dedupe logic is disabled
- external dedupe store usage is bypassed when dedupe is off

Testing:

- added a regression case to tests/dedupe-basic.test.ts that runs a crawl with --no-dedupe and verifies that no revisit records are written, even when --redisDedupeUrl is set

Notes:

- CLI usage is --no-dedupe
- config/YAML usage is dedupe: false
