### PR TITLE
Test CI with most recent commit reverted

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1106,22 +1106,18 @@ export class Recorder extends EventEmitter {
   }
 
   async awaitPageResources() {
-    // Check stale requests left in the pendingRequests list
     for (const [requestId, reqresp] of this.pendingRequests.entries()) {
-      // check if possibly being fetched, continue
-      if (reqresp.asyncLoading || reqresp.intercepting) {
-        continue;
-      }
-
-      // if request payload has finished, but somehow wasn't removed
-      // write and remove here
-      if (reqresp.payload?.length) {
+      if (reqresp.payload && !reqresp.asyncLoading) {
         this.removeReqResp(requestId);
         await this.serializeToWARC(reqresp);
-        // if no URL set, likely this has been abandoned, drop
-      } else if (!reqresp.url) {
+        // if no url, and not fetch intercept or async loading,
+        // drop this request, as it was not being loaded
+      } else if (
+        !reqresp.url ||
+        (!reqresp.intercepting && !reqresp.asyncLoading)
+      ) {
         logger.debug(
-          "Removing empty request that was never fetched",
+          "Removing pending request that was never fetched",
           { requestId, url: reqresp.url, ...this.logDetails },
           "recorder",
         );


### PR DESCRIPTION
We're seeing CI failures as of commit 217b8bd7c698a271173a3d178f581971905313dd. Let's test CI without it.