### PR TITLE
fix awaitPageResources() prematurely dropping pending requests

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1115,9 +1115,9 @@ export class Recorder extends EventEmitter {
         await this.serializeToWARC(reqresp);
         // if no url, and not fetching,
         // drop this request, as it was not being loaded
-      } else if (!reqresp.url || !isFetching) {
+      } else if (!reqresp.url && !isFetching) {
         logger.debug(
-          "Removing pending request that was never fetched",
+          "Removing empty request that was never fetched",
           { requestId, url: reqresp.url, ...this.logDetails },
           "recorder",
         );

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1106,17 +1106,19 @@ export class Recorder extends EventEmitter {
   }
 
   async awaitPageResources() {
+    // Check stale requests left in the pendingRequests list
     for (const [requestId, reqresp] of this.pendingRequests.entries()) {
-      // check if possibly being fetched
+      // check if possibly being fetched, continue
       if (reqresp.asyncLoading || reqresp.intercepting) {
         continue;
       }
 
+      // if request payload has finished, but somehow wasn't removed
+      // write and remove here
       if (reqresp.payload?.length) {
         this.removeReqResp(requestId);
         await this.serializeToWARC(reqresp);
-        // if no url, and not fetching,
-        // drop this request, as it was not being loaded
+        // if no URL set, likely this has been abandoned, drop
       } else if (!reqresp.url) {
         logger.debug(
           "Removing empty request that was never fetched",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1107,15 +1107,15 @@ export class Recorder extends EventEmitter {
 
   async awaitPageResources() {
     for (const [requestId, reqresp] of this.pendingRequests.entries()) {
-      if (reqresp.payload && !reqresp.asyncLoading) {
+      // check if possibly being fetched
+      const isFetching = reqresp.asyncLoading || reqresp.intercepting;
+
+      if (reqresp.payload?.length && !isFetching) {
         this.removeReqResp(requestId);
         await this.serializeToWARC(reqresp);
-        // if no url, and not fetch intercept or async loading,
+        // if no url, and not fetching,
         // drop this request, as it was not being loaded
-      } else if (
-        !reqresp.url ||
-        (!reqresp.intercepting && !reqresp.asyncLoading)
-      ) {
+      } else if (!reqresp.url || !isFetching) {
         logger.debug(
           "Removing pending request that was never fetched",
           { requestId, url: reqresp.url, ...this.logDetails },

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1108,14 +1108,16 @@ export class Recorder extends EventEmitter {
   async awaitPageResources() {
     for (const [requestId, reqresp] of this.pendingRequests.entries()) {
       // check if possibly being fetched
-      const isFetching = reqresp.asyncLoading || reqresp.intercepting;
+      if (reqresp.asyncLoading || reqresp.intercepting) {
+        continue;
+      }
 
-      if (reqresp.payload?.length && !isFetching) {
+      if (reqresp.payload?.length) {
         this.removeReqResp(requestId);
         await this.serializeToWARC(reqresp);
         // if no url, and not fetching,
         // drop this request, as it was not being loaded
-      } else if (!reqresp.url && !isFetching) {
+      } else if (!reqresp.url) {
         logger.debug(
           "Removing empty request that was never fetched",
           { requestId, url: reqresp.url, ...this.logDetails },


### PR DESCRIPTION
The pending request check did not account for 0 length payload and didn't check reqresp.intercepting, which is set when requested is being intercepted as part for CDN fetch handler:
- ensure payload is set to >0 and request is not currently being intercepted before writing and dropping!