### PR TITLE
Add --addRedirectedSeeds setting to make seed redirect policy configurable

### DIFF
--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -380,11 +380,8 @@ Options:
                                             redirect to a URL out of scope. Defa
                                             ult (strict): add the redirect URL a
                                             s a seed only if it differs in schem
-                                            e or www subdomain. Other options: a
-                                            llow (always add redirect URL as new
-                                             seed), block (never add redirect UR
-                                            L as new seed).
-              [string] [choices: "strict", "allow", "block"] [default: "strict"]
+                                            e or www subdomain
+                [string] [choices: "strict", "add", "block"] [default: "strict"]
       --config                              Path to YAML config file
 ```
 

--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -376,6 +376,15 @@ Options:
                                             limited pages before crawl is consid
                                             ered rate limited and is interrupted
                                                           [number] [default: -1]
+      --redirectSeedOutOfScope              Policy for how to handle seeds that
+                                            redirect to a URL out of scope. Defa
+                                            ult (strict): add the redirect URL a
+                                            s a seed only if it differs in schem
+                                            e or www subdomain. Other options: a
+                                            llow (always add redirect URL as new
+                                             seed), block (never add redirect UR
+                                            L as new seed).
+              [string] [choices: "strict", "allow", "block"] [default: "strict"]
       --config                              Path to YAML config file
 ```
 

--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -376,12 +376,12 @@ Options:
                                             limited pages before crawl is consid
                                             ered rate limited and is interrupted
                                                           [number] [default: -1]
-      --redirectSeedOutOfScope              Policy for how to handle seeds that
+      --addRedirectSeeds                    Policy for how to handle seeds that
                                             redirect to a URL out of scope. Defa
                                             ult (strict): add the redirect URL a
                                             s a seed only if it differs in schem
                                             e or www subdomain
-                [string] [choices: "strict", "add", "block"] [default: "strict"]
+             [string] [choices: "always", "strict", "never"] [default: "strict"]
       --config                              Path to YAML config file
 ```
 

--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -376,7 +376,7 @@ Options:
                                             limited pages before crawl is consid
                                             ered rate limited and is interrupted
                                                           [number] [default: -1]
-      --addRedirectSeeds                    Policy for how to handle seeds that
+      --addRedirectedSeeds                  Policy for how to handle seeds that
                                             redirect to a URL out of scope. Defa
                                             ult (strict): add the redirect URL a
                                             s a seed only if it differs in schem

--- a/docs/docs/user-guide/crawl-scope.md
+++ b/docs/docs/user-guide/crawl-scope.md
@@ -48,15 +48,15 @@ The `--extraHops` setting can be set globally or per seed to allow expanding the
 
 ## Seed Redirects
 
-Some seed URLs may redirect to a different URL that would be otherwise out of scope. The `--redirectSeedOutOfScope` setting can be used to specify how such redirects should be handled with regard to crawl scope.
+Some seed URLs may redirect to a different URL that would be otherwise out of scope. The `--addRedirectSeeds` setting can be used to specify how such redirects should be handled with regard to crawl scope.
 
 The default value `strict` will add the new URL as a seed to the crawl scope if it differs from the specified seed URL in its scheme (`http` vs. `https`) or `www.` subdomain (`example.com` vs `www.example.com`).
 
 The other available options are:
 
-- `add` - always add the redirect URL as a new seed to the crawl scope
+- `always` - always add the redirect URL as a new seed to the crawl scope
 
-- `block` - never add the redirect URL as a new seed to the crawl scope
+- `never` - never add the redirect URL as a new seed to the crawl scope
 
 If the URL a seed redirects to is not added as a new seed due to the option chosen, only the immediate page that is redirected to will be included in the crawl.
 

--- a/docs/docs/user-guide/crawl-scope.md
+++ b/docs/docs/user-guide/crawl-scope.md
@@ -48,7 +48,7 @@ The `--extraHops` setting can be set globally or per seed to allow expanding the
 
 ## Seed Redirects
 
-Some seed URLs may redirect to a different URL that would be otherwise out of scope. The `--addRedirectSeeds` setting can be used to specify how such redirects should be handled with regard to crawl scope.
+Some seed URLs may redirect to a different URL that would be otherwise out of scope. The `--addRedirectedSeeds` setting can be used to specify how such redirects should be handled with regard to crawl scope.
 
 The default value `strict` will add the new URL as a seed to the crawl scope if it differs from the specified seed URL in its scheme (`http` vs. `https`) or `www.` subdomain (`example.com` vs `www.example.com`).
 

--- a/docs/docs/user-guide/crawl-scope.md
+++ b/docs/docs/user-guide/crawl-scope.md
@@ -50,7 +50,7 @@ The `--extraHops` setting can be set globally or per seed to allow expanding the
 
 Some seed URLs may redirect to a different URL that would be otherwise out of scope. The `--redirectSeedOutOfScope` setting can be used to specify how such redirects should be handled with regard to crawl scope.
 
-The default value `strict` will add the new URL as a seed to the crawl sif it differs from the specified seed URL only by scheme (`http` vs. `https`) or `www.` subdomain (`example.com` vs `www.example.com`).
+The default value `strict` will add the new URL as a seed to the crawl scope if it differs from the specified seed URL in its scheme (`http` vs. `https`) or `www.` subdomain (`example.com` vs `www.example.com`).
 
 The other available options are:
 

--- a/docs/docs/user-guide/crawl-scope.md
+++ b/docs/docs/user-guide/crawl-scope.md
@@ -46,6 +46,20 @@ For example, this is most useful when crawling with a `host` or `prefix` scope, 
 
 The `--extraHops` setting can be set globally or per seed to allow expanding the current inclusion scope N 'hops' beyond the configured scope. Note that this mechanism only expands the inclusion scope, and any exclusion rules are still applied. If a URL is to be excluded via the exclusion rules, that will take precedence over the `--extraHops`.
 
+## Seed Redirects
+
+Some seed URLs may redirect to a different URL that would be otherwise out of scope. The `--redirectSeedOutOfScope` setting can be used to specify how such redirects should be handled with regard to crawl scope.
+
+The default value `strict` will add the new URL as a seed to the crawl sif it differs from the specified seed URL only by scheme (`http` vs. `https`) or `www.` subdomain (`example.com` vs `www.example.com`).
+
+The other available options are:
+
+- `allow` - always add the redirect URL as a new seed to the crawl scope
+
+- `block` - never add the redirect URL as a new seed to the crawl scope
+
+If the URL a seed redirects to is not added as a new seed due to the option chosen, only the immediate page that is redirected to will be included in the crawl.
+
 ## Scope Rule Examples
 
 !!! example "Regular expression exclude rules"

--- a/docs/docs/user-guide/crawl-scope.md
+++ b/docs/docs/user-guide/crawl-scope.md
@@ -54,7 +54,7 @@ The default value `strict` will add the new URL as a seed to the crawl scope if 
 
 The other available options are:
 
-- `allow` - always add the redirect URL as a new seed to the crawl scope
+- `add` - always add the redirect URL as a new seed to the crawl scope
 
 - `block` - never add the redirect URL as a new seed to the crawl scope
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -212,7 +212,7 @@ export class Crawler {
   recording: boolean;
   isExternalDedupeStore = false;
 
-  redirectSeedOutOfScope: string;
+  oosRedirectAddSeeds: string;
 
   constructor() {
     const args = this.parseArgs();
@@ -295,7 +295,8 @@ export class Crawler {
       timeout: this.params.pageLoadTimeout * 1000,
     };
 
-    this.redirectSeedOutOfScope = this.params.redirectSeedOutOfScope;
+    // Out Of Scope Redirects: Add Seeds Mode
+    this.oosRedirectAddSeeds = this.params.outOfScopeRedirectAddSeeds;
 
     // pages directory
     this.pagesDir = path.join(this.collDir, "pages");
@@ -2486,8 +2487,8 @@ self.__bx_behaviors.selectMainBehavior();
       const seedId = data.seedId;
 
       if (
-        this.redirectSeedOutOfScope === "add" ||
-        (this.redirectSeedOutOfScope === "strict" &&
+        this.oosRedirectAddSeeds === "always" ||
+        (this.oosRedirectAddSeeds === "strict" &&
           normalizedRedirectSeedUrl(origUrl) ==
             normalizedRedirectSeedUrl(newUrl))
       ) {
@@ -2503,7 +2504,7 @@ self.__bx_behaviors.selectMainBehavior();
             origUrl,
             newUrl,
             seedId,
-            policy: this.redirectSeedOutOfScope,
+            policy: this.oosRedirectAddSeeds,
           },
         );
       } else if (
@@ -2513,7 +2514,7 @@ self.__bx_behaviors.selectMainBehavior();
           origUrl,
           newUrl,
           seedId,
-          policy: this.redirectSeedOutOfScope,
+          policy: this.oosRedirectAddSeeds,
         });
       }
     }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2503,6 +2503,7 @@ self.__bx_behaviors.selectMainBehavior();
             origUrl,
             newUrl,
             seedId,
+            policy: this.redirectSeedOutOfScope,
           },
         );
       } else if (
@@ -2512,6 +2513,7 @@ self.__bx_behaviors.selectMainBehavior();
           origUrl,
           newUrl,
           seedId,
+          policy: this.redirectSeedOutOfScope,
         });
       }
     }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2486,7 +2486,7 @@ self.__bx_behaviors.selectMainBehavior();
       const seedId = data.seedId;
 
       if (
-        this.redirectSeedOutOfScope === "allow" ||
+        this.redirectSeedOutOfScope === "add" ||
         (this.redirectSeedOutOfScope === "strict" &&
           normalizedRedirectSeedUrl(origUrl) ==
             normalizedRedirectSeedUrl(newUrl))

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -212,6 +212,8 @@ export class Crawler {
   recording: boolean;
   isExternalDedupeStore = false;
 
+  redirectSeedOutOfScope: string;
+
   constructor() {
     const args = this.parseArgs();
     this.params = args as CrawlerArgs;
@@ -292,6 +294,8 @@ export class Crawler {
       waitUntil: this.params.waitUntil,
       timeout: this.params.pageLoadTimeout * 1000,
     };
+
+    this.redirectSeedOutOfScope = this.params.redirectSeedOutOfScope;
 
     // pages directory
     this.pagesDir = path.join(this.collDir, "pages");
@@ -2482,7 +2486,10 @@ self.__bx_behaviors.selectMainBehavior();
       const seedId = data.seedId;
 
       if (
-        normalizedRedirectSeedUrl(origUrl) == normalizedRedirectSeedUrl(newUrl)
+        this.redirectSeedOutOfScope === "allow" ||
+        (this.redirectSeedOutOfScope === "strict" &&
+          normalizedRedirectSeedUrl(origUrl) ==
+            normalizedRedirectSeedUrl(newUrl))
       ) {
         data.seedId = await this.crawlState.addExtraSeed(
           this.seeds,
@@ -2501,15 +2508,11 @@ self.__bx_behaviors.selectMainBehavior();
       } else if (
         !(await this.isInScope(seedId, { url: newUrl, depth, extraHops: 0 }))
       ) {
-        logger.info(
-          "Seed page redirected, only crawling this page. " +
-            "New seed doesn't match original (ignoring scheme and www.), not adding new seed",
-          {
-            origUrl,
-            newUrl,
-            seedId,
-          },
-        );
+        logger.info("Seed page redirected out of scope, not adding new seed", {
+          origUrl,
+          newUrl,
+          seedId,
+        });
       }
     }
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -212,7 +212,7 @@ export class Crawler {
   recording: boolean;
   isExternalDedupeStore = false;
 
-  addRedirectSeeds: string;
+  addRedirectedSeeds: string;
 
   constructor() {
     const args = this.parseArgs();
@@ -296,7 +296,7 @@ export class Crawler {
     };
 
     // Out Of Scope Redirects: Add Seeds Mode
-    this.addRedirectSeeds = this.params.addRedirectSeeds;
+    this.addRedirectedSeeds = this.params.addRedirectedSeeds;
 
     // pages directory
     this.pagesDir = path.join(this.collDir, "pages");
@@ -2487,8 +2487,8 @@ self.__bx_behaviors.selectMainBehavior();
       const seedId = data.seedId;
 
       if (
-        this.addRedirectSeeds === "always" ||
-        (this.addRedirectSeeds === "strict" &&
+        this.addRedirectedSeeds === "always" ||
+        (this.addRedirectedSeeds === "strict" &&
           normalizedRedirectSeedUrl(origUrl) ==
             normalizedRedirectSeedUrl(newUrl))
       ) {
@@ -2504,7 +2504,7 @@ self.__bx_behaviors.selectMainBehavior();
             origUrl,
             newUrl,
             seedId,
-            policy: this.addRedirectSeeds,
+            policy: this.addRedirectedSeeds,
           },
         );
       } else if (
@@ -2514,7 +2514,7 @@ self.__bx_behaviors.selectMainBehavior();
           origUrl,
           newUrl,
           seedId,
-          policy: this.addRedirectSeeds,
+          policy: this.addRedirectedSeeds,
         });
       }
     }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -212,7 +212,7 @@ export class Crawler {
   recording: boolean;
   isExternalDedupeStore = false;
 
-  oosRedirectAddSeeds: string;
+  addRedirectSeeds: string;
 
   constructor() {
     const args = this.parseArgs();
@@ -296,7 +296,7 @@ export class Crawler {
     };
 
     // Out Of Scope Redirects: Add Seeds Mode
-    this.oosRedirectAddSeeds = this.params.outOfScopeRedirectAddSeeds;
+    this.addRedirectSeeds = this.params.addRedirectSeeds;
 
     // pages directory
     this.pagesDir = path.join(this.collDir, "pages");
@@ -2487,8 +2487,8 @@ self.__bx_behaviors.selectMainBehavior();
       const seedId = data.seedId;
 
       if (
-        this.oosRedirectAddSeeds === "always" ||
-        (this.oosRedirectAddSeeds === "strict" &&
+        this.addRedirectSeeds === "always" ||
+        (this.addRedirectSeeds === "strict" &&
           normalizedRedirectSeedUrl(origUrl) ==
             normalizedRedirectSeedUrl(newUrl))
       ) {
@@ -2504,7 +2504,7 @@ self.__bx_behaviors.selectMainBehavior();
             origUrl,
             newUrl,
             seedId,
-            policy: this.oosRedirectAddSeeds,
+            policy: this.addRedirectSeeds,
           },
         );
       } else if (
@@ -2514,7 +2514,7 @@ self.__bx_behaviors.selectMainBehavior();
           origUrl,
           newUrl,
           seedId,
-          policy: this.oosRedirectAddSeeds,
+          policy: this.addRedirectSeeds,
         });
       }
     }

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -803,7 +803,7 @@ class ArgParser {
 
         redirectSeedOutOfScope: {
           describe:
-            "Policy for how to handle seeds that redirect to a URL out of scope. Default (strict): add the redirect URL as a seed only if it differs in scheme or www subdomain. Other options: allow (always add redirect URL as new seed), block (never add redirect URL as new seed).",
+            "Policy for how to handle seeds that redirect to a URL out of scope. Default (strict): add the redirect URL as a seed only if it differs in scheme or www subdomain. Other options: add (always add as new seed), block (never add as new seed)",
           type: "string",
           choices: REDIRECT_OUT_OF_SCOPE_OPTS,
           default: "strict",

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -803,7 +803,7 @@ class ArgParser {
 
         redirectSeedOutOfScope: {
           describe:
-            "Policy for how to handle seeds that redirect to a URL out of scope. Default (strict): add the redirect URL as a seed only if it differs in scheme or www subdomain. Other options: add (always add as new seed), block (never add as new seed)",
+            "Policy for how to handle seeds that redirect to a URL out of scope. Default (strict): add the redirect URL as a seed only if it differs in scheme or www subdomain",
           type: "string",
           choices: REDIRECT_OUT_OF_SCOPE_OPTS,
           default: "strict",

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -21,7 +21,7 @@ import {
   DEFAULT_CRAWL_ID_TEMPLATE,
   RATE_LIMIT_MATCH_200,
   RATE_LIMIT_TTL_SECS,
-  ADD_REDIRECT_SEEDS_OPTS,
+  ADD_REDIRECTED_SEEDS_OPTS,
 } from "./constants.js";
 import { interpolateFilename } from "./storage.js";
 import { screenshotTypes } from "./screenshots.js";
@@ -801,11 +801,11 @@ class ArgParser {
           default: -1,
         },
 
-        addRedirectSeeds: {
+        addRedirectedSeeds: {
           describe:
             "Policy for how to handle seeds that redirect to a URL out of scope. Default (strict): add the redirect URL as a seed only if it differs in scheme or www subdomain",
           type: "string",
-          choices: ADD_REDIRECT_SEEDS_OPTS,
+          choices: ADD_REDIRECTED_SEEDS_OPTS,
           default: "strict",
         },
       });

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_CRAWL_ID_TEMPLATE,
   RATE_LIMIT_MATCH_200,
   RATE_LIMIT_TTL_SECS,
+  REDIRECT_OUT_OF_SCOPE_OPTS,
 } from "./constants.js";
 import { interpolateFilename } from "./storage.js";
 import { screenshotTypes } from "./screenshots.js";
@@ -798,6 +799,14 @@ class ArgParser {
             "If >0, threshold for number of rate limited pages before crawl is considered rate limited and is interrupted",
           type: "number",
           default: -1,
+        },
+
+        redirectSeedOutOfScope: {
+          describe:
+            "Policy for how to handle seeds that redirect to a URL out of scope. Default (strict): add the redirect URL as a seed only if it differs in scheme or www subdomain. Other options: allow (always add redirect URL as new seed), block (never add redirect URL as new seed).",
+          type: "string",
+          choices: REDIRECT_OUT_OF_SCOPE_OPTS,
+          default: "strict",
         },
       });
   }

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -21,7 +21,7 @@ import {
   DEFAULT_CRAWL_ID_TEMPLATE,
   RATE_LIMIT_MATCH_200,
   RATE_LIMIT_TTL_SECS,
-  REDIRECT_OUT_OF_SCOPE_OPTS,
+  OOS_REDIRECT_ADD_SEEDS,
 } from "./constants.js";
 import { interpolateFilename } from "./storage.js";
 import { screenshotTypes } from "./screenshots.js";
@@ -801,11 +801,12 @@ class ArgParser {
           default: -1,
         },
 
-        redirectSeedOutOfScope: {
+        outOfScopeRedirectAddSeeds: {
+          alias: "oosRedirectAddSeeds",
           describe:
             "Policy for how to handle seeds that redirect to a URL out of scope. Default (strict): add the redirect URL as a seed only if it differs in scheme or www subdomain",
           type: "string",
-          choices: REDIRECT_OUT_OF_SCOPE_OPTS,
+          choices: OOS_REDIRECT_ADD_SEEDS,
           default: "strict",
         },
       });

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -21,7 +21,7 @@ import {
   DEFAULT_CRAWL_ID_TEMPLATE,
   RATE_LIMIT_MATCH_200,
   RATE_LIMIT_TTL_SECS,
-  OOS_REDIRECT_ADD_SEEDS,
+  ADD_REDIRECT_SEEDS_OPTS,
 } from "./constants.js";
 import { interpolateFilename } from "./storage.js";
 import { screenshotTypes } from "./screenshots.js";
@@ -801,12 +801,11 @@ class ArgParser {
           default: -1,
         },
 
-        outOfScopeRedirectAddSeeds: {
-          alias: "oosRedirectAddSeeds",
+        addRedirectSeeds: {
           describe:
             "Policy for how to handle seeds that redirect to a URL out of scope. Default (strict): add the redirect URL as a seed only if it differs in scheme or www subdomain",
           type: "string",
-          choices: OOS_REDIRECT_ADD_SEEDS,
+          choices: ADD_REDIRECT_SEEDS_OPTS,
           default: "strict",
         },
       });

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -18,7 +18,7 @@ export const SERVICE_WORKER_OPTS = [
 
 export type ServiceWorkerOpt = (typeof SERVICE_WORKER_OPTS)[number];
 
-export const REDIRECT_OUT_OF_SCOPE_OPTS = ["strict", "add", "block"] as const;
+export const OOS_REDIRECT_ADD_SEEDS = ["always", "strict", "never"] as const;
 
 export const DETECT_SITEMAP = "<detect>";
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -18,6 +18,8 @@ export const SERVICE_WORKER_OPTS = [
 
 export type ServiceWorkerOpt = (typeof SERVICE_WORKER_OPTS)[number];
 
+export const REDIRECT_OUT_OF_SCOPE_OPTS = ["strict", "allow", "block"] as const;
+
 export const DETECT_SITEMAP = "<detect>";
 
 export const EXTRACT_TEXT_TYPES = ["to-pages", "to-warc", "final-to-warc"];

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -18,7 +18,7 @@ export const SERVICE_WORKER_OPTS = [
 
 export type ServiceWorkerOpt = (typeof SERVICE_WORKER_OPTS)[number];
 
-export const ADD_REDIRECT_SEEDS_OPTS = ["always", "strict", "never"] as const;
+export const ADD_REDIRECTED_SEEDS_OPTS = ["always", "strict", "never"] as const;
 
 export const DETECT_SITEMAP = "<detect>";
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -18,7 +18,7 @@ export const SERVICE_WORKER_OPTS = [
 
 export type ServiceWorkerOpt = (typeof SERVICE_WORKER_OPTS)[number];
 
-export const REDIRECT_OUT_OF_SCOPE_OPTS = ["strict", "allow", "block"] as const;
+export const REDIRECT_OUT_OF_SCOPE_OPTS = ["strict", "add", "block"] as const;
 
 export const DETECT_SITEMAP = "<detect>";
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -18,7 +18,7 @@ export const SERVICE_WORKER_OPTS = [
 
 export type ServiceWorkerOpt = (typeof SERVICE_WORKER_OPTS)[number];
 
-export const OOS_REDIRECT_ADD_SEEDS = ["always", "strict", "never"] as const;
+export const ADD_REDIRECT_SEEDS_OPTS = ["always", "strict", "never"] as const;
 
 export const DETECT_SITEMAP = "<detect>";
 


### PR DESCRIPTION
Fixes #1070 

Makes the policy for how to handle seed redirects configurable, while keeping the new behavior introduced in https://github.com/webrecorder/browsertrix-crawler/issues/1051 as the default.

As mentioned in the issue, we may also want to add an option so that the redirected page is not loaded/captured, even if the new seed is not added to the crawl. That has not yet been added in this PR but could be in a follow-up if we think that's an option that will be important to users.

## Testing

Integration tests are a bit tricky since we rely on sites on the live web and we don't necessarily want CI crawling our main website (which can interfere with analytics). The following are some crawl commands and their expected outcomes that can be used to validate the behavior is as expected.

- `docker compose run crawler crawl --limit 3 --url https://browsertrix.com --addRedirectedSeeds always`: Adds new redirected seed https://webrecorder.net/browsertrix due to always policy
- `docker compose run crawler crawl --limit 3 --url https://browsertrix.com`: Does not add redirected seed https://webrecorder.net/browsertrix due to strict policy (implicit)
- `docker compose run crawler crawl --limit 3 --url https://browsertrix.com --addRedirectedSeeds strict`: Does not add redirected seed https://webrecorder.net/browsertrix due to strict policy (explicit)
- `docker compose run crawler crawl --limit 3 --url https://www.webrecorder.net`: Adds redirected seed https://webrecorder.net due to strict policy (implicit)
- `docker compose run crawler crawl --limit 3 --url https://www.webrecorder.net --addRedirectedSeeds strict`: Adds redirected seed https://webrecorder.net due to strict policy (explicit)
- `docker compose run crawler crawl --limit 3 --url https://www.webrecorder.net --addRedirectedSeeds never`: Does not add redirected seed https://webrecorder.net due to never policy