### PR TITLE
docker-compose: remove obsolete version parameter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   crawler:
     image: ${REGISTRY}webrecorder/browsertrix-crawler:latest


### PR DESCRIPTION
This was defined in earlier verisons but no longer does anything. docker-compose prints a warning if it's defined.
https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete