### PR TITLE
optimiziation: don't track any requests if skipping recording

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -1491,7 +1491,7 @@ export class Recorder extends EventEmitter {
 
   pendingReqResp(requestId: string, reuseOnly = false) {
     // don't record additional resources
-    if (this.finishingPage) {
+    if (this.finishingPage || this.skipRecordingPage) {
       return null;
     }
 


### PR DESCRIPTION
When not recording (eg. due to rate limit), skip request interception (by skipping creating an intercepted request/response entry). This ensures the page loads as quickly as possible before moving on to next page, in case of rate limit.

Testing:
- Try a rate limited site (eg. medium.com), observe the page moving to next page quickly. Without this change, page may get stuck waiting on Cloudflare spinner on the turnstile.