### PR TITLE
Fix page and page-spa scope with hashtag seeds

### DIFF
--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -199,10 +199,13 @@ export class ScopedSeed {
         break;
 
       case "page-spa":
-        // allow scheme-agnostic URLS as likely redirects
+        parsedUrl.hash = "";
         include = [
-          new RegExp("^" + urlRxEscape(normalizeUrl(parsedUrl.href)) + "#.+"),
+          new RegExp(
+            "^" + urlRxEscape(normalizeUrl(parsedUrl.href)) + "($|#.*)",
+          ),
         ];
+        console.log(include);
         allowHash = true;
         break;
 

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -200,6 +200,7 @@ export class ScopedSeed {
         break;
 
       case "page-spa":
+        // modifying here to remove # (to be refactored into internal function later)
         parsedUrl.hash = "";
         include = [
           new RegExp(

--- a/src/util/seeds.ts
+++ b/src/util/seeds.ts
@@ -196,6 +196,7 @@ export class ScopedSeed {
         include = [
           new RegExp("^" + urlRxEscape(normalizeUrl(parsedUrl.href)) + "$"),
         ];
+        allowHash = true;
         break;
 
       case "page-spa":
@@ -205,7 +206,6 @@ export class ScopedSeed {
             "^" + urlRxEscape(normalizeUrl(parsedUrl.href)) + "($|#.*)",
           ),
         ];
-        console.log(include);
         allowHash = true;
         break;
 

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -645,6 +645,14 @@ seeds:
       depth: 0,
     }),
   ).toBe(false);
+
+  // no hashtag, not included, must be exact
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/",
+      depth: 0,
+    }),
+  ).toBe(false);
 });
 
 test("www hashtag seed + page scope", async () => {
@@ -716,6 +724,14 @@ seeds:
       depth: 0,
     }),
   ).toBe(false);
+
+  // no hashtag, not included, must be exact
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/",
+      depth: 0,
+    }),
+  ).toBe(false);
 });
 
 test("hashtag seed + single-page spa", async () => {
@@ -778,6 +794,14 @@ seeds:
       depth: 0,
     }),
   ).not.toBe(false);
+
+  // no hashtag, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/",
+      depth: 0,
+    }),
+  ).not.toBe(false);
 });
 
 test("www hashtag seed + single-page spa", async () => {
@@ -837,6 +861,14 @@ seeds:
   expect(
     seeds[0].isIncluded({
       url: "https://www.example.com/#",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // no hashtag, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/",
       depth: 0,
     }),
   ).not.toBe(false);

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -644,7 +644,7 @@ seeds:
       url: "https://www.example.com/#",
       depth: 0,
     }),
-  ).not.toBe(false);
+  ).toBe(false);
 });
 
 test("www hashtag seed + page scope", async () => {

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -585,6 +585,11 @@ seeds:
 
 `);
 
+  // include, hashtag included for exact match
+  expect(seeds[0].include).toEqual([
+    /^https?:\/\/(www[\d]*\.)?example\.com\/#abc$/,
+  ]);
+
   // exact URL, included
   expect(
     seeds[0].isIncluded({
@@ -632,6 +637,14 @@ seeds:
       depth: 0,
     }),
   ).toBe(false);
+
+  // empty hashtag, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#",
+      depth: 0,
+    }),
+  ).not.toBe(false);
 });
 
 test("www hashtag seed + page scope", async () => {
@@ -642,6 +655,11 @@ seeds:
      depth: 0
 
 `);
+
+  // include, hashtag included for exact match
+  expect(seeds[0].include).toEqual([
+    /^https?:\/\/(www[\d]*\.)?example\.com\/#abc$/,
+  ]);
 
   // exact URL, included
   expect(
@@ -690,6 +708,14 @@ seeds:
       depth: 0,
     }),
   ).toBe(false);
+
+  // empty hashtag, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#",
+      depth: 0,
+    }),
+  ).toBe(false);
 });
 
 test("hashtag seed + single-page spa", async () => {
@@ -699,6 +725,11 @@ seeds:
      scopeType: page-spa
      depth: 0
 `);
+
+  // include, hashtag omitted to match any
+  expect(seeds[0].include).toEqual([
+    /^https?:\/\/(www[\d]*\.)?example\.com\/($|#.*)/,
+  ]);
 
   // exact URL, included
   expect(
@@ -739,6 +770,14 @@ seeds:
       depth: 0,
     }),
   ).toBe(false);
+
+  // empty hashtag, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#",
+      depth: 0,
+    }),
+  ).not.toBe(false);
 });
 
 test("www hashtag seed + single-page spa", async () => {
@@ -748,6 +787,11 @@ seeds:
      scopeType: page-spa
      depth: 1
 `);
+
+  // include, hashtag omitted to match any
+  expect(seeds[0].include).toEqual([
+    /^https?:\/\/(www[\d]*\.)?example\.com\/($|#.*)/,
+  ]);
 
   // exact URL, included
   expect(
@@ -788,4 +832,12 @@ seeds:
       depth: 1,
     }),
   ).toBe(false);
+
+  // empty hashtag, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#",
+      depth: 0,
+    }),
+  ).not.toBe(false);
 });

--- a/tests/scopes.test.ts
+++ b/tests/scopes.test.ts
@@ -334,7 +334,7 @@ exclude:
   expect(seeds[0].scopeType).toEqual("page-spa");
   expect(seeds[0].url).toEqual("https://example.com/1");
   expect(seeds[0].include).toEqual([
-    /^https?:\/\/(www[\d]*\.)?example\.com\/1#.+/,
+    /^https?:\/\/(www[\d]*\.)?example\.com\/1($|#.*)/,
   ]);
   expect(seeds[0].exclude).toEqual(excludeRxs);
 
@@ -574,4 +574,218 @@ scopeType: prefix
   expect((result3 as Exclude<typeof result1, false>).url).toBe(
     "https://example.com/abc",
   );
+});
+
+test("hashtag seed + page scope", async () => {
+  const seeds = await getSeeds(`
+seeds:
+   - url: https://example.com/#abc
+     scopeType: page
+     depth: 0
+
+`);
+
+  // exact URL, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#abc",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // different www. / scheme, included
+  expect(
+    seeds[0].isIncluded({
+      url: "http://example.com/#abc",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // different hashtag, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#xyz",
+      depth: 0,
+    }),
+  ).toBe(false);
+
+  // different hashtag, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://example.com/#xyz",
+      depth: 0,
+    }),
+  ).toBe(false);
+
+  // depth > 0, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#xyz",
+      depth: 1,
+    }),
+  ).toBe(false);
+
+  // different page, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/xyz",
+      depth: 0,
+    }),
+  ).toBe(false);
+});
+
+test("www hashtag seed + page scope", async () => {
+  const seeds = await getSeeds(`
+seeds:
+   - url: https://www.example.com/#abc
+     scopeType: page
+     depth: 0
+
+`);
+
+  // exact URL, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#abc",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // different www. / scheme, included
+  expect(
+    seeds[0].isIncluded({
+      url: "http://example.com/#abc",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // different hashtag, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#xyz",
+      depth: 0,
+    }),
+  ).toBe(false);
+
+  // different hashtag, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://example.com/#xyz",
+      depth: 0,
+    }),
+  ).toBe(false);
+
+  // depth > 0,not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#xyz",
+      depth: 1,
+    }),
+  ).toBe(false);
+
+  // different page, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/xyz",
+      depth: 0,
+    }),
+  ).toBe(false);
+});
+
+test("hashtag seed + single-page spa", async () => {
+  const seeds = await getSeeds(`
+seeds:
+   - url: https://example.com/#abc
+     scopeType: page-spa
+     depth: 0
+`);
+
+  // exact URL, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#abc",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // different www. / scheme, included
+  expect(
+    seeds[0].isIncluded({
+      url: "http://example.com/#abc",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // different hashtag, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#xyz",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // depth > 0, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#xyz",
+      depth: 1,
+    }),
+  ).toBe(false);
+
+  // different page, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/abc",
+      depth: 0,
+    }),
+  ).toBe(false);
+});
+
+test("www hashtag seed + single-page spa", async () => {
+  const seeds = await getSeeds(`
+seeds:
+   - url: https://www.example.com/#abc
+     scopeType: page-spa
+     depth: 1
+`);
+
+  // exact URL, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#abc",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // different www. / scheme, included
+  expect(
+    seeds[0].isIncluded({
+      url: "http://example.com/#abc",
+      depth: 0,
+    }),
+  ).not.toBe(false);
+
+  // different hashtag, included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#xyz",
+      depth: 1,
+    }),
+  ).not.toBe(false);
+
+  // depth > 1, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/#xyz",
+      depth: 2,
+    }),
+  ).toBe(false);
+
+  // different page, not included
+  expect(
+    seeds[0].isIncluded({
+      url: "https://www.example.com/abc",
+      depth: 1,
+    }),
+  ).toBe(false);
 });


### PR DESCRIPTION
Fixes #1129 

- 'page' scope: keep hashtag on include/norm URL to allow exact matching *with exact* hashtag, set allowHash to not drop hashtag
- 'page-spa' scope: remove hashtag from include/norm URL to allow matching by with *any hashtag*, set allowHash to check hashtag
- tests: add tests to check hashtag URLs with page and page-spa scopes, with and without www.