### PR TITLE
Dockefile: avoid persisting cache in layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,15 +33,14 @@ RUN mkdir -p /tmp/ads && cd /tmp/ads && \
     cat ad-hosts.txt | grep '^0.0.0.0 '| awk '{ print $2; }' | grep -v '0.0.0.0' | jq --raw-input --slurp 'split("\n")' > /app/ad-hosts.json && \
     rm /tmp/ads/ad-hosts.txt
 
-RUN yarn install --network-timeout 1000000
-
 ADD tsconfig.json /app/
 ADD src /app/src
 
-RUN yarn run tsc
-
-# prune devDependencies from the shipped image; runtime only needs production deps
-RUN yarn install --production --frozen-lockfile --network-timeout 1000000 && yarn cache clean
+# Last step prunes devDependencies from the shipped image;
+# runtime only needs production deps
+RUN yarn install --network-timeout 1000000 && \
+    yarn run tsc && \
+    yarn install --production --frozen-lockfile --network-timeout 1000000 && yarn cache clean
 
 ADD config/ /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ ADD src /app/src
 # runtime only needs production deps
 RUN yarn install --network-timeout 1000000 && \
     yarn run tsc && \
-    yarn install --production --frozen-lockfile --network-timeout 1000000 && yarn cache clean
+    yarn install --production --frozen-lockfile --network-timeout 1000000 && \
+    yarn cache clean
 
 ADD config/ /app/
 


### PR DESCRIPTION
#1042 intended to reduce the image size by removing the dev dependencies and clearing the cache, but because it did this in separate layers it didn't actually reduce the size of the image at all. The layer in which we first ran `yarn install` persisted that into the final image. Putting both yarn commands, the cache clean, and `tsc` in a single layer ensures we don't end up persisting this. Running locally, this took the container from 1535013302 bytes to 1403025478.