### PR TITLE
fault tolerance: allow ignoring failed per-host proxies

### DIFF
--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -330,10 +330,6 @@ Options:
       --proxyServerConfig                   if set, path to yaml/json file that
                                             configures multiple proxy servers pe
                                             r URL regex                 [string]
-      --proxyServerConfigIgnoreFailedProxi  if set, and --proxyServerConfig is u
-      es                                    sed, any of the per URL regex proxy
-                                            servers if they are not accessible
-                                                      [boolean] [default: false]
       --dryRun                              If true, no archive data is written
                                             to disk, only pages and logs (and op
                                             tionally saved state).     [boolean]

--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -328,8 +328,12 @@ Options:
                                             xyServer value will be preferred
                                                       [boolean] [default: false]
       --proxyServerConfig                   if set, path to yaml/json file that
-                                            configures multiple path servers per
-                                             URL regex                  [string]
+                                            configures multiple proxy servers pe
+                                            r URL regex                 [string]
+      --proxyServerConfigIgnoreFailedProxi  if set, and --proxyServerConfig is u
+      es                                    sed, any of the per URL regex proxy
+                                            servers if they are not accessible
+                                                      [boolean] [default: false]
       --dryRun                              If true, no archive data is written
                                             to disk, only pages and logs (and op
                                             tionally saved state).     [boolean]

--- a/docs/docs/user-guide/proxies.md
+++ b/docs/docs/user-guide/proxies.md
@@ -128,7 +128,7 @@ The same `--proxyServerConfig` option can also be used in browser profile creati
 
 ### SSH Tunnels
 
-For any SSH proxy that is listed as a possible proxy in `matchHosts` configuration, the crawler will attempt to set up an SSH tunnel before starting the crawl. By default, the crawl will not start and will be interrupted if any of the SSH tunnel connections fail. To allow ignoring failing SSH proxies (and perform a direct connection) the `ignoreOnFailedSSHTunnel: true` can be set for each SSH proxy that should be ignored on failure.
+For any SSH proxy that is listed as a possible proxy in `matchHosts` configuration, the crawler will attempt to set up an SSH tunnel before starting the crawl. By default, the crawl will not start and will be interrupted if any of the SSH tunnel connections fail. To allow ignoring failing SSH proxies and perform a direct connection instead, `ignoreOnFailedSSHTunnel: true` can be set for each SSH proxy that should be ignored on failure.
 
 SOCKS5 and HTTP proxy connections are made by the browser only on first use, and are not checked for successful connection until they are used.
 

--- a/docs/docs/user-guide/proxies.md
+++ b/docs/docs/user-guide/proxies.md
@@ -121,14 +121,15 @@ files, the crawler can be started with:
 docker run -v $PWD/crawls:/crawls -v $PWD/proxies:/proxies -it webrecorder/browsertrix-crawler --url https://example.com/ --proxyServerConfig /proxies/proxyConfig.yaml
 ```
 
-Note that if SSH proxies are provided, an SSH tunnel must be opened for each one before the crawl starts.
-The crawl will not start if any of the SSH proxy connections fail, even if a host-specific proxy is not yet used.
-The `--proxyServerConfigIgnoreFailedProxies` flag can be provided to silently ignore
-any failed proxies and connect directly.
-
-SOCKS5 and HTTP proxy connections are attempted only on first use.
-
 The same `--proxyServerConfig` option can also be used in browser profile creation with the `create-login-profile` command in the same way.
+
+### SSH Tunnels
+
+For any SSH proxy that is listed as a possible proxy in `matchHosts` configuration, the crawler will attempt to set up an SSH tunnel before starting the crawl. By default, the crawl will not start if any of the SSH tunnel connections fail and the crawl
+will be interrupted. However, the `--proxyServerConfigIgnoreFailedProxies` flag can be provided to ignore any failing
+proxies and use a direct connection instead.
+
+SOCKS5 and HTTP proxy connections are made by the browser only on first use, and are not checked for successful connection until/if they are used.
 
 ### Proxy Precedence
 

--- a/docs/docs/user-guide/proxies.md
+++ b/docs/docs/user-guide/proxies.md
@@ -122,7 +122,10 @@ docker run -v $PWD/crawls:/crawls -v $PWD/proxies:/proxies -it webrecorder/brows
 ```
 
 Note that if SSH proxies are provided, an SSH tunnel must be opened for each one before the crawl starts.
-The crawl will not start if any of the SSH proxy connections fail, even if a host-specific proxy is not actually used.
+The crawl will not start if any of the SSH proxy connections fail, even if a host-specific proxy is not yet used.
+The `--proxyServerConfigIgnoreFailedProxies` flag can be provided to silently ignore
+any failed proxies and connect directly.
+
 SOCKS5 and HTTP proxy connections are attempted only on first use.
 
 The same `--proxyServerConfig` option can also be used in browser profile creation with the `create-login-profile` command in the same way.

--- a/docs/docs/user-guide/proxies.md
+++ b/docs/docs/user-guide/proxies.md
@@ -126,7 +126,7 @@ The same `--proxyServerConfig` option can also be used in browser profile creati
 ### SSH Tunnels
 
 For any SSH proxy that is listed as a possible proxy in `matchHosts` configuration, the crawler will attempt to set up an SSH tunnel before starting the crawl. By default, the crawl will not start if any of the SSH tunnel connections fail and the crawl
-will be interrupted. However, the `--proxyServerConfigIgnoreFailedProxies` flag can be provided to ignore any failing
+will be interrupted. However, the `--proxyServerConfigIgnoreFailed` flag can be provided to ignore any failing
 proxies and use a direct connection instead.
 
 SOCKS5 and HTTP proxy connections are made by the browser only on first use, and are not checked for successful connection until they are used.

--- a/docs/docs/user-guide/proxies.md
+++ b/docs/docs/user-guide/proxies.md
@@ -112,6 +112,9 @@ proxies:
   default-proxy:
     url: ssh://user@my-social-proxy.example.com
     privateKeyFile: /proxies/default-proxy-private-key
+
+    # optional, if set, ignore this proxy if tunnel can not be established at crawl start time
+    ignoreOnFailedSSHTunnel: true
 ```
 
 If the above config is stored in `./proxies/proxyConfig.yaml` along with the SSH private keys and known public hosts
@@ -125,9 +128,7 @@ The same `--proxyServerConfig` option can also be used in browser profile creati
 
 ### SSH Tunnels
 
-For any SSH proxy that is listed as a possible proxy in `matchHosts` configuration, the crawler will attempt to set up an SSH tunnel before starting the crawl. By default, the crawl will not start if any of the SSH tunnel connections fail and the crawl
-will be interrupted. However, the `--proxyServerConfigIgnoreFailed` flag can be provided to ignore any failing
-proxies and use a direct connection instead.
+For any SSH proxy that is listed as a possible proxy in `matchHosts` configuration, the crawler will attempt to set up an SSH tunnel before starting the crawl. By default, the crawl will not start and will be interrupted if any of the SSH tunnel connections fail. To allow ignoring failing SSH proxies (and perform a direct connection) the `ignoreOnFailedSSHTunnel: true` can be set for each SSH proxy that should be ignored on failure.
 
 SOCKS5 and HTTP proxy connections are made by the browser only on first use, and are not checked for successful connection until they are used.
 

--- a/docs/docs/user-guide/proxies.md
+++ b/docs/docs/user-guide/proxies.md
@@ -129,7 +129,7 @@ For any SSH proxy that is listed as a possible proxy in `matchHosts` configurati
 will be interrupted. However, the `--proxyServerConfigIgnoreFailedProxies` flag can be provided to ignore any failing
 proxies and use a direct connection instead.
 
-SOCKS5 and HTTP proxy connections are made by the browser only on first use, and are not checked for successful connection until/if they are used.
+SOCKS5 and HTTP proxy connections are made by the browser only on first use, and are not checked for successful connection until they are used.
 
 ### Proxy Precedence
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -707,7 +707,7 @@ class ArgParser {
           type: "string",
         },
 
-        proxyServerConfigIgnoreFailedProxies: {
+        proxyServerConfigIgnoreFailed: {
           describe:
             "if set, ignore any per-URL regex proxy servers set with --proxyServerConfig if they are not available rather than interrupting crawl",
           type: "boolean",

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -703,8 +703,15 @@ class ArgParser {
 
         proxyServerConfig: {
           describe:
-            "if set, path to yaml/json file that configures multiple path servers per URL regex",
+            "if set, path to yaml/json file that configures multiple proxy servers per URL regex",
           type: "string",
+        },
+
+        proxyServerConfigIgnoreFailedProxies: {
+          describe:
+            "if set, and --proxyServerConfig is used, any of the per URL regex proxy servers if they are not accessible",
+          type: "boolean",
+          default: false,
         },
 
         dryRun: {

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -707,13 +707,6 @@ class ArgParser {
           type: "string",
         },
 
-        proxyServerConfigIgnoreFailed: {
-          describe:
-            "if set, ignore any per-URL regex proxy servers set with --proxyServerConfig if they are not available rather than interrupting crawl",
-          type: "boolean",
-          default: false,
-        },
-
         dryRun: {
           describe:
             "If true, no archive data is written to disk, only pages and logs (and optionally saved state).",

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -709,7 +709,7 @@ class ArgParser {
 
         proxyServerConfigIgnoreFailedProxies: {
           describe:
-            "if set, and --proxyServerConfig is used, any of the per URL regex proxy servers if they are not accessible",
+            "if set, ignore any per-URL regex proxy servers set with --proxyServerConfig if they are not available rather than interrupting crawl",
           type: "boolean",
           default: false,
         },

--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -68,7 +68,7 @@ export type ProxyCLIArgs = {
 
   proxyServer?: string;
   proxyServerPreferSingleProxy?: boolean;
-  proxyServerConfigIgnoreFailedProxies?: boolean;
+  proxyServerConfigIgnoreFailed?: boolean;
 
   proxyMap?: ProxyServerConfig;
 };
@@ -191,7 +191,7 @@ export async function initProxy(
   }
 
   // if set, ignore failed proxies on match hosts
-  const ignoreFailed = params.proxyServerConfigIgnoreFailedProxies;
+  const ignoreFailed = params.proxyServerConfigIgnoreFailed;
 
   for (const [rx, name] of Object.entries(params.proxyMap.matchHosts)) {
     const proxyDef = nameToProxy.get(name);

--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -470,6 +470,12 @@ export async function runSSHD(
         "proxy",
         ExitCodes.ProxyError,
       );
+    } else {
+      logger.warn(
+        "Ignoring failed proxy, using direct connection",
+        { proxyString: getSafeProxyString(proxyString) },
+        "proxy",
+      );
     }
     return "";
   }

--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -68,6 +68,7 @@ export type ProxyCLIArgs = {
 
   proxyServer?: string;
   proxyServerPreferSingleProxy?: boolean;
+  proxyServerConfigIgnoreFailedProxies?: boolean;
 
   proxyMap?: ProxyServerConfig;
 };
@@ -190,7 +191,7 @@ export async function initProxy(
   }
 
   // if set, ignore failed proxies on match hosts
-  const ignoreFailed = params.proxyMap.ignoreFailedHostProxies;
+  const ignoreFailed = params.proxyServerConfigIgnoreFailedProxies;
 
   for (const [rx, name] of Object.entries(params.proxyMap.matchHosts)) {
     const proxyDef = nameToProxy.get(name);

--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -49,12 +49,16 @@ const followRedirectDispatcher = addRedirectInterceptor(
   addDecompressInterceptor(new Agent(baseOpts)),
 );
 
+export type ProxyDef = {
+  url: string;
+  privateKeyFile?: string;
+  publicHostsFile?: string;
+};
+
 export type ProxyServerConfig = {
   matchHosts?: Record<string, string>;
-  proxies?: Record<
-    string,
-    string | { url: string; privateKeyFile?: string; publicHostsFile?: string }
-  >;
+  ignoreFailedHostProxies?: boolean;
+  proxies?: Record<string, string | ProxyDef>;
 };
 
 export type ProxyCLIArgs = {
@@ -68,7 +72,7 @@ export type ProxyCLIArgs = {
   proxyMap?: ProxyServerConfig;
 };
 
-const proxyMap = new Map<RegExp, ProxyEntry>();
+const proxyMap = new Map<RegExp, ProxyEntry | null>();
 let defaultProxyEntry: ProxyEntry | null = null;
 
 export function getEnvProxyUrl() {
@@ -147,9 +151,10 @@ export async function initProxy(
       detached,
       sshProxyPrivateKeyFile,
       sshProxyKnownHostsFile,
+      false,
     );
-    if (params.proxyServerPreferSingleProxy && defaultProxyEntry.proxyUrl) {
-      return { proxyServer: defaultProxyEntry.proxyUrl };
+    if (params.proxyServerPreferSingleProxy && defaultProxyEntry!.proxyUrl) {
+      return { proxyServer: defaultProxyEntry!.proxyUrl };
     }
   }
 
@@ -160,17 +165,20 @@ export async function initProxy(
     return { proxyServer: defaultProxyEntry?.proxyUrl };
   }
 
-  const nameToProxy = new Map<string, ProxyEntry>();
+  const nameToProxy = new Map<
+    string,
+    ProxyDef & { entry?: ProxyEntry | null }
+  >();
 
   for (const [name, value] of Object.entries(params.proxyMap.proxies)) {
-    let proxyUrl = "";
+    let url = "";
     let privateKeyFile: string | undefined = "";
     let publicHostsFile: string | undefined = "";
 
     if (typeof value === "string") {
-      proxyUrl = value;
+      url = value;
     } else {
-      proxyUrl = value.url;
+      url = value.url;
       privateKeyFile = value.privateKeyFile;
       publicHostsFile = value.publicHostsFile;
     }
@@ -178,31 +186,38 @@ export async function initProxy(
     privateKeyFile = privateKeyFile || sshProxyPrivateKeyFile;
     publicHostsFile = publicHostsFile || sshProxyKnownHostsFile;
 
-    const entry = await initSingleProxy(
-      proxyUrl,
-      localPort++,
-      detached,
-      privateKeyFile,
-      publicHostsFile,
-    );
-
-    nameToProxy.set(name, entry);
+    nameToProxy.set(name, { url, privateKeyFile, publicHostsFile });
   }
 
-  for (const [rx, name] of Object.entries(params.proxyMap.matchHosts)) {
-    const entry = nameToProxy.get(name);
+  // if set, ignore failed proxies on match hosts
+  const ignoreFailed = params.proxyMap.ignoreFailedHostProxies;
 
-    if (!entry) {
+  for (const [rx, name] of Object.entries(params.proxyMap.matchHosts)) {
+    const proxyDef = nameToProxy.get(name);
+    if (!proxyDef) {
       await logger.fatal(
         "Proxy specified but not found in proxies list: " + name,
       );
       return {};
     }
 
+    if (proxyDef.entry === undefined) {
+      const { url, privateKeyFile, publicHostsFile } = proxyDef;
+
+      proxyDef.entry = await initSingleProxy(
+        url,
+        localPort++,
+        detached,
+        privateKeyFile,
+        publicHostsFile,
+        ignoreFailed,
+      );
+    }
+
     if (rx) {
-      proxyMap.set(new RegExp(rx), entry);
+      proxyMap.set(new RegExp(rx), proxyDef.entry);
     } else {
-      defaultProxyEntry = entry;
+      defaultProxyEntry = proxyDef.entry;
     }
   }
 
@@ -219,7 +234,8 @@ export async function initSingleProxy(
   detached: boolean,
   sshProxyPrivateKeyFile?: string,
   sshProxyKnownHostsFile?: string,
-): Promise<ProxyEntry> {
+  ignoreFailed = false,
+): Promise<ProxyEntry | null> {
   logger.debug("Initing proxy", {
     url: getSafeProxyString(proxyUrl),
     localPort,
@@ -234,7 +250,12 @@ export async function initSingleProxy(
       detached,
       sshProxyPrivateKeyFile,
       sshProxyKnownHostsFile,
+      ignoreFailed,
     );
+  }
+
+  if (!proxyUrl) {
+    return null;
   }
 
   return createDispatchers(
@@ -338,6 +359,7 @@ export async function runSSHD(
   detached: boolean,
   privateKey?: string,
   publicKnownHost?: string,
+  ignoreFailed = false,
 ) {
   if (!proxyServer || !proxyServer.startsWith("ssh://")) {
     return "";
@@ -435,17 +457,19 @@ export async function runSSHD(
   try {
     await waitForSocksPort;
   } catch (e) {
-    await logger.interrupt(
-      "Unable to establish SSH connection for proxy",
-      {
-        error: e,
-        stdout: procStdout,
-        stderr: procStderr,
-        code: proc.exitCode,
-      },
-      "proxy",
-      ExitCodes.ProxyError,
-    );
+    if (!ignoreFailed) {
+      await logger.interrupt(
+        "Unable to establish SSH connection for proxy",
+        {
+          error: e,
+          stdout: procStdout,
+          stderr: procStderr,
+          code: proc.exitCode,
+        },
+        "proxy",
+        ExitCodes.ProxyError,
+      );
+    }
     return "";
   }
 
@@ -472,6 +496,7 @@ export async function runSSHD(
       detached,
       privateKey,
       publicKnownHost,
+      ignoreFailed,
     ).catch((e) => logger.error("proxy retry error", e, "proxy"));
   });
 
@@ -511,10 +536,9 @@ class ProxyPacServer {
 function FindProxyForURL(url, host) {
 
 `;
-    proxyMap.forEach(({ proxyUrl }, k) => {
-      this.proxyPacText += `  if (url.match(/${
-        k.source
-      }/)) { return ${urlToProxy(proxyUrl)}; }\n`;
+    proxyMap.forEach((proxyEntry, k) => {
+      const target = proxyEntry ? urlToProxy(proxyEntry.proxyUrl) : `"DIRECT"`;
+      this.proxyPacText += `  if (url.match(/${k.source}/)) { return ${target}; }\n`;
     });
 
     this.proxyPacText += `\n  return ${

--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -53,6 +53,7 @@ export type ProxyDef = {
   url: string;
   privateKeyFile?: string;
   publicHostsFile?: string;
+  ignoreOnFailedSSHTunnel?: boolean;
 };
 
 export type ProxyServerConfig = {
@@ -68,7 +69,6 @@ export type ProxyCLIArgs = {
 
   proxyServer?: string;
   proxyServerPreferSingleProxy?: boolean;
-  proxyServerConfigIgnoreFailed?: boolean;
 
   proxyMap?: ProxyServerConfig;
 };
@@ -175,6 +175,7 @@ export async function initProxy(
     let url = "";
     let privateKeyFile: string | undefined = "";
     let publicHostsFile: string | undefined = "";
+    let ignoreOnFailedSSHTunnel = false;
 
     if (typeof value === "string") {
       url = value;
@@ -182,16 +183,19 @@ export async function initProxy(
       url = value.url;
       privateKeyFile = value.privateKeyFile;
       publicHostsFile = value.publicHostsFile;
+      ignoreOnFailedSSHTunnel = value.ignoreOnFailedSSHTunnel ?? false;
     }
 
     privateKeyFile = privateKeyFile || sshProxyPrivateKeyFile;
     publicHostsFile = publicHostsFile || sshProxyKnownHostsFile;
 
-    nameToProxy.set(name, { url, privateKeyFile, publicHostsFile });
+    nameToProxy.set(name, {
+      url,
+      privateKeyFile,
+      publicHostsFile,
+      ignoreOnFailedSSHTunnel,
+    });
   }
-
-  // if set, ignore failed proxies on match hosts
-  const ignoreFailed = params.proxyServerConfigIgnoreFailed;
 
   for (const [rx, name] of Object.entries(params.proxyMap.matchHosts)) {
     const proxyDef = nameToProxy.get(name);
@@ -203,7 +207,8 @@ export async function initProxy(
     }
 
     if (proxyDef.entry === undefined) {
-      const { url, privateKeyFile, publicHostsFile } = proxyDef;
+      const { url, privateKeyFile, publicHostsFile, ignoreOnFailedSSHTunnel } =
+        proxyDef;
 
       proxyDef.entry = await initSingleProxy(
         url,
@@ -211,7 +216,7 @@ export async function initProxy(
         detached,
         privateKeyFile,
         publicHostsFile,
-        ignoreFailed,
+        ignoreOnFailedSSHTunnel,
       );
     }
 

--- a/tests/fixtures/proxies/proxy-test-failed-ignore.pac
+++ b/tests/fixtures/proxies/proxy-test-failed-ignore.pac
@@ -1,0 +1,10 @@
+matchHosts:
+  old.webrecorder.net: ssh-proxy
+
+proxies:
+  ssh-proxy:
+    url: ssh://proxy-not-found:1081
+    ignoreOnFailedSSHTunnel: true
+
+  # this is ignored as the proxy is not used in matchHosts
+  unused-ssh-proxy: ssh://proxy-not-found:1082

--- a/tests/fixtures/proxies/proxy-test-failed.pac
+++ b/tests/fixtures/proxies/proxy-test-failed.pac
@@ -1,5 +1,8 @@
 matchHosts:
-  old.webrecorder.net: socks-proxy
+  old.webrecorder.net: ssh-proxy
 
 proxies:
-  socks-proxy: socks5://proxy-not-found:1081
+  ssh-proxy: ssh://proxy-not-found:1081
+
+  # this is ignored as the proxy is not used in matchHosts
+  unused-ssh-proxy: ssh://proxy-not-found:1082

--- a/tests/fixtures/proxies/proxy-test-failed.pac
+++ b/tests/fixtures/proxies/proxy-test-failed.pac
@@ -1,0 +1,5 @@
+matchHosts:
+  old.webrecorder.net: socks-proxy
+
+proxies:
+  socks-proxy: socks5://proxy-not-found:1081

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -254,7 +254,7 @@ test("proxy per-host, ignore only if flag set", () => {
   // ignored
   try {
     execSync(
-      `docker run --rm -v $PWD/tests/fixtures/proxies/:/proxies/ webrecorder/browsertrix-crawler crawl --proxyServerConfig /proxies/proxy-test-failed.pac --proxyServerConfigIgnoreFailedProxies --url ${HTML} ${extraArgs}`,
+      `docker run --rm -v $PWD/tests/fixtures/proxies/:/proxies/ webrecorder/browsertrix-crawler crawl --proxyServerConfig /proxies/proxy-test-failed.pac --proxyServerConfigIgnoreFailed --url ${HTML} ${extraArgs}`,
       { encoding: "utf-8" },
     );
   } catch (e) {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -248,7 +248,7 @@ test("proxy with config file, correct auth or no match", () => {
   );
 });
 
-test("proxy per-host, ignore only if flag set", () => {
+test("proxy per-host, ignore only if option set", () => {
   let status = 0;
 
   // ignored

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -247,3 +247,29 @@ test("proxy with config file, correct auth or no match", () => {
     { encoding: "utf-8" },
   );
 });
+
+test("proxy per-host, ignore only if flag set", () => {
+  let status = 0;
+
+  // ignored
+  try {
+    execSync(
+      `docker run --rm -v $PWD/tests/fixtures/proxies/:/proxies/ webrecorder/browsertrix-crawler crawl --proxyServerConfig /proxies/proxy-test-failed.pac --proxyServerConfigIgnoreFailedProxies --url ${HTML} ${extraArgs}`,
+      { encoding: "utf-8" },
+    );
+  } catch (e) {
+    status = (e as ErrorWithStatus).status;
+  }
+  expect(status).toBe(0);
+
+  // not ignored
+  try {
+    execSync(
+      `docker run --rm -v $PWD/tests/fixtures/proxies/:/proxies/ webrecorder/browsertrix-crawler crawl --proxyServerConfig /proxies/proxy-test-failed.pac --url ${HTML} ${extraArgs}`,
+      { encoding: "utf-8" },
+    );
+  } catch (e) {
+    status = (e as ErrorWithStatus).status;
+  }
+  expect(status).toBe(PROXY_EXIT_CODE);
+});

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -254,7 +254,7 @@ test("proxy per-host, ignore only if flag set", () => {
   // ignored
   try {
     execSync(
-      `docker run --rm -v $PWD/tests/fixtures/proxies/:/proxies/ webrecorder/browsertrix-crawler crawl --proxyServerConfig /proxies/proxy-test-failed.pac --proxyServerConfigIgnoreFailed --url ${HTML} ${extraArgs}`,
+      `docker run --rm -v $PWD/tests/fixtures/proxies/:/proxies/ webrecorder/browsertrix-crawler crawl --proxyServerConfig /proxies/proxy-test-failed-ignore.pac --url ${HTML} ${extraArgs}`,
       { encoding: "utf-8" },
     );
   } catch (e) {


### PR DESCRIPTION
For failed proxy connections:
- interrupt instead of failing crawl

For per-host proxies specified in matchHosts:
- only attempt to init host proxies that are actually in use
- add optional `ignoreOnFailedSSHTunnel` to each proxy config to allow ignoring SSH proxies specified via `matchHosts` proxies if they are not available, and just connecting directly, instead of interrupting crawl. This only applies to SSH proxies and only when used with `matchHosts`

fixes #1076