### PR TITLE
treat connection timeouts as rate limits:

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1253,6 +1253,7 @@ self.__bx_behaviors.selectMainBehavior();
 
     // if it was a DNS error, fail page
     if (data.rateLimitStatus === STATUS_DNS_ERROR) {
+      recorder?.addPageFailedRecord(0, "net::ERR_NAME_NOT_RESOLVED");
       this.pageFailed("Page Load Aborted: DNS Error", data.retry, logDetails);
       return;
     }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -53,6 +53,7 @@ import {
   CrawlStatus,
   STATUS_CONNECTION_ERROR,
   STATUS_IS_HTML_NO_DIRECT_FETCH,
+  STATUS_DNS_ERROR,
 } from "./util/constants.js";
 
 import { AdBlockRules, BlockRuleDecl, BlockRules } from "./util/blockrules.js";
@@ -1229,9 +1230,15 @@ self.__bx_behaviors.selectMainBehavior();
         );
         if (
           status === STATUS_CONNECTION_ERROR ||
+          status === STATUS_DNS_ERROR ||
           this.params.rateLimitStatusCodes.includes(status)
         ) {
           await this.crawlState.incRateLimited(status, 0, true);
+        }
+
+        // skip any further loading
+        if (status === STATUS_DNS_ERROR) {
+          data.rateLimitStatus = STATUS_DNS_ERROR;
         }
       }
 
@@ -1241,6 +1248,12 @@ self.__bx_behaviors.selectMainBehavior();
     if (recorder && (await doDirectFetch())) {
       // return if direct fetch succeeds
       await this.awaitPageExtraDelay(opts);
+      return;
+    }
+
+    // if it was a DNS error, fail page
+    if (data.rateLimitStatus === STATUS_DNS_ERROR) {
+      this.pageFailed("Page Load Aborted: DNS Error", data.retry, logDetails);
       return;
     }
 
@@ -1430,8 +1443,8 @@ self.__bx_behaviors.selectMainBehavior();
       depth,
       url,
       pageSkipped,
-      pageRateLimited,
-      pageRateLimitedRetryAfter,
+      rateLimitStatus,
+      rateLimitedRetryAfter,
       noRetries,
     } = data;
 
@@ -1458,19 +1471,24 @@ self.__bx_behaviors.selectMainBehavior();
 
         this.limitHit = false;
       } else {
+        const useRateLimitRetries =
+          !!rateLimitStatus &&
+          rateLimitStatus !== STATUS_CONNECTION_ERROR &&
+          rateLimitStatus !== STATUS_DNS_ERROR;
+
         const retry = await this.crawlState.markFailed(
           url,
           noRetries,
-          !!pageRateLimited,
+          useRateLimitRetries,
         );
 
         if (this.healthChecker) {
           this.healthChecker.incError();
         }
-        if (pageRateLimited) {
+        if (rateLimitStatus) {
           await this.crawlState.incRateLimited(
-            pageRateLimited,
-            pageRateLimitedRetryAfter,
+            rateLimitStatus,
+            rateLimitedRetryAfter,
             false,
           );
         }
@@ -2371,18 +2389,18 @@ self.__bx_behaviors.selectMainBehavior();
     throw new Error("logged");
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  pageFailed(msg: string, retry: number, msgData: any) {
-    if (retry < this.params.maxPageRetries) {
+  pageFailed(msg: string, retry: number, msgData: LogDetails) {
+    const retries = this.params.maxPageRetries;
+    if (retry < retries) {
       logger.warn(
         msg + ": will retry",
-        { retry, retries: this.params.maxPageRetries, ...msgData },
+        { retry, retries, ...msgData },
         "pageStatus",
       );
     } else {
       logger.error(
         msg + ": retry limit reached",
-        { retry, retries: this.params.maxPageRetries, ...msgData },
+        { retry, retries, ...msgData },
         "pageStatus",
       );
     }
@@ -2486,20 +2504,10 @@ self.__bx_behaviors.selectMainBehavior();
               { msg },
               data,
             );
-          } else if (
-            loadState === LoadState.FAILED ||
-            msg.startsWith("net::ERR_HTTP2_PROTOCOL_ERROR") ||
-            msg.startsWith("net::ERR_CONNECTION_TIMED_OUT")
-          ) {
-            // treat as rate limit, page blocked
-            data.pageRateLimited = STATUS_CONNECTION_ERROR;
-            logger.warn(
-              "Page load interrupted, possibly rate limited",
-              { url, msg, ...logDetails },
-              "pageStatus",
-            );
-            throw new Error("logged");
           } else {
+            // treat as rate limit, page blocked
+            data.rateLimitStatus = STATUS_CONNECTION_ERROR;
+
             return this.pageFailed("Page Load Failed", retry, {
               msg,
               url,
@@ -2561,7 +2569,7 @@ self.__bx_behaviors.selectMainBehavior();
     const status = resp.status();
     data.status = status;
 
-    if (!isChromeError && data.pageRateLimited) {
+    if (!isChromeError && data.rateLimitStatus) {
       logger.warn(
         "Page possibly rate limited, retrying",
         { url, status, ...logDetails },

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2487,6 +2487,7 @@ self.__bx_behaviors.selectMainBehavior();
               data,
             );
           } else if (
+            loadState === LoadState.FAILED ||
             msg.startsWith("net::ERR_HTTP2_PROTOCOL_ERROR") ||
             msg.startsWith("net::ERR_CONNECTION_TIMED_OUT")
           ) {

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -51,7 +51,7 @@ import {
   BxFunctionBindings,
   MAX_JS_DIALOG_PER_PAGE,
   CrawlStatus,
-  STATUS_UNKNOWN_ERROR,
+  STATUS_CONNECTION_ERROR,
   STATUS_IS_HTML_NO_DIRECT_FETCH,
 } from "./util/constants.js";
 
@@ -1205,7 +1205,7 @@ self.__bx_behaviors.selectMainBehavior();
           "fetch",
         );
         // indicate this was some other error
-        status = STATUS_UNKNOWN_ERROR;
+        status = STATUS_CONNECTION_ERROR;
       }
 
       // direct fetch succeeded
@@ -1227,7 +1227,10 @@ self.__bx_behaviors.selectMainBehavior();
           { status, ...logDetails },
           "fetch",
         );
-        if (this.params.rateLimitStatusCodes.includes(status)) {
+        if (
+          status === STATUS_CONNECTION_ERROR ||
+          this.params.rateLimitStatusCodes.includes(status)
+        ) {
           await this.crawlState.incRateLimited(status, 0, true);
         }
       }
@@ -2483,9 +2486,12 @@ self.__bx_behaviors.selectMainBehavior();
               { msg },
               data,
             );
-          } else if (msg.startsWith("net::ERR_HTTP2_PROTOCOL_ERROR")) {
+          } else if (
+            msg.startsWith("net::ERR_HTTP2_PROTOCOL_ERROR") ||
+            msg.startsWith("net::ERR_CONNECTION_TIMED_OUT")
+          ) {
             // treat as rate limit, page blocked
-            data.pageRateLimited = STATUS_UNKNOWN_ERROR;
+            data.pageRateLimited = STATUS_CONNECTION_ERROR;
             logger.warn(
               "Page load interrupted, possibly rate limited",
               { url, msg, ...logDetails },

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -140,6 +140,9 @@ export const STATUS_IS_HTML_NO_DIRECT_FETCH = 600;
 // Connection Error -- unable to connect to site
 export const STATUS_CONNECTION_ERROR = 999;
 
+// DNS Error -- unable to resolve hostname
+export const STATUS_DNS_ERROR = 899;
+
 // ============================================================================
 // Rate Limit Constants
 export const RATE_LIMIT_TTL_SECS = 300;

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -137,7 +137,8 @@ export enum SkippedReason {
 // Direct Fetch Error Constants
 export const STATUS_IS_HTML_NO_DIRECT_FETCH = 600;
 
-export const STATUS_UNKNOWN_ERROR = 999;
+// Connection Error -- unable to connect to site
+export const STATUS_CONNECTION_ERROR = 999;
 
 // ============================================================================
 // Rate Limit Constants

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -34,6 +34,7 @@ import {
   STATUS_IS_HTML_NO_DIRECT_FETCH,
   STATUS_CONNECTION_ERROR,
   WARC_REFERS_TO_CONTAINER,
+  STATUS_DNS_ERROR,
 } from "./constants.js";
 import { Readable } from "stream";
 import { createHash } from "crypto";
@@ -1077,9 +1078,9 @@ export class Recorder extends EventEmitter {
   markRateLimited(status: number, retryAfterHeader: string | null) {
     this.skipRecordingPage = true;
     if (this.state) {
-      this.state.pageRateLimited = status;
+      this.state.rateLimitStatus = status;
       if (retryAfterHeader) {
-        this.state.pageRateLimitedRetryAfter = parseInt(retryAfterHeader) || 0;
+        this.state.rateLimitedRetryAfter = parseInt(retryAfterHeader) || 0;
       }
     }
   }
@@ -1541,7 +1542,7 @@ export class Recorder extends EventEmitter {
     });
 
     if (!(await fetcher.loadHeaders())) {
-      return STATUS_CONNECTION_ERROR;
+      return fetcher.dnsError ? STATUS_DNS_ERROR : STATUS_CONNECTION_ERROR;
     }
 
     const mime = reqresp.getMimeType() || "";
@@ -1978,6 +1979,8 @@ class AsyncFetcher {
 
   maxRetries = DEFAULT_MAX_RETRIES;
 
+  dnsError = false;
+
   constructor({
     reqresp,
     expectedSize = -1,
@@ -2043,6 +2046,9 @@ class AsyncFetcher {
         success = await this.loadHeadersFetch();
       }
     } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "ENOTFOUND") {
+        this.dnsError = true;
+      }
       logger.warn(
         "Async load headers failed",
         { ...formatErr(e), url: this.reqresp.url, ...this.recorder.logDetails },

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -32,7 +32,7 @@ import {
   RateLimitRule,
   SkippedReason,
   STATUS_IS_HTML_NO_DIRECT_FETCH,
-  STATUS_UNKNOWN_ERROR,
+  STATUS_CONNECTION_ERROR,
   WARC_REFERS_TO_CONTAINER,
 } from "./constants.js";
 import { Readable } from "stream";
@@ -1541,7 +1541,7 @@ export class Recorder extends EventEmitter {
     });
 
     if (!(await fetcher.loadHeaders())) {
-      return STATUS_UNKNOWN_ERROR;
+      return STATUS_CONNECTION_ERROR;
     }
 
     const mime = reqresp.getMimeType() || "";

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1101,6 +1101,10 @@ export class Recorder extends EventEmitter {
     }
   }
 
+  addPageFailedRecord(status: number, error: string) {
+    this.pageInfo.urls[this.pageInfo.url] = { status, error };
+  }
+
   writePageInfoRecord() {
     if (this.skipPageInfo || this.skipRecordingPage) {
       logger.debug(

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1546,7 +1546,9 @@ export class Recorder extends EventEmitter {
     });
 
     if (!(await fetcher.loadHeaders())) {
-      return fetcher.dnsError ? STATUS_DNS_ERROR : STATUS_CONNECTION_ERROR;
+      return fetcher.lastError === "ENOTFOUND"
+        ? STATUS_DNS_ERROR
+        : STATUS_CONNECTION_ERROR;
     }
 
     const mime = reqresp.getMimeType() || "";
@@ -1983,7 +1985,7 @@ class AsyncFetcher {
 
   maxRetries = DEFAULT_MAX_RETRIES;
 
-  dnsError = false;
+  lastError = "";
 
   constructor({
     reqresp,
@@ -2050,9 +2052,7 @@ class AsyncFetcher {
         success = await this.loadHeadersFetch();
       }
     } catch (e) {
-      if ((e as NodeJS.ErrnoException).code === "ENOTFOUND") {
-        this.dnsError = true;
-      }
+      this.lastError = (e as NodeJS.ErrnoException).code ?? "";
       logger.warn(
         "Async load headers failed",
         { ...formatErr(e), url: this.reqresp.url, ...this.recorder.logDetails },

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -104,8 +104,8 @@ export class PageState {
   skipBehaviors = false;
   pageSkipped = false;
   pageSkipReason: SkippedReason | null = null;
-  pageRateLimited = 0;
-  pageRateLimitedRetryAfter = 0;
+  rateLimitStatus = 0;
+  rateLimitedRetryAfter = 0;
   noRetries = false;
 
   isDirectFetched = false;

--- a/tests/pageinfo-records.test.ts
+++ b/tests/pageinfo-records.test.ts
@@ -182,7 +182,6 @@ function validateResourcesInvalid(json: Record<string, unknown>) {
   expect(json.urls).toEqual({
     "https://invalid.invalid/": {
       status: 0,
-      type: "document",
       error: "net::ERR_NAME_NOT_RESOLVED",
     },
   });


### PR DESCRIPTION
Connection timeouts (both for direct fetch and browser page load) should be considered as rate limits and also increment the corresponding counters:
- Use STATUS_CONNECTION_ERROR as 999
- Add STATUS_DNS_ERROR 899 as DNS failure (ENOTFOUND error)
- Increment rate limit counts, but treat both statuses as failures (use fail page retry max for these failures)
- For DNS failure in direct fetch, don't attempt to load page in the browser, as will also certainly failure.