### PR TITLE
crawler: treat addLink links as in scope unless excluded

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -67,7 +67,7 @@ import {
 } from "puppeteer-core";
 import { Recorder } from "./util/recorder.js";
 import { SitemapReader } from "./util/sitemapper.js";
-import { ScopedSeed, parseSeeds } from "./util/seeds.js";
+import { LinkEntry, ScopedSeed, parseSeeds } from "./util/seeds.js";
 import { WARCWriter, createWARCInfo, setWARCInfo } from "./util/warcwriter.js";
 import { isHTMLMime, isRedirectStatus } from "./util/reqresp.js";
 import { initProxy } from "./util/proxy.js";
@@ -775,55 +775,18 @@ export class Crawler {
     }
   }
 
-  protected getScope(
-    {
-      seedId,
-      url,
-      depth,
-      extraHops,
-      noOOS,
-      pageUrl,
-    }: {
-      seedId: number;
-      url: string;
-      depth: number;
-      extraHops: number;
-      noOOS: boolean;
-      pageUrl?: string;
-    },
-    logDetails = {},
-  ) {
-    return this.seeds[seedId].isIncluded(
-      url,
-      depth,
-      extraHops,
-      logDetails,
-      noOOS,
-      pageUrl,
-    );
+  protected getScope(seedId: number, link: LinkEntry, logDetails: LogDetails) {
+    return this.seeds[seedId].isIncluded(link, logDetails);
   }
 
   async isInScope(
-    {
-      seedId,
-      url,
-      depth,
-      pageUrl,
-      extraHops,
-      ignoreScope,
-    }: {
-      seedId: number;
-      url: string;
-      depth: number;
-      extraHops: number;
-      pageUrl?: string;
-      ignoreScope?: boolean;
-    },
-    logDetails = {},
+    seedId: number,
+    link: LinkEntry,
+    logDetails: LogDetails = {},
   ): Promise<boolean> {
     // If we've been told to explicitly ignore the scope,
     // then this is always in scope.
-    if (ignoreScope) {
+    if (link.ignoreScope) {
       return true;
     }
 
@@ -833,16 +796,10 @@ export class Crawler {
       seedId,
     );
 
-    const res = seed.isIncluded(
-      url,
-      depth,
-      extraHops,
-      logDetails,
-      false,
-      pageUrl,
-    );
+    const res = seed.isIncluded(link, logDetails);
 
     if (!res) {
+      const { url, depth } = link;
       this.writeSkippedPage(url, seedId, depth, SkippedReason.OutOfScope);
     }
 
@@ -1018,15 +975,15 @@ self.__bx_behaviors.selectMainBehavior();
 
           const logDetails = { page: url, workerid };
 
-          await this.queueInScopeUrls(
+          await this.queueInScopeUrls({
             seedId,
-            [params.url],
+            urls: [params.url],
             depth,
             extraHops,
-            false,
-            url,
+            noOOS: false,
+            pageUrl: url,
             logDetails,
-          );
+          });
         });
       }
     }
@@ -2737,15 +2694,16 @@ self.__bx_behaviors.selectMainBehavior();
   ) {
     const { seedId, depth, extraHops = 0, filteredFrames, callbacks } = data;
 
-    callbacks.addLink = async (url: string) => {
-      await this.queueNonExcludedUrls(
+    callbacks.addLink = async (url: string, enforceScope = false) => {
+      await this.queueInScopeUrls({
         seedId,
-        [url],
+        urls: [url],
         depth,
         extraHops,
-        page.url(),
+        pageUrl: page.url(),
         logDetails,
-      );
+        ignoreScope: !enforceScope,
+      });
     };
 
     const frames = filteredFrames || page.frames();
@@ -2782,15 +2740,25 @@ self.__bx_behaviors.selectMainBehavior();
     }
   }
 
-  async queueInScopeUrls(
-    seedId: number,
-    urls: string[],
-    depth: number,
+  async queueInScopeUrls({
+    seedId,
+    urls,
+    depth,
     extraHops = 0,
     noOOS = false,
-    pageUrl?: string,
-    logDetails: LogDetails = {},
-  ) {
+    pageUrl = undefined,
+    ignoreScope = false,
+    logDetails = {},
+  }: {
+    seedId: number;
+    urls: string[];
+    depth: number;
+    extraHops?: number;
+    noOOS?: boolean;
+    pageUrl?: string;
+    ignoreScope?: boolean;
+    logDetails?: LogDetails;
+  }) {
     try {
       depth += 1;
 
@@ -2799,13 +2767,14 @@ self.__bx_behaviors.selectMainBehavior();
 
       for (const possibleUrl of urls) {
         const res = this.getScope(
+          seedId,
           {
             url: possibleUrl,
             extraHops: newExtraHops,
             depth,
-            seedId,
             noOOS,
             pageUrl,
+            ignoreScope,
           },
           logDetails,
         );
@@ -2836,44 +2805,6 @@ self.__bx_behaviors.selectMainBehavior();
             logDetails,
           );
         }
-      }
-    } catch (e) {
-      logger.error("Queuing Error", e, "links");
-    }
-  }
-
-  async queueNonExcludedUrls(
-    seedId: number,
-    urls: string[],
-    depth: number,
-    extraHops = 0,
-    pageUrl?: string,
-    logDetails: LogDetails = {},
-  ) {
-    try {
-      depth += 1;
-
-      for (const possibleUrl of urls) {
-        if (this.seeds[seedId].isExcluded(possibleUrl)) {
-          logger.warn("Skipping Link; excluded", { url: possibleUrl }, "links");
-          this.writeSkippedPage(
-            possibleUrl,
-            seedId,
-            depth,
-            SkippedReason.OutOfScope,
-          );
-        }
-
-        await this.queueUrl(
-          seedId,
-          possibleUrl,
-          depth,
-          extraHops,
-          logDetails,
-          0,
-          undefined,
-          { ignoreScope: true },
-        );
       }
     } catch (e) {
       logger.error("Queuing Error", e, "links");
@@ -2913,7 +2844,7 @@ self.__bx_behaviors.selectMainBehavior();
     logDetails: LogDetails = {},
     ts = 0,
     pageid?: string,
-    extraData = {},
+    ignoreScope = false,
   ) {
     if (this.limitHit) {
       logger.debug(
@@ -2939,7 +2870,7 @@ self.__bx_behaviors.selectMainBehavior();
     }
 
     const result = await this.crawlState.addToQueue(
-      { url, seedId, depth, extraHops, ts, pageid, ...extraData },
+      { url, seedId, depth, extraHops, ts, pageid, ignoreScope },
       this.queuePageLimit,
     );
 
@@ -3210,9 +3141,13 @@ self.__bx_behaviors.selectMainBehavior();
             "sitemap",
           );
         }
-        this.queueInScopeUrls(seedId, [url], 0, 0, true).catch((e) =>
-          logger.warn("Error queuing urls", e, "links"),
-        );
+        this.queueInScopeUrls({
+          seedId,
+          urls: [url],
+          depth: 0,
+          extraHops: 0,
+          noOOS: true,
+        }).catch((e) => logger.warn("Error queuing urls", e, "links"));
         if (count >= 100 && !resolved) {
           logger.info(
             "Sitemap partially parsed, continue parsing large sitemap in the background",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -810,15 +810,23 @@ export class Crawler {
       depth,
       pageUrl,
       extraHops,
+      ignoreScope,
     }: {
       seedId: number;
       url: string;
       depth: number;
       extraHops: number;
       pageUrl?: string;
+      ignoreScope?: boolean;
     },
     logDetails = {},
   ): Promise<boolean> {
+    // If we've been told to explicitly ignore the scope,
+    // then this is always in scope.
+    if (ignoreScope) {
+      return true;
+    }
+
     const seed = await this.crawlState.getSeedAt(
       this.seeds,
       this.numOriginalSeeds,
@@ -2730,12 +2738,11 @@ self.__bx_behaviors.selectMainBehavior();
     const { seedId, depth, extraHops = 0, filteredFrames, callbacks } = data;
 
     callbacks.addLink = async (url: string) => {
-      await this.queueInScopeUrls(
+      await this.queueNonExcludedUrls(
         seedId,
         [url],
         depth,
         extraHops,
-        false,
         page.url(),
         logDetails,
       );
@@ -2804,6 +2811,11 @@ self.__bx_behaviors.selectMainBehavior();
         );
 
         if (!res) {
+          logger.warn(
+            "Skipping Link; not in scope",
+            { url: possibleUrl },
+            "links",
+          );
           this.writeSkippedPage(
             possibleUrl,
             seedId,
@@ -2824,6 +2836,44 @@ self.__bx_behaviors.selectMainBehavior();
             logDetails,
           );
         }
+      }
+    } catch (e) {
+      logger.error("Queuing Error", e, "links");
+    }
+  }
+
+  async queueNonExcludedUrls(
+    seedId: number,
+    urls: string[],
+    depth: number,
+    extraHops = 0,
+    pageUrl?: string,
+    logDetails: LogDetails = {},
+  ) {
+    try {
+      depth += 1;
+
+      for (const possibleUrl of urls) {
+        if (this.seeds[seedId].isExcluded(possibleUrl)) {
+          logger.warn("Skipping Link; excluded", { url: possibleUrl }, "links");
+          this.writeSkippedPage(
+            possibleUrl,
+            seedId,
+            depth,
+            SkippedReason.OutOfScope,
+          );
+        }
+
+        await this.queueUrl(
+          seedId,
+          possibleUrl,
+          depth,
+          extraHops,
+          logDetails,
+          0,
+          undefined,
+          { ignoreScope: true },
+        );
       }
     } catch (e) {
       logger.error("Queuing Error", e, "links");
@@ -2863,6 +2913,7 @@ self.__bx_behaviors.selectMainBehavior();
     logDetails: LogDetails = {},
     ts = 0,
     pageid?: string,
+    extraData = {},
   ) {
     if (this.limitHit) {
       logger.debug(
@@ -2888,7 +2939,7 @@ self.__bx_behaviors.selectMainBehavior();
     }
 
     const result = await this.crawlState.addToQueue(
-      { url, seedId, depth, extraHops, ts, pageid },
+      { url, seedId, depth, extraHops, ts, pageid, ...extraData },
       this.queuePageLimit,
     );
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2694,7 +2694,11 @@ self.__bx_behaviors.selectMainBehavior();
   ) {
     const { seedId, depth, extraHops = 0, filteredFrames, callbacks } = data;
 
-    callbacks.addLink = async (url: string, enforceScope = false) => {
+    callbacks.addLink = async (url: string, enforceScope = true) => {
+      if (this.params.allowBehaviorLinks) {
+        enforceScope = false;
+      }
+
       await this.queueInScopeUrls({
         seedId,
         urls: [url],
@@ -2803,6 +2807,9 @@ self.__bx_behaviors.selectMainBehavior();
             depth,
             isOOS ? newExtraHops : extraHops,
             logDetails,
+            0,
+            undefined,
+            ignoreScope,
           );
         }
       }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2500,7 +2500,7 @@ self.__bx_behaviors.selectMainBehavior();
           },
         );
       } else if (
-        !(await this.isInScope({ seedId, url: newUrl, depth, extraHops: 0 }))
+        !(await this.isInScope(seedId, { url: newUrl, depth, extraHops: 0 }))
       ) {
         logger.info(
           "Seed page redirected, only crawling this page. " +

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2046,7 +2046,14 @@ self.__bx_behaviors.selectMainBehavior();
   protected async _addInitialSeeds() {
     for (let i = 0; i < this.seeds.length; i++) {
       const seed = this.seeds[i];
-      if (!(await this.queueUrl(i, seed.url, 0, 0))) {
+      if (
+        !(await this.queueUrl({
+          seedId: i,
+          url: seed.url,
+          depth: 0,
+          extraHops: 0,
+        }))
+      ) {
         if (this.limitHit) {
           break;
         }
@@ -2801,16 +2808,14 @@ self.__bx_behaviors.selectMainBehavior();
         const { url, isOOS } = res;
 
         if (url) {
-          await this.queueUrl(
+          await this.queueUrl({
             seedId,
             url,
             depth,
-            isOOS ? newExtraHops : extraHops,
+            extraHops: isOOS ? newExtraHops : extraHops,
             logDetails,
-            0,
-            undefined,
             ignoreScope,
-          );
+          });
         }
       }
     } catch (e) {
@@ -2843,16 +2848,25 @@ self.__bx_behaviors.selectMainBehavior();
     }
   }
 
-  async queueUrl(
-    seedId: number,
-    url: string,
-    depth: number,
-    extraHops: number,
-    logDetails: LogDetails = {},
+  async queueUrl({
+    seedId,
+    url,
+    depth,
+    extraHops,
+    logDetails = {},
     ts = 0,
-    pageid?: string,
+    pageid = undefined,
     ignoreScope = false,
-  ) {
+  }: {
+    seedId: number;
+    url: string;
+    depth: number;
+    extraHops: number;
+    logDetails?: LogDetails;
+    ts?: number;
+    pageid?: string;
+    ignoreScope?: boolean;
+  }) {
     if (this.limitHit) {
       logger.debug(
         "Page URL not queued, at page limit",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2701,9 +2701,11 @@ self.__bx_behaviors.selectMainBehavior();
   ) {
     const { seedId, depth, extraHops = 0, filteredFrames, callbacks } = data;
 
-    callbacks.addLink = async (url: string, enforceScope = true) => {
-      if (this.params.allowBehaviorLinks) {
-        enforceScope = false;
+    callbacks.addLink = async (url: string, ignoreScope = false) => {
+      // if crawler arg set, always ignore scope
+      // otherwise, may be determined by behavior addLink()
+      if (this.params.ignoreScopeForBehaviorLinks) {
+        ignoreScope = true;
       }
 
       await this.queueInScopeUrls({
@@ -2713,7 +2715,7 @@ self.__bx_behaviors.selectMainBehavior();
         extraHops,
         pageUrl: page.url(),
         logDetails,
-        ignoreScope: !enforceScope,
+        ignoreScope,
       });
     };
 

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -252,7 +252,14 @@ export class ReplayCrawler extends Crawler {
       }
     }
 
-    await this.queueUrl(0, url, depth, 0, {}, ts, id);
+    await this.queueUrl({
+      seedId: 0,
+      url,
+      depth,
+      extraHops: 0,
+      ts,
+      pageid: id,
+    });
   }
 
   async loadPagesDirect(pages: ReplayPage[]) {

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -785,6 +785,13 @@ class ArgParser {
           type: "number",
           default: -1,
         },
+
+        allowBehaviorLinks: {
+          describe:
+            "If set, permits addLink calls from behavior scripts to bypass crawl scope and ensures that the extra links are always crawled",
+          type: "boolean",
+          default: false,
+        },
       });
   }
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -189,6 +189,13 @@ class ArgParser {
           coerce,
         },
 
+        ignoreScopeForBehaviorLinks: {
+          describe:
+            "If set, permits addLink() calls from behavior scripts to bypass crawl scope and ensures that the extra links are always crawled",
+          type: "boolean",
+          default: false,
+        },
+
         clickSelector: {
           describe:
             "Selector for elements to click when using the autoclick behavior",
@@ -784,13 +791,6 @@ class ArgParser {
             "If >0, threshold for number of rate limited pages before crawl is considered rate limited and is interrupted",
           type: "number",
           default: -1,
-        },
-
-        allowBehaviorLinks: {
-          describe:
-            "If set, permits addLink calls from behavior scripts to bypass crawl scope and ensures that the extra links are always crawled",
-          type: "boolean",
-          default: false,
         },
       });
   }

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 
 import { MAX_DEPTH } from "./constants.js";
 import { collectOnlineSeedFile } from "./file_reader.js";
-import { logger } from "./logger.js";
+import { LogDetails, logger } from "./logger.js";
 import { type CrawlerArgs } from "./argParser.js";
 import { normalizeUrl } from "./normalize.js";
 
@@ -25,6 +25,15 @@ export type ScopedSeedInitOpts = {
   sitemap?: string | boolean | null;
   extraHops?: number;
   auth?: string | null;
+};
+
+export type LinkEntry = {
+  url: string;
+  depth: number;
+  extraHops?: number;
+  noOOS?: boolean;
+  ignoreScope?: boolean;
+  pageUrl?: string;
 };
 
 export class ScopedSeed {
@@ -145,7 +154,7 @@ export class ScopedSeed {
     }
   }
 
-  parseUrl(url: string, pageUrl?: string, logDetails = {}) {
+  parseUrl(url: string, pageUrl?: string, logDetails: LogDetails = {}) {
     let parsedUrl = null;
     try {
       parsedUrl = new URL(url.trim(), pageUrl);
@@ -247,12 +256,15 @@ export class ScopedSeed {
   }
 
   isIncluded(
-    url: string,
-    depth: number,
-    extraHops = 0,
-    logDetails = {},
-    noOOS = false,
-    pageUrl?: string,
+    {
+      url,
+      depth = 0,
+      extraHops = 0,
+      noOOS = false,
+      ignoreScope = false,
+      pageUrl,
+    }: LinkEntry,
+    logDetails: LogDetails = {},
   ): { url: string; isOOS: boolean } | false {
     const urlParsed = this.parseUrl(url, pageUrl, logDetails);
     if (!urlParsed) {
@@ -273,15 +285,12 @@ export class ScopedSeed {
       return { url, isOOS: false };
     }
 
-    // skip already crawled
-    // if (this.seenList.has(url)) {
-    //  return false;
-    //}
-    let inScope = false;
+    // if ignoring scope, all URLs in scope unless excluded
+    let inScope = ignoreScope;
 
     // check scopes if depth <= maxDepth
     // if depth exceeds, than always out of scope
-    if (depth <= this.maxDepth) {
+    if (!inScope && depth <= this.maxDepth) {
       for (const s of this.include) {
         if (s.test(normUrl)) {
           inScope = true;

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -61,6 +61,7 @@ export type QueueEntry = {
   ts?: number;
   pageid?: string;
   retry?: number;
+  ignoreScope?: boolean;
 };
 
 // ============================================================================
@@ -90,6 +91,7 @@ export class PageState {
   title?: string;
   mime?: string;
   ts?: Date;
+  ignoreScope?: boolean;
 
   callbacks: PageCallbacks = {};
 
@@ -124,6 +126,9 @@ export class PageState {
     this.pageid = redisData.pageid || uuidv4();
     this.status = 0;
     this.retry = redisData.retry || 0;
+    if (redisData.ignoreScope) {
+      this.ignoreScope = redisData.ignoreScope;
+    }
   }
 }
 
@@ -1365,6 +1370,7 @@ return inx;
       extraHops = 0,
       ts = 0,
       pageid = undefined,
+      ignoreScope = undefined,
     }: QueueEntry,
     limit = 0,
   ) {
@@ -1379,6 +1385,9 @@ return inx;
     }
     if (pageid) {
       data.pageid = pageid;
+    }
+    if (ignoreScope) {
+      data.ignoreScope = ignoreScope;
     }
 
     // return codes

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -40,7 +40,7 @@ export enum QueueState {
 }
 
 // ============================================================================
-// treat 0 or 206 as 200 for purposes of dedup
+// treat 0 or 206 as 200 for purposes of dedupe
 export function normalizeDedupeStatus(status: number): string {
   if (status === 0 || status === 206) {
     return "200";
@@ -1141,7 +1141,9 @@ return inx;
   recheckScope(data: QueueEntry, seeds: ScopedSeed[]) {
     const seed = seeds[data.seedId];
 
-    return seed.isIncluded(data.url, data.depth, data.extraHops);
+    const { url, depth, extraHops } = data;
+
+    return seed.isIncluded({ url, depth, extraHops });
   }
 
   async isFinished() {

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -383,7 +383,9 @@ export class PageWorker {
         }
 
         // filter out any out-of-scope pages right away
-        if (!(await this.crawler.isInScope(data, this.logDetails))) {
+        if (
+          !(await this.crawler.isInScope(data.seedId, data, this.logDetails))
+        ) {
           logger.info("Page no longer in scope", data);
           await crawlState.markExcluded(data.url);
           continue;

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -44,12 +44,63 @@ seeds:
 
 exclude: https://example.com/pathexclude
 
+depth: 2
 `);
 
   expect(seeds.length).toEqual(1);
   expect(seeds[0].scopeType).toEqual("prefix");
   expect(seeds[0].include).toEqual([/^https?:\/\/example\.com\//]);
   expect(seeds[0].exclude).toEqual([/https:\/\/example.com\/pathexclude/]);
+
+  // included, in scope
+  expect(
+    seeds[0].isIncluded({ url: "https://example.com/path", depth: 0 }),
+  ).not.toBe(false);
+
+  // included, ignore scope
+  expect(
+    seeds[0].isIncluded({
+      url: "https://example.org/",
+      depth: 0,
+      ignoreScope: true,
+    }),
+  ).not.toBe(false);
+
+  // included, ignore scope, and depth limit exceeded
+  expect(
+    seeds[0].isIncluded({
+      url: "https://example.org/",
+      depth: 3,
+      ignoreScope: true,
+    }),
+  ).not.toBe(false);
+
+  // not included, in scope, but depth limit exceeded
+  expect(
+    seeds[0].isIncluded({ url: "https://example.com/path", depth: 3 }),
+  ).toBe(false);
+
+  // not included, not in scope
+  expect(seeds[0].isIncluded({ url: "https://example.org/", depth: 0 })).toBe(
+    false,
+  );
+
+  // not included, excluded
+  expect(
+    seeds[0].isIncluded({
+      url: "https://example.com/pathexclude/subpath",
+      depth: 0,
+    }),
+  ).toBe(false);
+
+  // not included, ignore scope, but still excluded
+  expect(
+    seeds[0].isIncluded({
+      url: "https://example.com/pathexclude/subpath",
+      depth: 0,
+      ignoreScope: true,
+    }),
+  ).toBe(false);
 });
 
 test("default scope + exclude is numeric", async () => {
@@ -348,20 +399,18 @@ seeds:
   expect(seeds[0].maxExtraHops).toEqual(0);
 
   // Test with the same URL (should match)
-  const result1 = seeds[0].isIncluded(
-    "https://example.com/page?foo=bar&baz=qux",
-    0,
-    0,
-  );
+  const result1 = seeds[0].isIncluded({
+    url: "https://example.com/page?foo=bar&baz=qux",
+    depth: 0,
+  });
   expect(result1).not.toBe(false);
   expect((result1 as Exclude<typeof result1, false>).isOOS).toBe(false);
 
   // Test with reordered query parameters (should still match)
-  const result2 = seeds[0].isIncluded(
-    "https://example.com/page?baz=qux&foo=bar",
-    0,
-    0,
-  );
+  const result2 = seeds[0].isIncluded({
+    url: "https://example.com/page?baz=qux&foo=bar",
+    depth: 0,
+  });
   expect(result2).not.toBe(false);
   expect((result2 as Exclude<typeof result2, false>).isOOS).toBe(false);
 });
@@ -381,12 +430,12 @@ seeds:
   expect(seeds[0].maxExtraHops).toEqual(0);
 
   // Test with the same URL (should match)
-  const result1 = seeds[0].isIncluded(doubleEncodedUrl, 0, 0);
+  const result1 = seeds[0].isIncluded({ url: doubleEncodedUrl, depth: 0 });
   expect(result1).not.toBe(false);
   expect((result1 as Exclude<typeof result1, false>).isOOS).toBe(false);
 
   // Test with self (should match)
-  const result2 = seeds[0].isIncluded(seeds[0].url, 0, 0);
+  const result2 = seeds[0].isIncluded({ url: seeds[0].url, depth: 0 });
   expect(result2).not.toBe(false);
   expect((result2 as Exclude<typeof result2, false>).isOOS).toBe(false);
 });
@@ -402,7 +451,10 @@ scopeType: page
   expect(seeds[0].scopeType).toEqual("page");
 
   // Test with self (should match)
-  const result = seeds[0].isIncluded("https://example.com/#hashtag", 0, 0);
+  const result = seeds[0].isIncluded({
+    url: "https://example.com/#hashtag",
+    depth: 0,
+  });
   expect(result).not.toBe(false);
   expect((result as Exclude<typeof result, false>).isOOS).toBe(false);
 });
@@ -443,37 +495,28 @@ scopeType: prefix
   expect(seeds[0].scopeType).toEqual("prefix");
   expect(seeds[0].allowHash).toEqual(true);
 
-  const result1 = seeds[0].isIncluded(
-    "#abc",
-    0,
-    0,
-    {},
-    false,
-    "https://example.com/",
-  );
+  const result1 = seeds[0].isIncluded({
+    url: "#abc",
+    depth: 0,
+    pageUrl: "https://example.com/",
+  });
   expect(result1).not.toBe(false);
   expect((result1 as Exclude<typeof result1, false>).url).toBe(
     "https://example.com/#abc",
   );
 
-  const result2 = seeds[0].isIncluded(
-    "#abc",
-    0,
-    0,
-    {},
-    false,
-    "https://example.org/",
-  );
+  const result2 = seeds[0].isIncluded({
+    url: "#abc",
+    depth: 0,
+    pageUrl: "https://example.org/",
+  });
   expect(result2).toBe(false);
 
-  const result3 = seeds[0].isIncluded(
-    "/abc",
-    0,
-    0,
-    {},
-    false,
-    "https://example.com/",
-  );
+  const result3 = seeds[0].isIncluded({
+    url: "/abc",
+    depth: 0,
+    pageUrl: "https://example.com/",
+  });
   expect(result3).not.toBe(false);
   expect((result3 as Exclude<typeof result1, false>).url).toBe(
     "https://example.com/abc",


### PR DESCRIPTION
Previously, links added via behaviours could be rejected as out of scope. This could be confusing to users, who may have expected these URLs to end up being included. For example, when archiving an Instagram profile, we add URLs to archive the stories, but these would be skipped if the profile was added via certain scopes. This adds a new `ignoreScope` parameter which, when present, causes us to ignore the usual out of scope check and only consider explicit exclusions. It also uses a new method to add these URLs to the queue which doesn't perform scope checks and only looks for explicit exclusions.

Fixes #1033.