### PR TITLE
scope fix: ensure single page with www. is still in scope

### DIFF
--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -193,12 +193,16 @@ export class ScopedSeed {
 
     switch (scopeType) {
       case "page":
-        include = [new RegExp("^" + urlRxEscape(parsedUrl.href) + "$")];
+        include = [
+          new RegExp("^" + urlRxEscape(normalizeUrl(parsedUrl.href)) + "$"),
+        ];
         break;
 
       case "page-spa":
         // allow scheme-agnostic URLS as likely redirects
-        include = [new RegExp("^" + urlRxEscape(parsedUrl.href) + "#.+")];
+        include = [
+          new RegExp("^" + urlRxEscape(normalizeUrl(parsedUrl.href)) + "#.+"),
+        ];
         allowHash = true;
         break;
 

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -193,7 +193,7 @@ export class ScopedSeed {
 
     switch (scopeType) {
       case "page":
-        include = [];
+        include = [new RegExp("^" + urlRxEscape(parsedUrl.href) + "$")];
         break;
 
       case "page-spa":

--- a/tests/norm-test.test.ts
+++ b/tests/norm-test.test.ts
@@ -56,3 +56,12 @@ test("same URL with same query args, but different sort order", async () => {
   // no other response records, (others are revisit, resource, etc..)
   expect(count).toBe(1);
 });
+
+test("single page www. URL crawled successfully", async () => {
+  // crawl should succeed
+  expect(() => {
+    execSync(
+      "docker run --rm -v $PWD/test-crawls:/crawls webrecorder/browsertrix-crawler crawl --url https://www.old.webrecorder.net/ --scopeType page",
+    );
+  }).not.toThrow();
+});

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -451,12 +451,19 @@ seeds:
   expect((result2 as Exclude<typeof result2, false>).isOOS).toBe(false);
 
   // Test with www and reordered query parameters (should still match)
-  const result3 = seeds[0].isIncluded({
-    url: "https://www.example.com/page?baz=qux&foo=bar",
-    depth: 0,
-  });
-  expect(result3).not.toBe(false);
-  expect((result3 as Exclude<typeof result2, false>).isOOS).toBe(false);
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/page?baz=qux&foo=bar",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/page?foo=bar&baz=qux",
+      depth: 0,
+    }),
+  ).not.toBe(false);
 });
 
 test("scopeType page should match URLs with double-encoded query parameters", async () => {

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -185,6 +185,30 @@ seeds:
   );
 });
 
+test("single page scope ignore www.", async () => {
+  const seeds = await getSeeds(`
+seeds:
+   - url: https://www.example.com/
+     scopeType: page
+`);
+
+  // matches with www
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // matches without
+  expect(
+    seeds[0].isIncluded({
+      url: "https://example.com/",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+});
+
 test("domain scope drop www.", async () => {
   const seeds = await getSeeds(`
 seeds:
@@ -328,12 +352,16 @@ exclude:
 
   expect(seeds[3].scopeType).toEqual("page");
   expect(seeds[3].url).toEqual("https://example.com/3");
-  expect(seeds[3].include).toEqual([]);
+  expect(seeds[3].include).toEqual([
+    /^https?:\/\/(www[\d]*\.)?example\.com\/3$/,
+  ]);
   expect(seeds[3].exclude).toEqual(excludeRxs);
 
   expect(seeds[4].scopeType).toEqual("page");
   expect(seeds[4].url).toEqual("https://example.com/4");
-  expect(seeds[4].include).toEqual([]);
+  expect(seeds[4].include).toEqual([
+    /^https?:\/\/(www[\d]*\.)?example\.com\/4$/,
+  ]);
   expect(seeds[4].exclude).toEqual([]);
 });
 
@@ -400,7 +428,9 @@ seeds:
 
   expect(seeds.length).toEqual(1);
   expect(seeds[0].scopeType).toEqual("page");
-  expect(seeds[0].include).toEqual([]);
+  expect(seeds[0].include).toEqual([
+    /^https?:\/\/(www[\d]*\.)?example\.com\/page\?baz=qux&foo=bar$/,
+  ]);
   expect(seeds[0].maxDepth).toEqual(0);
   expect(seeds[0].maxExtraHops).toEqual(0);
 
@@ -419,6 +449,14 @@ seeds:
   });
   expect(result2).not.toBe(false);
   expect((result2 as Exclude<typeof result2, false>).isOOS).toBe(false);
+
+  // Test with www and reordered query parameters (should still match)
+  const result3 = seeds[0].isIncluded({
+    url: "https://www.example.com/page?baz=qux&foo=bar",
+    depth: 0,
+  });
+  expect(result3).not.toBe(false);
+  expect((result3 as Exclude<typeof result2, false>).isOOS).toBe(false);
 });
 
 test("scopeType page should match URLs with double-encoded query parameters", async () => {
@@ -431,7 +469,9 @@ seeds:
 
   expect(seeds.length).toEqual(1);
   expect(seeds[0].scopeType).toEqual("page");
-  expect(seeds[0].include).toEqual([]);
+  expect(seeds[0].include).toEqual([
+    /^https?:\/\/(www[\d]*\.)?example\.com\/page\?foo=%252fbar$/,
+  ]);
   expect(seeds[0].maxDepth).toEqual(0);
   expect(seeds[0].maxExtraHops).toEqual(0);
 


### PR DESCRIPTION
fixes regression from #1088
- scopeType page did not have a `include` field, counting on exact match only.
- with www. normalization, that is no longer the case, so need to add include regex as well
- normalize URL single page include so that query arguments arg ignored, eg. single page seed of `https://example.com/?B=2&A=1` matches page `https://www.example.com/?A=1&B=2`
tests: add test for www. seed with scopeType page + update scopes tests
