### PR TITLE
Add option to disable media sources

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -76,6 +76,8 @@ import { isDisallowedByRobots, setRobotsConfig } from "./util/robots.js";
 import { request } from "undici";
 import { normalizedRedirectSeedUrl } from "./util/normalize.js";
 
+import { DISABLE_MEDIASOURCE_SCRIPT } from "@webrecorder/wabac";
+
 const btrixBehaviors = fs.readFileSync(
   new URL(
     "../node_modules/browsertrix-behaviors/dist/behaviors.js",
@@ -888,6 +890,13 @@ self.__bx_behaviors.selectMainBehavior();
       });
 
       await this.browser.addInitScript(page, initScript);
+    }
+
+    // Used for sites like YouTube that serve up media we currently can't
+    // replay reliably; this forces them to serve up MP4 format media in a
+    // more convenient codec that we're able to replay better.
+    if (this.params.disableMediaSource) {
+      await this.browser.addInitScript(page, DISABLE_MEDIASOURCE_SCRIPT);
     }
 
     let dialogCount = 0;

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -792,6 +792,15 @@ class ArgParser {
           type: "number",
           default: -1,
         },
+
+        disableMediaSource: {
+          describe:
+            "If set, runs a script to disable AV1 media types for video site captures",
+          type: "boolean",
+          // We should consider changing the default to false in the future
+          // when this is less necessary for capturing sites like YouTube.
+          default: true,
+        },
       });
   }
 


### PR DESCRIPTION
This uses wabac's media source script to try to disable media types we currently have trouble playing back, for example YouTube's more complex video formats.