### PR TITLE
typing fixes: don't include 'jest' in app globals, include only in tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,7 +3,6 @@ module.exports = {
     browser: true,
     es2021: true,
     node: true,
-    jest: true,
   },
   extends: [
     "eslint:recommended",
@@ -37,10 +36,16 @@ module.exports = {
   reportUnusedDisableDirectives: true,
   overrides: [
     {
-      "files": ["tests/*.ts"],
-      "rules": {
-        "@typescript-eslint/no-floating-promises": "off"
-      }
-    }
-  ]
+      files: ["tests/*.ts"],
+      env: {
+        jest: true,
+      },
+      parserOptions: {
+        project: ["./tsconfig.test.json"],
+      },
+      rules: {
+        "@typescript-eslint/no-floating-promises": "off",
+      },
+    },
+  ],
 };

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1188,7 +1188,7 @@ export class Recorder extends EventEmitter {
     if (this.pendingRequests.size) {
       logger.warn(
         "Dropping timed out requests",
-        { numPending, pending, ...this.logDetails },
+        { numPending, ...this.logDetails },
         "recorder",
       );
       for (const requestId of this.pendingRequests.keys()) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"],                                   /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*", "tests/**/*"],
   "exclude": [


### PR DESCRIPTION
recorder: remove undefined variable included due to incorrect typing

follow-up from #1090 