### PR TITLE
Ensure direct fetched resources always result in revisit records

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -122,8 +122,11 @@ enum SerializeRes {
   // WARC record writing aborted due to incomplete, should retry
   Aborted = 1,
 
-  // WARC record skipped (eg. dupe, cached) and should not be retried
-  Skipped = 2,
+  // WARC record skipped because it is already been written
+  SkippedDupe = 2,
+
+  // WARC record skipped because it should not be written
+  SkippedNoWrite = 3,
 }
 
 // =================================================================
@@ -1726,8 +1729,9 @@ export class Recorder extends EventEmitter {
     skipPageInfo = false,
     matchHash?: string,
   ): Promise<SerializeRes> {
-    if (this.skipRecordingPage) {
-      return SerializeRes.Skipped;
+    // skip here if skipping recording page, and not asyncLoading outside of page
+    if (this.skipRecordingPage && !reqresp.asyncLoading) {
+      return SerializeRes.SkippedNoWrite;
     }
 
     // always include in pageinfo record if going to serialize to WARC
@@ -1746,7 +1750,7 @@ export class Recorder extends EventEmitter {
         { url, status },
         "recorder",
       );
-      return SerializeRes.Skipped;
+      return SerializeRes.SkippedDupe;
     } else if (!iter && reqresp.shouldSkipSave()) {
       logger.debug(
         "Skipping writing request/response",
@@ -1759,7 +1763,7 @@ export class Recorder extends EventEmitter {
         },
         "recorder",
       );
-      return SerializeRes.Skipped;
+      return SerializeRes.SkippedNoWrite;
     }
 
     if (
@@ -1773,7 +1777,7 @@ export class Recorder extends EventEmitter {
         status,
         ...this.logDetails,
       });
-      return SerializeRes.Skipped;
+      return SerializeRes.SkippedDupe;
     }
 
     let responseRecord = createResponse(reqresp, pageid, iter);
@@ -1837,10 +1841,10 @@ export class Recorder extends EventEmitter {
       const res = await this.crawlState.getHashDupe(hash);
 
       // if only writing revisit, ensure it's a revisit and hash
-      // matches expected value, otherwise just return
+      // matches expected value, otherwise return SkippedNoWrite
       // should always match, but just in case!
       if (matchHash && (matchHash !== hash || !res)) {
-        return SerializeRes.Skipped;
+        return SerializeRes.SkippedNoWrite;
       }
 
       if (res) {
@@ -1972,7 +1976,7 @@ class AsyncFetcher {
       if (!(await this.loadHeaders())) {
         continue;
       }
-      if (!(await this.loadBody())) {
+      if ((await this.loadBody()) === SerializeRes.Aborted) {
         continue;
       }
       return true;
@@ -2012,7 +2016,7 @@ class AsyncFetcher {
     return success;
   }
 
-  async loadBody() {
+  async loadBody(): Promise<SerializeRes> {
     try {
       const { reqresp, useBrowserNetwork, body, stream, cdp, recorder } = this;
 
@@ -2027,20 +2031,19 @@ class AsyncFetcher {
         throw new Error("resp body missing");
       }
 
-      if (
-        (await recorder.serializeToWARC(reqresp, iter)) === SerializeRes.Skipped
-      ) {
+      const res = await recorder.serializeToWARC(reqresp, iter);
+
+      if (res == SerializeRes.SkippedNoWrite || res === SerializeRes.Aborted) {
         await this.doCancel();
-        return false;
       }
-      return true;
+      return res;
     } catch (e) {
       logger.warn(
         "Async load body failed",
         { ...formatErr(e), ...this.recorder.logDetails },
         "fetch",
       );
-      return false;
+      return SerializeRes.Aborted;
     }
   }
 
@@ -2202,7 +2205,7 @@ class AsyncFetcher {
   }
 
   async loadDirectPage(state: PageState, crawler: Crawler) {
-    const success = await this.loadBody();
+    const result = await this.loadBody();
 
     this.recorder.addPageRecord(this.reqresp);
 
@@ -2212,16 +2215,20 @@ class AsyncFetcher {
       state.mime = mime;
       state.isHTMLPage = isHTMLMime(mime);
     }
-    if (success) {
+    if (
+      result === SerializeRes.Success ||
+      result === SerializeRes.SkippedDupe
+    ) {
       state.loadState = LoadState.FULL_PAGE_LOADED;
       state.status = 200;
       state.ts = this.reqresp.ts || new Date();
-      logger.info(
-        "Direct fetch successful",
-        { url: this.reqresp.url, mime, workerid: this.recorder.workerid },
-        "fetch",
-      );
     }
+    logger.debug(
+      "Direct fetch page done",
+      { result, url: this.reqresp.url, mime, workerid: this.recorder.workerid },
+      "fetch",
+    );
+
     await crawler.pageFinished(state);
   }
 }

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -909,7 +909,10 @@ export class Recorder extends EventEmitter {
           requestId,
           errorReason: "BlockedByResponse",
         });
-        await this.serializeToWARC(reqresp, undefined, false, true, hash);
+        await this.serializeToWARC(reqresp, {
+          canRetry: true,
+          matchHash: hash,
+        });
         this.skipPageInfo = true;
         this.state!.pageSkipReason = SkippedReason.Duplicate;
         logger.debug(
@@ -1574,8 +1577,10 @@ export class Recorder extends EventEmitter {
       try {
         // if aborted, allow retrying
         if (
-          (await this.serializeToWARC(reqresp, iter, true)) ===
-          SerializeRes.Aborted
+          (await this.serializeToWARC(reqresp, {
+            iter,
+            skipPageInfo: true,
+          })) === SerializeRes.Aborted
         ) {
           return false;
         }
@@ -1724,10 +1729,19 @@ export class Recorder extends EventEmitter {
 
   async serializeToWARC(
     reqresp: RequestResponseInfo,
-    iter?: AsyncIterable<Uint8Array>,
-    canRetry = false,
-    skipPageInfo = false,
-    matchHash?: string,
+    {
+      iter = undefined,
+      canRetry = false,
+      skipPageInfo = false,
+      matchHash = undefined,
+      alwaysWriteRevisit = false,
+    }: {
+      iter?: AsyncIterable<Uint8Array>;
+      canRetry?: boolean;
+      skipPageInfo?: boolean;
+      matchHash?: string;
+      alwaysWriteRevisit?: boolean;
+    } = {},
   ): Promise<SerializeRes> {
     // skip here if skipping recording page, and not asyncLoading outside of page
     if (this.skipRecordingPage && !reqresp.asyncLoading) {
@@ -1744,7 +1758,7 @@ export class Recorder extends EventEmitter {
     const { url, status, requestId, method, payload } = reqresp;
 
     // Specifically log skipping cached resources
-    if (reqresp.isCached()) {
+    if (reqresp.isCached() && !alwaysWriteRevisit) {
       logger.debug(
         "Skipping cached resource, should be already recorded",
         { url, status },
@@ -1767,6 +1781,7 @@ export class Recorder extends EventEmitter {
     }
 
     if (
+      !alwaysWriteRevisit &&
       url &&
       method === "GET" &&
       !isRedirectStatus(status) &&
@@ -2016,7 +2031,7 @@ class AsyncFetcher {
     return success;
   }
 
-  async loadBody(): Promise<SerializeRes> {
+  async loadBody(alwaysWriteRevisit = false): Promise<SerializeRes> {
     try {
       const { reqresp, useBrowserNetwork, body, stream, cdp, recorder } = this;
 
@@ -2031,7 +2046,10 @@ class AsyncFetcher {
         throw new Error("resp body missing");
       }
 
-      const res = await recorder.serializeToWARC(reqresp, iter);
+      const res = await recorder.serializeToWARC(reqresp, {
+        iter,
+        alwaysWriteRevisit,
+      });
 
       if (res == SerializeRes.SkippedNoWrite || res === SerializeRes.Aborted) {
         await this.doCancel();
@@ -2205,7 +2223,7 @@ class AsyncFetcher {
   }
 
   async loadDirectPage(state: PageState, crawler: Crawler) {
-    const result = await this.loadBody();
+    const result = await this.loadBody(true);
 
     this.recorder.addPageRecord(this.reqresp);
 
@@ -2215,10 +2233,7 @@ class AsyncFetcher {
       state.mime = mime;
       state.isHTMLPage = isHTMLMime(mime);
     }
-    if (
-      result === SerializeRes.Success ||
-      result === SerializeRes.SkippedDupe
-    ) {
+    if (result === SerializeRes.Success) {
       state.loadState = LoadState.FULL_PAGE_LOADED;
       state.status = 200;
       state.ts = this.reqresp.ts || new Date();

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -910,7 +910,7 @@ export class Recorder extends EventEmitter {
           errorReason: "BlockedByResponse",
         });
         await this.serializeToWARC(reqresp, {
-          canRetry: true,
+          skipPageInfo: true,
           matchHash: hash,
         });
         this.skipPageInfo = true;
@@ -1579,7 +1579,7 @@ export class Recorder extends EventEmitter {
         if (
           (await this.serializeToWARC(reqresp, {
             iter,
-            skipPageInfo: true,
+            canRetry: true,
           })) === SerializeRes.Aborted
         ) {
           return false;

--- a/tests/non-html-crawl.test.ts
+++ b/tests/non-html-crawl.test.ts
@@ -149,7 +149,7 @@ test("XML: check that CDX contains one xml 200, one 301 and one 200, two pageinf
     .map((line) => JSON.parse(line.split(" ").slice(2).join(" ")))
     .sort((a, b) => (a.url < b.url ? -1 : 1));
 
-  expect(cdxj.length).toBe(5);
+  expect(cdxj.length).toBe(6);
 
   expect(cdxj[0].url).toBe("https://webrecorder.net/favicon.ico");
 
@@ -157,12 +157,16 @@ test("XML: check that CDX contains one xml 200, one 301 and one 200, two pageinf
   expect(cdxj[1].status).toBe("200");
   expect(cdxj[1].mime).toBe("application/xml");
 
-  expect(cdxj[2].url).toBe(XML_REDIR);
-  expect(cdxj[2].status).toBe("301");
+  expect(cdxj[2].url).toBe(XML);
+  expect(cdxj[2].status).toBe("200");
+  expect(cdxj[2].mime).toBe("warc/revisit");
 
-  expect(cdxj[3].url).toBe("urn:pageinfo:" + XML);
-  expect(cdxj[3].mime).toBe("application/json");
+  expect(cdxj[3].url).toBe(XML_REDIR);
+  expect(cdxj[3].status).toBe("301");
 
-  expect(cdxj[4].url).toBe("urn:pageinfo:" + XML_REDIR);
+  expect(cdxj[4].url).toBe("urn:pageinfo:" + XML);
   expect(cdxj[4].mime).toBe("application/json");
+
+  expect(cdxj[5].url).toBe("urn:pageinfo:" + XML_REDIR);
+  expect(cdxj[5].mime).toBe("application/json");
 });


### PR DESCRIPTION
- Refactors serializeWARC to differentiate between 'skipped not writing' and 'skipped already written' (duplicate) to clarify intent
- Adds 'alwaysWriteRevisit' to ensure a revisit is always written when 'skipped already written' would be returned.
- For direct fetches, always writes revisit records since the page will correspond to that record.
- Fixes #1073 

Testing:
- Run a crawl of a site that has lots of .pdf images linked as pages, but also crawled internally
- Observe these pages are in the CDX, but are added to extraPages.json with loadState 0 (failed)
- With this PR, should no longer be the case.