### PR TITLE
fault tolerance: if redis is not available, interrupt but don't fail crawl

### DIFF
--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -81,8 +81,9 @@ export const DISPLAY = ":99";
 export enum ExitCodes {
   Success = 0,
   GenericError = 1,
-  Failed = 9,
   OutOfSpace = 3,
+  RedisUnavailable = 8,
+  Failed = 9,
   BrowserCrashed = 10,
   SignalInterrupted = 11,
   FailedLimit = 12,

--- a/src/util/redis.ts
+++ b/src/util/redis.ts
@@ -1,6 +1,7 @@
 import { Redis } from "ioredis";
 import { logger } from "./logger.js";
 import { sleep } from "./timing.js";
+import { ExitCodes } from "./constants.js";
 
 const error = console.error;
 
@@ -19,10 +20,11 @@ console.error = function (...args) {
 
     if (now - lastLogTime > REDIS_ERROR_LOG_INTERVAL_SECS) {
       if (lastLogTime && exitOnError) {
-        void logger.fatal(
-          "Crawl interrupted, redis gone, exiting",
+        void logger.interrupt(
+          "Redis unavailable, interrupting crawl",
           {},
           "redis",
+          ExitCodes.RedisUnavailable,
         );
       }
       logger.warn("ioredis error", { error: args[0] }, "redis");


### PR DESCRIPTION
- Exit with .interrupt() instead of .fatal()
- Add new interrupt (exit code 8)

Previously, the crawl could only be marked as failed if redis becomes available on subsequent attempt, which is not the desired goal.
fixes #1075