### PR TITLE
tests: fix custom_selector test

### DIFF
--- a/tests/custom_selector.test.ts
+++ b/tests/custom_selector.test.ts
@@ -42,8 +42,8 @@ test("test custom selector crawls JS files as pages", async () => {
   const expectedPages = new Set(["https://www.iana.org/"]);
 
   const expectedExtraPages = new Set([
-    "https://www.iana.org/static/_js/jquery.js",
-    "https://www.iana.org/static/_js/iana.js",
+    "https://www.iana.org/static/js/dtable.46ee921d4414.js",
+    "https://www.iana.org/static/js/jquery.a8e7cabd4d49.js",
   ]);
 
   expect(pages).toEqual(expectedPages);


### PR DESCRIPTION
The IANA webpage has changed since the test was written. We should migrate this test to use a different site when we can, but in the meantime this should get it passing again.