### PR TITLE
Improve Docker labels (follow-up to #972)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: "linux/amd64,linux/arm64"
           build-args: |
             MINIMIZE_IMAGE_SIZE=1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,11 +26,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
       - name: Login to DockerHub
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,14 +13,14 @@ jobs:
 
       - name: Docker image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: webrecorder/browsertrix-crawler
           tags: |
             type=semver,pattern={{version}}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ ARG BROWSER_IMAGE_BASE=webrecorder/browsertrix-browser-base:brave-${BROWSER_VERS
 FROM ${BROWSER_IMAGE_BASE}
 
 LABEL org.opencontainers.image.vendor="Webrecorder <https://webrecorder.net/>"
-LABEL org.opencontainers.image.source="https://github.com/webrecorder/browsertrix-crawler"
 LABEL org.opencontainers.image.documentation="https://crawler.docs.browsertrix.com/"
-LABEL org.opencontainers.image.licenses="AGPL-3.0-or-later"
 
 # set to 1 to minimize size for prod, but longer build time, otherwise faster build and rebuild but larger image
 ARG MINIMIZE_IMAGE_SIZE=0


### PR DESCRIPTION
In #972, I added some OCI labels to the Docker image to better support Dependabot, Renovate, and other third-party tools. [There were some shortcomings](https://github.com/webrecorder/browsertrix-crawler/pull/972#issuecomment-4051071637), and this attempts to fix the ones that are fixable.

It turns out a some of the labels I added are already generated by the `docker/metadata-action` step, but we just weren’t applying them to the image build. The main thing here is to start applying those, and remove the redundant ones from the Dockerfile. This *also* improves things by setting some other recommended labels we were missing (e.g. `revision`, `created`) and overriding some that were bleeding through from the base image (`version`) and providing incorrect values for our build.

**I left the two static labels (`documentation` and `vendor`) in the Dockerfile itself. I can also move them to metadata action, too, if you think it’s better to define them there** (that action lets you list supplemental labels and also customize how the default labels are determined).

This now generates the following labels (based on a test build from my fork):

```
$ docker inspect mr0grog/test-browsertrix-crawler:1.0.0-b1 | jq '.[].Config.Labels'
{
  "org.opencontainers.image.created": "2026-06-29T18:22:09.776Z",
  "org.opencontainers.image.description": "Run a high-fidelity browser-based web archiving crawler in a single Docker container",
  "org.opencontainers.image.documentation": "https://crawler.docs.browsertrix.com/",
  "org.opencontainers.image.licenses": "AGPL-3.0",                                      # <- Note this is slightly different than the current label ("AGPL-3.0-or-later")
  "org.opencontainers.image.revision": "0720728402fcfcf50ae4b736213cbca17d57d6ec",
  "org.opencontainers.image.source": "https://github.com/Mr0grog/browsertrix-crawler",  # <- Will be correct when built from this repo :)
  "org.opencontainers.image.title": "browsertrix-crawler",
  "org.opencontainers.image.url": "https://github.com/Mr0grog/browsertrix-crawler",     # <- Will be correct when built from this repo
  "org.opencontainers.image.vendor": "Webrecorder <https://webrecorder.net/>",
  "org.opencontainers.image.version": "1.0.0-b1"                                        # <- Will be correct when built from this repo
}
```

Unfortunately, this *won’t* fix Dependabot not showing release notes in its PRs (but should be helpful for other tools). After a bunch of testing, it turns out [that Dependabot feature only works for images pulled from the GitHub container/package registry (`ghcr.io`) and not for images from Docker Hub](https://github.com/dependabot/dependabot-core/issues/15417). They just don’t document that fact anywhere. :(

While I was at it, I also updated the Docker actions (no breaking changes unless you are hosting your own runners) and cleaned up some spacing in the workflow definition.