### PR TITLE
optimizations and fixes for pending list:

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2282,8 +2282,9 @@ self.__bx_behaviors.selectMainBehavior();
       return;
     }
 
-    const pendingPages = await this.crawlState.getPendingList();
-    const pending = pendingPages.length;
+    const pendingPagesFull = await this.crawlState.getPendingList();
+    const pending = pendingPagesFull.length;
+    const pendingPages = pendingPagesFull.slice(0, 10);
     const crawled = await this.crawlState.numDone();
     const failed = await this.crawlState.numFailed();
     const total = await this.crawlState.numFound();

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1502,7 +1502,6 @@ export class Recorder extends EventEmitter {
     url,
     headers,
     cdp,
-    crawler,
     state,
   }: DirectFetchRequest): Promise<number> {
     const reqresp = new RequestResponseInfo("0");
@@ -1546,8 +1545,11 @@ export class Recorder extends EventEmitter {
       return STATUS_IS_HTML_NO_DIRECT_FETCH;
     }
     if (!this.stopping) {
-      state.isDirectFetched = true;
-      void this.asyncFetchQ.add(() => fetcher.loadDirectPage(state, crawler));
+      // todo: revisit async queuing at a later time
+      //state.isDirectFetched = true;
+      //void this.asyncFetchQ.add(() => fetcher.loadDirectPage(state, crawler));
+      // load immediately for now
+      await fetcher.loadDirectPage(state);
     }
     return reqresp.status;
   }
@@ -2230,7 +2232,7 @@ class AsyncFetcher {
     }
   }
 
-  async loadDirectPage(state: PageState, crawler: Crawler) {
+  async loadDirectPage(state: PageState, crawler?: Crawler) {
     const result = await this.loadBody(true);
 
     this.recorder.addPageRecord(this.reqresp);
@@ -2252,7 +2254,9 @@ class AsyncFetcher {
       "fetch",
     );
 
-    await crawler.pageFinished(state);
+    if (crawler) {
+      await crawler.pageFinished(state);
+    }
   }
 }
 

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -936,6 +936,7 @@ if redis.call('sadd', KEYS[3], ARGV[1]) == 0 then
 end
 redis.call('zadd', KEYS[2], ARGV[2], ARGV[3]);
 redis.call('hdel', KEYS[1], ARGV[1]);
+redis.call('del', KEYS[1] .. ":" .. ARGV[1]);
 return 0;
 `,
     });
@@ -953,6 +954,7 @@ return 0;
       if json then
         local data = cjson.decode(json);
         redis.call('hdel', KEYS[2], data.url);
+        redis.call('del', KEYS[2] .. ":" .. data.url);
         redis.call('sadd', KEYS[3], data.url);
       end
       return 1;
@@ -1012,6 +1014,7 @@ if json then
   local retry = data['retry'] or 0;
 
   redis.call('hdel', KEYS[1], ARGV[1]);
+  redis.call('del', KEYS[1] .. ":" .. ARGV[1]);
 
   local maxRetries = tonumber(ARGV[2]);
 
@@ -1026,6 +1029,7 @@ if json then
     redis.call('lpush', KEYS[3], json);
   end
 end
+redis.call('del', KEYS[1] .. ":" .. ARGV[1]);
 return -1;
 
 `,
@@ -1100,6 +1104,7 @@ return inx;
     await this.redis.hdel(this.pkey, url);
 
     await this.redis.del(
+      this.pkey + ":" + url,
       `${this.crawlId}:rateLimited`,
       `${this.crawlId}:rateLimitedDirect`,
     );
@@ -1126,6 +1131,7 @@ return inx;
 
   async markExcluded(url: string) {
     await this.redis.hdel(this.pkey, url);
+    await this.redis.del(this.pkey + ":" + url);
 
     await this.redis.sadd(this.exKey, url);
   }

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -1009,12 +1009,13 @@ end
       lua: `
 local json = redis.call('hget', KEYS[1], ARGV[1]);
 
+redis.call('del', KEYS[1] .. ":" .. ARGV[1]);
+
 if json then
   local data = cjson.decode(json);
   local retry = data['retry'] or 0;
 
   redis.call('hdel', KEYS[1], ARGV[1]);
-  redis.call('del', KEYS[1] .. ":" .. ARGV[1]);
 
   local maxRetries = tonumber(ARGV[2]);
 
@@ -1029,7 +1030,6 @@ if json then
     redis.call('lpush', KEYS[3], json);
   end
 end
-redis.call('del', KEYS[1] .. ":" .. ARGV[1]);
 return -1;
 
 `,


### PR DESCRIPTION
- call loadDirectPage() immediately instead of queuing, as async queue may grow large with unfinished pages (will revisit at a later time)
- logging: print only first 10 entries in pending list, and total size of pending list, in case the list does grow large
- state: whenever removing a url from pending list, also remove the `<crawlid>:p:<url>` lock, since the page is no longer pending, the lock key should be removed.
- fixes #1061 