### PR TITLE
typo fix: don't reuse same alias for rateLimitRetries and it overrides maxPageRetries

### DIFF
--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -788,7 +788,6 @@ class ArgParser {
         },
 
         rateLimitMaxRetries: {
-          alias: "retries",
           describe:
             "If set >=0, number of times to retry rate limited pages before marking them as failed. If -1, retry indefinitely",
           type: "number",

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1157,7 +1157,7 @@ export class Recorder extends EventEmitter {
       !this.crawler.interruptReason &&
       !this.crawler.postCrawling
     ) {
-      const pending = [];
+      const pendingLog = [];
       for (const [requestId, reqresp] of this.pendingRequests.entries()) {
         if (reqresp.unchangedSizeCount() >= PENDING_UNCHANGED_COUNT) {
           if (reqresp.currSize) {
@@ -1173,12 +1173,12 @@ export class Recorder extends EventEmitter {
           }
           this.removeReqResp(requestId);
         }
-        pending.push(reqresp.toJSON());
+        pendingLog.push(reqresp.toJSON());
       }
 
       logger.debug(
         "Finishing pending requests for page",
-        { numPending, pending, ...this.logDetails },
+        { numPending, pendingLog, ...this.logDetails },
         "recorder",
       );
       await sleep(5.0);
@@ -1188,7 +1188,7 @@ export class Recorder extends EventEmitter {
     if (this.pendingRequests.size) {
       logger.warn(
         "Dropping timed out requests",
-        { numPending, pending, ...this.logDetails },
+        { numPending, ...this.logDetails },
         "recorder",
       );
       for (const requestId of this.pendingRequests.keys()) {

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1157,7 +1157,7 @@ export class Recorder extends EventEmitter {
       !this.crawler.interruptReason &&
       !this.crawler.postCrawling
     ) {
-      const pendingLog = [];
+      const pending = [];
       for (const [requestId, reqresp] of this.pendingRequests.entries()) {
         if (reqresp.unchangedSizeCount() >= PENDING_UNCHANGED_COUNT) {
           if (reqresp.currSize) {
@@ -1173,12 +1173,12 @@ export class Recorder extends EventEmitter {
           }
           this.removeReqResp(requestId);
         }
-        pendingLog.push(reqresp.toJSON());
+        pending.push(reqresp.toJSON());
       }
 
       logger.debug(
         "Finishing pending requests for page",
-        { numPending, pendingLog, ...this.logDetails },
+        { numPending, pending, ...this.logDetails },
         "recorder",
       );
       await sleep(5.0);
@@ -1188,7 +1188,7 @@ export class Recorder extends EventEmitter {
     if (this.pendingRequests.size) {
       logger.warn(
         "Dropping timed out requests",
-        { numPending, ...this.logDetails },
+        { numPending, pending, ...this.logDetails },
         "recorder",
       );
       for (const requestId of this.pendingRequests.keys()) {


### PR DESCRIPTION
- don't reuse same alias for rateLimitRetries as it overrides regular retries
- use different variable for 'pending' as was not being detected as a out-of-scope due to type conflict