### PR TITLE
Fix rate limit exit code documentation

### DIFF
--- a/docs/docs/user-guide/exit-codes.md
+++ b/docs/docs/user-guide/exit-codes.md
@@ -7,6 +7,7 @@ The crawler uses following exit codes to indicate crawl result.
 | 0 | Success | Crawl completed normally |
 | 1 | GenericError | Unspecified error, check logs for more details |
 | 3 | OutOfSpace | Disk is already full |
+| 8 | RedisUnavailable | Could not connect to the Redis instance for managing queues or deduplication |
 | 9 | Failed | Crawl failed unexpectedly, might be worth retrying |
 | 10 | BrowserCrashed | Browser used to fetch pages has crashed |
 | 11 | SignalInterrupted | Crawl stopped gracefully in response to SIGINT signal |
@@ -18,3 +19,4 @@ The crawler uses following exit codes to indicate crawl result.
 | 17 | Fatal | A fatal (non-retryable) error occured |
 | 18 | RateLimited | Maximum number of rate-limited responses, configured with `--rateLimitInterruptCount`, have been received |
 | 21 | ProxyError | Unable to establish connection with proxy |
+| 22 | UploadFailed | Could not write a WACZ file, if configured with `--generateWACZ`, to disk or remote storage |

--- a/docs/docs/user-guide/exit-codes.md
+++ b/docs/docs/user-guide/exit-codes.md
@@ -16,4 +16,5 @@ The crawler uses following exit codes to indicate crawl result.
 | 15 | TimeLimit | Limit on maximum crawl duration, configured with `--timeLimit`, has been reached |
 | 16 | DiskUtilization | Limit on maximum disk usage, configured with `--diskUtilization`, has been reached |
 | 17 | Fatal | A fatal (non-retryable) error occured |
+| 18 | RateLimited | Maximum number of rate-limited responses, configured with `--rateLimitInterruptCount`, have been received |
 | 21 | ProxyError | Unable to establish connection with proxy |

--- a/docs/docs/user-guide/rate-limits.md
+++ b/docs/docs/user-guide/rate-limits.md
@@ -36,7 +36,7 @@ by setting `--rateLimitMaxRetries` to a value >= 0, where 0 implies no retries a
 
 By default, the crawler will continue, skipping rate limited pages and retrying them indefinitely, to match existing behavior.
 
-If the `--rateLimitInterruptCount M` flag is set, the crawler will exit with a rate limit exit code (exit code 21) after M rate limited pages within the N seconds, configured via `--rateLimitTimeout`.
+If the `--rateLimitInterruptCount M` flag is set, the crawler will exit with a rate limit exit code (exit code 18) after M rate limited pages within the N seconds, configured via `--rateLimitTimeout`.
 
 This can allow a job runner or other system that starts and monitors the crawler container to implement an exponential backoff system if the crawler repeatedly exits due to being rate limited.
 The Browsertrix application provides this through built-in exponential backoff available in Kubernetes, where the system


### PR DESCRIPTION
The actual exit code for rate limiting is 18, but it was documented as 21 (actually a proxy error) on the rate limiting guide and not listed at all in the exit codes reference.