### PR TITLE
always remove singletons after profile is created, fixes #1021

### DIFF
--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -118,6 +118,9 @@ export class Browser {
 
     await this.installProfile(profileUrl);
 
+    // remove singletons from profile dir always
+    this.removeSingletons();
+
     this.swOpt = swOpt;
 
     this.emulateDevice = emulateDevice;
@@ -277,7 +280,6 @@ export class Browser {
         cwd: profileDir,
         stdio: "ignore",
       });
-      this.removeSingletons();
     } catch (e) {
       throw new Error(`Profile ${profileLocalSrc} not a valid tar.gz`);
     }


### PR DESCRIPTION
Singleton may still exist without a custom profile, since the profile dir may be persisted across restarts. This ensures they are removed when the crawler is starting.