### PR TITLE
argParser: mark CSS selector parse failure unrecoverable

### DIFF
--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -15,6 +15,7 @@ import {
   SERVICE_WORKER_OPTS,
   DEFAULT_SELECTORS,
   BEHAVIOR_TYPES,
+  ExitCodes,
   ExtractSelector,
   DEFAULT_MAX_RETRIES,
   BxFunctionBindings,
@@ -877,6 +878,11 @@ class ArgParser {
         try {
           parser(argv.clickSelector);
         } catch (e) {
+          // Try to avoid triggering a restart since this is unrecoverable
+          // without changing the config.
+          if (argv.restartsOnError) {
+            logger.setOverrideFatalExitCode(ExitCodes.InvalidConfig);
+          }
           void logger.fatal("Invalid Autoclick CSS Selector", {
             selector: argv.clickSelector,
           });

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -95,6 +95,7 @@ export enum ExitCodes {
   RateLimited = 18,
   ProxyError = 21,
   UploadFailed = 22,
+  InvalidConfig = 30,
 }
 
 export enum InterruptReason {


### PR DESCRIPTION
Since these are provided in the config/CLI arguments, these selectors won't change between runs. If that happens, and we have the crawler set to restart on error, we could end up in a crashloop where we keep trying to run this crawl over and over again.