### PR TITLE
recorder: fix call to undefined variable

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1178,7 +1178,7 @@ export class Recorder extends EventEmitter {
 
       logger.debug(
         "Finishing pending requests for page",
-        { numPending, pending, ...this.logDetails },
+        { numPending, ...this.logDetails },
         "recorder",
       );
       await sleep(5.0);
@@ -1188,7 +1188,7 @@ export class Recorder extends EventEmitter {
     if (this.pendingRequests.size) {
       logger.warn(
         "Dropping timed out requests",
-        { numPending, pending, ...this.logDetails },
+        { numPending, ...this.logDetails },
         "recorder",
       );
       for (const requestId of this.pendingRequests.keys()) {


### PR DESCRIPTION
624128bc8c579806df64f1f28c91a82ecc2aa0bd moved the `pending` variable into the `while` loop, so it's no longer defined at the places we call these two log statements.