### PR TITLE
ci: skip docker login for external PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
           key: docker-${{ runner.os }}-${{ hashFiles('Dockerfile') }}
 
       - name: Login to DockerHub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
This allows external PRs to still run without dockerhub login, but will be more rate limited