### PR TITLE
restrict auto-adding redirected seeds

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -74,6 +74,7 @@ import { initProxy } from "./util/proxy.js";
 import { initFlow, nextFlowStep } from "./util/flowbehavior.js";
 import { isDisallowedByRobots, setRobotsConfig } from "./util/robots.js";
 import { request } from "undici";
+import { normalizedRedirectSeedUrl } from "./util/normalize.js";
 
 const btrixBehaviors = fs.readFileSync(
   new URL(
@@ -2505,17 +2506,40 @@ self.__bx_behaviors.selectMainBehavior();
       respUrl + "/" !== url &&
       !downloadResponse
     ) {
-      data.seedId = await this.crawlState.addExtraSeed(
-        this.seeds,
-        this.numOriginalSeeds,
-        data.seedId,
-        respUrl,
-      );
-      logger.info("Seed page redirected, adding redirected seed", {
-        origUrl: url,
-        newUrl: respUrl,
-        seedId: data.seedId,
-      });
+      const newUrl = respUrl;
+      const origUrl = url;
+      const seedId = data.seedId;
+
+      if (
+        normalizedRedirectSeedUrl(origUrl) == normalizedRedirectSeedUrl(newUrl)
+      ) {
+        data.seedId = await this.crawlState.addExtraSeed(
+          this.seeds,
+          this.numOriginalSeeds,
+          data.seedId,
+          respUrl,
+        );
+        logger.info(
+          "Seed page redirected out of scope, adding redirected seed",
+          {
+            origUrl,
+            newUrl,
+            seedId,
+          },
+        );
+      } else if (
+        !(await this.isInScope({ seedId, url: newUrl, depth, extraHops: 0 }))
+      ) {
+        logger.info(
+          "Seed page redirected, only crawling this page. " +
+            "New seed doesn't match original (ignoring scheme and www.), not adding new seed",
+          {
+            origUrl,
+            newUrl,
+            seedId,
+          },
+        );
+      }
     }
 
     const status = resp.status();

--- a/src/util/normalize.ts
+++ b/src/util/normalize.ts
@@ -24,3 +24,9 @@ export function normalizeUrl(url: string) {
     return url;
   }
 }
+
+// URL normalization for redirect seed
+// strip www. and set default protocol, but leave everything else unchanged
+export function normalizedRedirectSeedUrl(url: string) {
+  return url.replace(/^https?:\/\/(www[\d]*[.])?/, "");
+}

--- a/tests/normalize-examples.test.ts
+++ b/tests/normalize-examples.test.ts
@@ -1,0 +1,31 @@
+import { normalizeUrl, normalizedRedirectSeedUrl } from "../src/util/normalize";
+
+test("normalize url: normalize case and arg order", async () => {
+  expect(
+    normalizeUrl("https://WWW.example.com/path/somefile.html?B=2&A=1"),
+  ).toBe("https://www.example.com/path/somefile.html?A=1&B=2");
+});
+
+test("seed redirect: change in www. matches", async () => {
+  expect(normalizedRedirectSeedUrl("https://www.example.com/")).toBe(
+    normalizedRedirectSeedUrl("https://example.com/"),
+  );
+});
+
+test("seed redirect: change in scheme matches", async () => {
+  expect(normalizedRedirectSeedUrl("http://www3.example.com/")).toBe(
+    normalizedRedirectSeedUrl("http://example.com/"),
+  );
+});
+
+test("seed redirect: change in www. and scheme matches", async () => {
+  expect(normalizedRedirectSeedUrl("https://www3.example.com/")).toBe(
+    normalizedRedirectSeedUrl("http://example.com/"),
+  );
+});
+
+test("seed redirect: change in tld, does not match", async () => {
+  expect(
+    normalizedRedirectSeedUrl("https://www3.example.org/path/some"),
+  ).not.toBe(normalizedRedirectSeedUrl("http://example.com/path/some"));
+});


### PR DESCRIPTION
allow redirected seeds to be added as new seeds only if new URL differs by www. prefix or scheme:
- add new normalizedRedirectSeedUrl() which strips only www. and scheme
- if different redirect, print warning that new seed is not added
- if new seed page URL is in scope of original, continue as before, as crawl should be able to continue with original seed scope

fixes #1051