### PR TITLE
browser: adjust two calls

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -273,7 +273,7 @@ export class Browser {
     }
 
     try {
-      child_process.execSync("tar xvfz " + profileLocalSrc, {
+      child_process.execFileSync("tar", ["xvfz", profileLocalSrc], {
         cwd: profileDir,
         stdio: "ignore",
       });
@@ -284,8 +284,9 @@ export class Browser {
   }
 
   removeSingletons() {
+    const singletons = fs.globSync("./Singleton*");
     try {
-      child_process.execSync("rm ./Singleton*", {
+      child_process.execFileSync("rm", singletons, {
         cwd: this.profileDir,
         stdio: "ignore",
       });


### PR DESCRIPTION
I've broken this out from #1031 since node 20, which we're using at the moment, doesn't have the `glob` family of functions. We can discuss this one separately and decide how we want to do it.