### PR TITLE
docs: fix a couple of youtube details

### DIFF
--- a/docs/docs/user-guide/behaviors.md
+++ b/docs/docs/user-guide/behaviors.md
@@ -81,7 +81,7 @@ The Facebook behavior is able to automate the following features:
 
 The YouTube behavior is able to automate the following features:
 
-- Selecting a video format that the crawler will be able to capture in a single stream. Currently, this will be a .mp4 with resolution of <= 320p due to YouTube limitations.
+- Selecting a video format that the crawler will be able to replay correctly. Currently, this will be a .mp4 at 360p resolution due to YouTube limitations.
 - Ensuring that video playback has started
 
 ## Enabling Behaviors


### PR DESCRIPTION
I believe we pick this format for replay specifically, and it's 360p rather than 320p or lower.