### PR TITLE
Fix incorrect handling of redis extra seeds + extra logging for for excluded pages

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1424,7 +1424,7 @@ self.__bx_behaviors.selectMainBehavior();
 
       await this.checkLimits();
     } else {
-      if (pageSkipped) {
+      if (pageSkipped || data.pageSkipReason) {
         await this.markExcluded(
           data,
           data.pageSkipReason || SkippedReason.Failed,

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -10,6 +10,7 @@ import {
   QueueState,
   PageState,
   WorkerId,
+  QueueEntry,
 } from "./util/state.js";
 
 import { CrawlerArgs, parseArgs } from "./util/argParser.js";
@@ -1387,6 +1388,13 @@ self.__bx_behaviors.selectMainBehavior();
     }
   }
 
+  async markExcluded(data: QueueEntry | PageState, skipReason: SkippedReason) {
+    const { url, seedId, depth } = data;
+    await this.crawlState.markExcluded(url);
+
+    this.writeSkippedPage(url, seedId, depth, skipReason);
+  }
+
   async pageFinished(data: PageState, lastErrorText = "") {
     // if page loaded, considered page finished successfully
     // (even if behaviors timed out)
@@ -1417,11 +1425,11 @@ self.__bx_behaviors.selectMainBehavior();
       await this.checkLimits();
     } else {
       if (pageSkipped) {
-        await this.crawlState.markExcluded(url);
+        await this.markExcluded(
+          data,
+          data.pageSkipReason || SkippedReason.Failed,
+        );
 
-        if (data.pageSkipReason) {
-          this.writeSkippedPage(url, data.seedId, depth, data.pageSkipReason);
-        }
         this.limitHit = false;
       } else {
         const retry = await this.crawlState.markFailed(

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -127,7 +127,7 @@ export const WARC_REFERS_TO_CONTAINER = "WARC-Refers-To-Container";
 export enum SkippedReason {
   OutOfScope = "outOfScope",
   OutOfScopeMidCrawl = "outOfScopeMidCrawl",
-  ExcludedMidCrawl = "excludedMidCrawl",
+  ExcludedMidCrawl = "outOfScopeUserExclusion",
   PageLimit = "pageLimit",
   RobotsTxt = "robotsTxt",
   RedirectToExcluded = "redirectToExcluded",

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -126,6 +126,8 @@ export const WARC_REFERS_TO_CONTAINER = "WARC-Refers-To-Container";
 
 export enum SkippedReason {
   OutOfScope = "outOfScope",
+  OutOfScopeMidCrawl = "outOfScopeMidCrawl",
+  ExcludedMidCrawl = "excludedMidCrawl",
   PageLimit = "pageLimit",
   RobotsTxt = "robotsTxt",
   RedirectToExcluded = "redirectToExcluded",

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -1071,7 +1071,7 @@ if res then
     return tonumber(res);
 end
 
-local inx = redis.call('lpush', KEYS[1], ARGV[1]) - 1;
+local inx = redis.call('rpush', KEYS[1], ARGV[1]) - 1;
 redis.call('hset', KEYS[2], ARGV[2], tostring(inx));
 redis.call('sadd', KEYS[3], ARGV[2]);
 return inx;
@@ -1868,7 +1868,7 @@ return inx;
     origLength: number,
     origSeedId: number,
     newUrl: string,
-  ) {
+  ): Promise<number> {
     if (!seeds[origSeedId]) {
       await logger.fatal(
         "State load, original seed missing",
@@ -1876,6 +1876,16 @@ return inx;
         "state",
       );
     }
+
+    const indexStr = await this.redis.hget(this.esMap, newUrl);
+    const indexNum = parseInt(indexStr || "");
+
+    // already exists, don't readd same seed
+    if (!isNaN(indexNum)) {
+      await this.getSeedAt(seeds, origLength, indexNum);
+      return indexNum;
+    }
+
     const redirectSeed: ExtraRedirectSeed = { origSeedId, newUrl };
     const seedData = JSON.stringify(redirectSeed);
     const newSeedId =
@@ -1889,25 +1899,25 @@ return inx;
       ));
     seeds[newSeedId] = seeds[origSeedId].newScopedSeed(newUrl);
 
-    //const newSeedId = seeds.length - 1;
-    //await this.redis.sadd(this.skey, newUrl);
-    //await this.redis.lpush(this.esKey, JSON.stringify(redirectSeed));
     return newSeedId;
   }
 
-  async getSeedAt(seeds: ScopedSeed[], origLength: number, newSeedId: number) {
+  async getSeedAt(
+    seeds: ScopedSeed[],
+    origLength: number,
+    newSeedId: number,
+  ): Promise<ScopedSeed> {
     if (seeds[newSeedId]) {
       return seeds[newSeedId];
     }
 
-    const newSeedDataList = await this.redis.lrange(
+    const newSeedData = await this.redis.lindex(
       this.esKey,
       newSeedId - origLength,
-      newSeedId - origLength,
     );
-    if (newSeedDataList.length) {
+    if (newSeedData) {
       const { origSeedId, newUrl } = JSON.parse(
-        newSeedDataList[0],
+        newSeedData,
       ) as ExtraRedirectSeed;
       seeds[newSeedId] = seeds[origSeedId].newScopedSeed(newUrl);
     }

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -1882,15 +1882,6 @@ return inx;
       );
     }
 
-    const indexStr = await this.redis.hget(this.esMap, newUrl);
-    const indexNum = parseInt(indexStr || "");
-
-    // already exists, don't readd same seed
-    if (!isNaN(indexNum)) {
-      await this.getSeedAt(seeds, origLength, indexNum);
-      return indexNum;
-    }
-
     const redirectSeed: ExtraRedirectSeed = { origSeedId, newUrl };
     const seedData = JSON.stringify(redirectSeed);
     const newSeedId =

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -1337,7 +1337,10 @@ return inx;
     await this.redis.set(`${this.crawlId}:stopping`, "1");
   }
 
-  async processMessage(seeds: ScopedSeed[]) {
+  async processMessage(
+    seeds: ScopedSeed[],
+    markExcluded: (data: QueueEntry) => Promise<void>,
+  ) {
     while (true) {
       const result = await this.redis.lpop(`${this.uid}:msg`);
       if (!result) {
@@ -1357,7 +1360,7 @@ return inx;
             // can happen async w/o slowing down crawling
             // each page is still checked if in scope before crawling, even while
             // queue is being filtered
-            this.filterQueue(regex).catch((e) =>
+            this.filterQueue(regex, markExcluded).catch((e) =>
               logger.warn("filtering queue error", e, "exclusion"),
             );
             break;
@@ -1383,7 +1386,10 @@ return inx;
     return s.replace(/\\/g, "").replace(/[\\^$*+?.()|[\]{}]/g, "\\$&") === s;
   }
 
-  filterQueue(regexStr: string) {
+  filterQueue(
+    regexStr: string,
+    markExcluded: (data: QueueEntry) => Promise<void>,
+  ) {
     const regex = new RegExp(regexStr);
 
     let matcher = undefined;
@@ -1399,12 +1405,11 @@ return inx;
       stream.pause();
 
       for (const result of results) {
-        const { url } = JSON.parse(result);
+        const data = JSON.parse(result);
+        const { url } = data;
         if (regex.test(url)) {
           const removed = await this.redis.zrem(this.qkey, result);
-          //if (removed) {
-          await this.markExcluded(url);
-          //}
+          await markExcluded(data);
           logger.debug(
             "Removing excluded URL",
             { url, regex, removed },

--- a/src/util/worker.ts
+++ b/src/util/worker.ts
@@ -5,7 +5,7 @@ import { sleep, timedRun } from "./timing.js";
 import { Recorder } from "./recorder.js";
 import { rxEscape } from "./seeds.js";
 import { CDPSession, Page } from "puppeteer-core";
-import { PageState, WorkerId } from "./state.js";
+import { PageState, QueueEntry, WorkerId } from "./state.js";
 import { Crawler } from "../crawler.js";
 import { PAGE_OP_TIMEOUT_SECS, SkippedReason } from "./constants.js";
 
@@ -356,7 +356,9 @@ export class PageWorker {
     let loggedWaiting = false;
 
     while (await this.crawler.isCrawlRunning()) {
-      await crawlState.processMessage(this.crawler.seeds);
+      await crawlState.processMessage(this.crawler.seeds, (data: QueueEntry) =>
+        this.crawler.markExcluded(data, SkippedReason.ExcludedMidCrawl),
+      );
 
       const data = await crawlState.nextFromQueue();
 
@@ -370,15 +372,9 @@ export class PageWorker {
           limit > 0 &&
           (await crawlState.numDone()) >= limit
         ) {
-          const { url, seedId, depth } = data;
+          const { url } = data;
           logger.info("Skipping queued page, at limit", { url, limit });
-          await crawlState.markExcluded(url);
-          this.crawler.writeSkippedPage(
-            url,
-            seedId,
-            depth,
-            SkippedReason.PageLimit,
-          );
+          await this.crawler.markExcluded(data, SkippedReason.PageLimit);
           continue;
         }
 
@@ -387,7 +383,10 @@ export class PageWorker {
           !(await this.crawler.isInScope(data.seedId, data, this.logDetails))
         ) {
           logger.info("Page no longer in scope", data);
-          await crawlState.markExcluded(data.url);
+          await this.crawler.markExcluded(
+            data,
+            SkippedReason.OutOfScopeMidCrawl,
+          );
           continue;
         }
 


### PR DESCRIPTION
- Fixes #1097 
- Using rpush instead of lpush to avoid seed index being off
- other cleanup: use lindex instead of lrange to get one entry
- Improved logging of excluded pages: consolidate markExcluded() in crawler which always logs to skippedPages report (if in enabled)
Add new SkippedReasons:
- outOfScopeMidCrawl if a page became out-of-scope for some reason while crawl is running (eg. crawl was restarted with scope changed)
- excludedMidCrawl if a page was excluded due to user-added exclusions mid crawl