### PR TITLE
tests: point test-extract at webrecorder.net

### DIFF
--- a/tests/text-extract.test.ts
+++ b/tests/text-extract.test.ts
@@ -4,7 +4,7 @@ import child_process, { ExecException } from "child_process";
 test("check that urn:text and urn:textfinal records are written to WARC", async () => {
   try {
     child_process.execSync(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection text-extract --url https://www.nytimes.com/ --scopeType page --generateCDX --text to-warc,final-to-warc",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection text-extract --url https://webrecorder.net/ --scopeType page --generateCDX --text to-warc,final-to-warc",
     );
   } catch (error) {
     //console.log(new TextDecoder().decode(error));
@@ -16,7 +16,7 @@ test("check that urn:text and urn:textfinal records are written to WARC", async 
     { encoding: "utf-8" },
   );
 
-  expect(data.indexOf("urn:text:https://www.nytimes.com/") > 0).toBe(true);
+  expect(data.indexOf("urn:text:https://webrecorder.net/") > 0).toBe(true);
 
-  expect(data.indexOf("urn:textFinal:https://www.nytimes.com/") > 0).toBe(true);
+  expect(data.indexOf("urn:textFinal:https://webrecorder.net/") > 0).toBe(true);
 });

--- a/tests/text-extract.test.ts
+++ b/tests/text-extract.test.ts
@@ -4,7 +4,7 @@ import child_process, { ExecException } from "child_process";
 test("check that urn:text and urn:textfinal records are written to WARC", async () => {
   try {
     child_process.execSync(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection text-extract --url https://old.webrecorder.net/ --scopeType page --generateCDX --text to-warc,final-to-warc",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection text-extract --url https://old.webrecorder.net/community --scopeType page --generateCDX --text to-warc,final-to-warc",
     );
   } catch (error) {
     //console.log(new TextDecoder().decode(error));
@@ -16,9 +16,9 @@ test("check that urn:text and urn:textfinal records are written to WARC", async 
     { encoding: "utf-8" },
   );
 
-  expect(data.indexOf("urn:text:https://old.webrecorder.net/") > 0).toBe(true);
+  expect(data.indexOf("urn:text:https://old.webrecorder.net/community") > 0).toBe(true);
 
-  expect(data.indexOf("urn:textFinal:https://old.webrecorder.net/") > 0).toBe(
+  expect(data.indexOf("urn:textFinal:https://old.webrecorder.net/community") > 0).toBe(
     true,
   );
 });

--- a/tests/text-extract.test.ts
+++ b/tests/text-extract.test.ts
@@ -16,9 +16,11 @@ test("check that urn:text and urn:textfinal records are written to WARC", async 
     { encoding: "utf-8" },
   );
 
-  expect(data.indexOf("urn:text:https://old.webrecorder.net/community") > 0).toBe(true);
+  expect(
+    data.indexOf("urn:text:https://old.webrecorder.net/community") > 0,
+  ).toBe(true);
 
-  expect(data.indexOf("urn:textFinal:https://old.webrecorder.net/community") > 0).toBe(
-    true,
-  );
+  expect(
+    data.indexOf("urn:textFinal:https://old.webrecorder.net/community") > 0,
+  ).toBe(true);
 });

--- a/tests/text-extract.test.ts
+++ b/tests/text-extract.test.ts
@@ -4,7 +4,7 @@ import child_process, { ExecException } from "child_process";
 test("check that urn:text and urn:textfinal records are written to WARC", async () => {
   try {
     child_process.execSync(
-      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection text-extract --url https://webrecorder.net/ --scopeType page --generateCDX --text to-warc,final-to-warc",
+      "docker run -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --collection text-extract --url https://old.webrecorder.net/ --scopeType page --generateCDX --text to-warc,final-to-warc",
     );
   } catch (error) {
     //console.log(new TextDecoder().decode(error));
@@ -16,7 +16,9 @@ test("check that urn:text and urn:textfinal records are written to WARC", async 
     { encoding: "utf-8" },
   );
 
-  expect(data.indexOf("urn:text:https://webrecorder.net/") > 0).toBe(true);
+  expect(data.indexOf("urn:text:https://old.webrecorder.net/") > 0).toBe(true);
 
-  expect(data.indexOf("urn:textFinal:https://webrecorder.net/") > 0).toBe(true);
+  expect(data.indexOf("urn:textFinal:https://old.webrecorder.net/") > 0).toBe(
+    true,
+  );
 });


### PR DESCRIPTION
The previous version isn't working in CI, possibly because nytimes.com is blocking Azure's IP ranges.