### PR TITLE
ci: avoid logging in for dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
           key: docker-${{ runner.os }}-${{ hashFiles('Dockerfile') }}
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
787398adf72c744af098ca2555518f2cf4dd6a61 restricted us to running this step when not running from a fork, but this didn't account for Dependabot - its permissions are the same as if it ran from a fork, but that's not reflected in `github.event.pull_request.head.repo.full_name`.