### PR TITLE
ci: update docker actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
           key: docker-${{ runner.os }}-${{ hashFiles('Dockerfile') }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/deploy-dev-channel.yaml
+++ b/.github/workflows/deploy-dev-channel.yaml
@@ -25,14 +25,14 @@ jobs:
           driver-opts: network=host
 
       - name: Login to Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.DEPLOY_REGISTRY }}
           username: ${{ secrets.DEPLOY_REGISTRY_API_TOKEN }}
           password: ${{ secrets.DEPLOY_REGISTRY_API_TOKEN }}
 
       - name: Build Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,13 +27,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
This is similar to #1029, but updates the Docker-managed actions versions. These were also warning us about node changes. I don't *think* any of these changes will break things for us; I read the changelogs.