### PR TITLE
qa: fix QA of small WACZ files:

### DIFF
--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -225,7 +225,11 @@ export class ReplayCrawler extends Crawler {
         }
       }
     } catch (e) {
-      logger.warn("No extraPages.jsonl found, ignoring", {}, "replay");
+      logger.warn(
+        "No extraPages.jsonl found or error reading extraPages, ignoring",
+        e,
+        "replay",
+      );
     }
   }
 

--- a/src/replaycrawler.ts
+++ b/src/replaycrawler.ts
@@ -213,15 +213,19 @@ export class ReplayCrawler extends Crawler {
       }
     }
 
-    const extraPagesReader = await loader.loadFile("pages/extraPages.jsonl");
+    try {
+      const extraPagesReader = await loader.loadFile("pages/extraPages.jsonl");
 
-    if (extraPagesReader) {
-      for await (const buff of extraPagesReader.iterLines()) {
-        await this.addPage(buff, count++);
-        if (this.limitHit) {
-          break;
+      if (extraPagesReader) {
+        for await (const buff of extraPagesReader.iterLines()) {
+          await this.addPage(buff, count++);
+          if (this.limitHit) {
+            break;
+          }
         }
       }
+    } catch (e) {
+      logger.warn("No extraPages.jsonl found, ignoring", {}, "replay");
     }
   }
 

--- a/src/util/replayserver.ts
+++ b/src/util/replayserver.ts
@@ -139,7 +139,7 @@ export class ReplayServer {
       opts.end = parseInt(array[2]);
       // negative value, subtract from end
       if (isNaN(opts.start) && !isNaN(opts.end)) {
-        opts.start = total - opts.end;
+        opts.start = Math.max(0, total - opts.end);
         opts.end = total - 1;
       } else if (isNaN(opts.end)) {
         opts.end = total - 1;


### PR DESCRIPTION
- avoid negative index, clamp to 0
- also ignore extraPages.jsonl if it does not exist and only use pages.jsonl
- fixes #1127