### PR TITLE
ci: append `next` to list of tags on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
           images: webrecorder/browsertrix-crawler
           tags: |
             type=semver,pattern={{version}}
+            type=raw,pattern=edge
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4


### PR DESCRIPTION
We publish with the `latest` label for stable releases, but are currently missing a consistent tag that's available to represent a floating "current development-or-stable version". This adds that `next` label to the labels we want to use before publishing.

Incidentally, it doesn't look like we automate doing the "latest" tag either - I guess we've been doing it manually?

~~Note: I'm aware how bizarre this looks, but as far as I can tell this five-year-old comment is still accurate and there's no official way to append to an array short of serializing to JSON and modifying it using `jq`. https://github.com/orgs/community/discussions/7875#discussioncomment-1773980~~

Fixes #1110.