### PR TITLE
Fix --alwaysAddBehaviorLinks / smart scoping to work as expected:

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@novnc/novnc": "1.7.0",
     "@puppeteer/replay": "^3.1.3",
     "@webrecorder/wabac": "^2.26.5",
-    "browsertrix-behaviors": "^0.12.0",
+    "browsertrix-behaviors": "^0.12.1",
     "client-zip": "^2.4.5",
     "css-selector-parser": "^3.0.5",
     "fetch-socks": "^1.3.2",

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -813,7 +813,25 @@ export class Crawler {
   }
 
   async setupPage(opts: WorkerState) {
-    const { page, cdp, workerid, callbacks, frameIdToExecId, recorder } = opts;
+    const { page, cdp, workerid, frameIdToExecId, recorder } = opts;
+
+    const addLink = async (url: string, alwaysObeyScope: boolean = false) => {
+      const { seedId, depth, extraHops = 0, logDetails } = opts.data;
+
+      // if not always obeying scope and allowed to ignore scope, set to true
+      const ignoreScope =
+        !alwaysObeyScope && this.params.alwaysAddBehaviorLinks;
+
+      await this.queueInScopeUrls({
+        seedId,
+        urls: [url],
+        depth,
+        extraHops,
+        pageUrl: page.url(),
+        logDetails,
+        ignoreScope,
+      });
+    };
 
     await this.browser.setupPage({ page, cdp });
 
@@ -864,10 +882,7 @@ export class Crawler {
       await this.screencaster.screencastPage(page, cdp, workerid);
     }
 
-    await page.exposeFunction(
-      BxFunctionBindings.AddLinkFunc,
-      (url: string) => callbacks.addLink && callbacks.addLink(url),
-    );
+    await page.exposeFunction(BxFunctionBindings.AddLinkFunc, addLink);
 
     // used for both behaviors and link extraction now
     await this.browser.addInitScript(page, btrixBehaviors);
@@ -998,7 +1013,7 @@ self.__bx_behaviors.selectMainBehavior();
       BxFunctionBindings.AddToSeenSet,
       (data: string) => {
         if (data && (data.startsWith("https:") || data.startsWith("http:"))) {
-          void callbacks.addLink(data);
+          void addLink(data);
         }
         return this.crawlState.addToUserSet(data);
       },
@@ -1121,8 +1136,7 @@ self.__bx_behaviors.selectMainBehavior();
   async crawlPage(opts: WorkerState): Promise<void> {
     await this.writeStats();
 
-    const { page, cdp, data, workerid, callbacks, recorder } = opts;
-    data.callbacks = callbacks;
+    const { page, cdp, data, workerid, recorder } = opts;
 
     const { url, seedId, depth } = data;
 
@@ -2705,25 +2719,7 @@ self.__bx_behaviors.selectMainBehavior();
     selectors: ExtractSelector[],
     logDetails: LogDetails,
   ) {
-    const { seedId, depth, extraHops = 0, filteredFrames, callbacks } = data;
-
-    callbacks.addLink = async (url: string, ignoreScope = false) => {
-      // if crawler arg set, always ignore scope
-      // otherwise, may be determined by behavior addLink()
-      if (this.params.alwaysAddBehaviorLinks) {
-        ignoreScope = true;
-      }
-
-      await this.queueInScopeUrls({
-        seedId,
-        urls: [url],
-        depth,
-        extraHops,
-        pageUrl: page.url(),
-        logDetails,
-        ignoreScope,
-      });
-    };
+    const { filteredFrames } = data;
 
     const frames = filteredFrames || page.frames();
 

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -19,8 +19,6 @@ export type WorkerState = {
   page: Page;
   cdp: CDPSession;
   workerid: WorkerId;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  callbacks: Record<string, Function>;
   recorder: Recorder | null;
   markPageUsed: () => void;
   frameIdToExecId: Map<string, number>;
@@ -40,9 +38,6 @@ export class PageWorker {
   alwaysReuse: boolean;
   page?: Page | null;
   cdp?: CDPSession | null;
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  callbacks?: Record<string, Function>;
 
   opts?: WorkerState;
 
@@ -171,13 +166,11 @@ export class PageWorker {
 
         this.page = page;
         this.cdp = cdp;
-        this.callbacks = {};
 
         this.opts = {
           page,
           cdp,
           workerid,
-          callbacks: this.callbacks,
           recorder: this.recorder,
           frameIdToExecId: new Map<string, number>(),
           markPageUsed: () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,10 +2031,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.1"
 
-browsertrix-behaviors@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.12.0.tgz#967cea632ae82d1d9416994505fd1715227c9ab0"
-  integrity sha512-JY+b8nobI8fsZRNbyF5t+XTBOwboB+rxIN8uJsObqoN5U1vby4NUsVhvC3KAzLF8EQk1T3D2QvzL9lCG/8LNzw==
+browsertrix-behaviors@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.12.1.tgz#65e5ac2bbcecdb0392c84972cbe8ec14ebd4adf8"
+  integrity sha512-Vudm3K5dK9Lv0zCYVSTTjoQsBUDEJD87OQQktLVfp4n4hNLaVB1VHG3sidKyRpqSPivh717DFhLu9nwcwzWs3Q==
   dependencies:
     query-selector-shadow-dom "^1.0.1"
 


### PR DESCRIPTION
- ensure regular links always obey scope, as using same method
- support addLink(url, alwaysObeyScope) from added in, webrecorder/browsertrix-behaviors#150
- scope only ignored if alwaysObeyScope is false and alwaysAddBehaviorLinks is set
- move addLink() declaration to setupPage(), as extractLinks() not called for single page scope
- simplify, no longer need extra 'callbacks' in PageState