### PR TITLE
deps: browsertrix-behaviors 0.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@novnc/novnc": "1.7.0",
     "@puppeteer/replay": "^3.1.3",
     "@webrecorder/wabac": "^2.26.5",
-    "browsertrix-behaviors": "^0.12.1",
+    "browsertrix-behaviors": "^0.12.2",
     "client-zip": "^2.4.5",
     "css-selector-parser": "^3.0.5",
     "fetch-socks": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,10 +2031,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.1"
 
-browsertrix-behaviors@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.12.1.tgz#65e5ac2bbcecdb0392c84972cbe8ec14ebd4adf8"
-  integrity sha512-Vudm3K5dK9Lv0zCYVSTTjoQsBUDEJD87OQQktLVfp4n4hNLaVB1VHG3sidKyRpqSPivh717DFhLu9nwcwzWs3Q==
+browsertrix-behaviors@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.12.2.tgz#8feafe1ed695ae48046de7af316404e8e71629fc"
+  integrity sha512-pVM+axbFsyistgmkdIHqXNpK7i1MRy439jONRQDrPgpV1J+JsY4t2iI0D2+AkCb/6VvCcP+u4fABt01jh7j/YQ==
   dependencies:
     query-selector-shadow-dom "^1.0.1"
 


### PR DESCRIPTION
This incorporates the fix that keeps us from running the Facebook behaviours on Instagram profiles.