### PR TITLE
crawler: add addLinkBatch function

### DIFF
--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -847,6 +847,27 @@ export class Crawler {
       });
     };
 
+    const addLinkBatch = async (
+      urls: Set<string>,
+      alwaysObeyScope: boolean = false,
+    ) => {
+      const { seedId, depth, extraHops = 0, logDetails } = opts.data;
+
+      // if not always obeying scope and allowed to ignore scope, set to true
+      const ignoreScope =
+        !alwaysObeyScope && this.params.alwaysAddBehaviorLinks;
+
+      await this.queueInScopeUrls({
+        seedId,
+        urls: Array.from(urls),
+        depth,
+        extraHops,
+        pageUrl: page.url(),
+        logDetails,
+        ignoreScope,
+      });
+    };
+
     await this.browser.setupPage({ page, cdp });
 
     await this.setupExecContextEvents(cdp, frameIdToExecId);
@@ -897,6 +918,10 @@ export class Crawler {
     }
 
     await page.exposeFunction(BxFunctionBindings.AddLinkFunc, addLink);
+    await page.exposeFunction(
+      BxFunctionBindings.AddLinkBatchFunc,
+      addLinkBatch,
+    );
 
     // used for both behaviors and link extraction now
     await this.browser.addInitScript(page, btrixBehaviors);

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -848,10 +848,12 @@ export class Crawler {
     };
 
     const addLinkBatch = async (
-      urls: Set<string>,
+      urls: string,
       alwaysObeyScope: boolean = false,
     ) => {
       const { seedId, depth, extraHops = 0, logDetails } = opts.data;
+
+      const urlsSplit = urls.split("\n\n");
 
       // if not always obeying scope and allowed to ignore scope, set to true
       const ignoreScope =
@@ -859,7 +861,7 @@ export class Crawler {
 
       await this.queueInScopeUrls({
         seedId,
-        urls: Array.from(urls),
+        urls: urlsSplit,
         depth,
         extraHops,
         pageUrl: page.url(),

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -31,6 +31,7 @@ export const DUPE_CANCELED_CRAWLS = "canceledcrawls";
 export enum BxFunctionBindings {
   BehaviorLogFunc = "__bx_log",
   AddLinkFunc = "__bx_addLink",
+  AddLinkBatchFunc = "__bx_addLinkBatch",
   FetchFunc = "__bx_fetch",
   AddToSeenSet = "__bx_addSet",
 


### PR DESCRIPTION
This works like addLink but takes a double newline-joined string containing an arbitrary number of URLs instead of a single URL, queueing them in a single action.

Fixes #1141 .