### PR TITLE
more clearly mark config / invalid arg errors with distinct exit code,

### DIFF
--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -113,7 +113,7 @@ Options:
   ", "originOverride", "healthcheck", "browser", "blocking", "behavior", "behavi
   orScript", "behaviorScriptCustom", "jsError", "fetch", "pageStatus", "memorySt
    atus", "crawlStatus", "links", "sitemap", "wacz", "replay", "proxy", "scope",
-                                               "robots", "dedupe"] [default: []]
+                                     "robots", "dedupe", "config"] [default: []]
       --logExcludeContext                   Comma-separated list of contexts to
                                             NOT include in logs
   [array] [choices: "general", "worker", "recorder", "recorderNetwork", "writer"
@@ -121,7 +121,8 @@ Options:
   ", "originOverride", "healthcheck", "browser", "blocking", "behavior", "behavi
   orScript", "behaviorScriptCustom", "jsError", "fetch", "pageStatus", "memorySt
    atus", "crawlStatus", "links", "sitemap", "wacz", "replay", "proxy", "scope",
-       "robots", "dedupe"] [default: ["recorderNetwork","jsError","screencast"]]
+  "robots", "dedupe", "config"] [default: ["recorderNetwork","jsError","screenca
+                                                                           st"]]
       --text                                Extract initial (default) or final t
                                             ext to pages.jsonl or WARC resource
                                             record(s)
@@ -411,6 +412,9 @@ Options:
                                                       [boolean] [default: false]
   --shutdownWait            Shutdown browser in interactive after this many seco
                             nds, if no pings received      [number] [default: 0]
+  --postLoadDelay           If >0, amount of time to sleep (in seconds) after pa
+                            ge has loaded (only in automated mode)
+                                                           [number] [default: 0]
   --profile                 Path or HTTP(S) URL to tar.gz file which contains th
                             e browser profile directory   [string] [default: ""]
   --windowSize              Browser window dimensions, specified as: width,heigh

--- a/docs/docs/user-guide/exit-codes.md
+++ b/docs/docs/user-guide/exit-codes.md
@@ -7,6 +7,7 @@ The crawler uses following exit codes to indicate crawl result.
 | 0 | Success | Crawl completed normally |
 | 1 | GenericError | Unspecified error, check logs for more details |
 | 3 | OutOfSpace | Disk is already full |
+| 4 | InvalidConfig | A CLI argument or YAML config options is invalid, fatal (non-retryable) |
 | 8 | RedisUnavailable | Could not connect to the Redis instance for managing queues or deduplication |
 | 9 | Failed | Crawl failed unexpectedly, might be worth retrying |
 | 10 | BrowserCrashed | Browser used to fetch pages has crashed |

--- a/docs/docs/user-guide/exit-codes.md
+++ b/docs/docs/user-guide/exit-codes.md
@@ -7,7 +7,7 @@ The crawler uses following exit codes to indicate crawl result.
 | 0 | Success | Crawl completed normally |
 | 1 | GenericError | Unspecified error, check logs for more details |
 | 3 | OutOfSpace | Disk is already full |
-| 4 | InvalidConfig | A CLI argument or YAML config options is invalid, fatal (non-retryable) |
+| 4 | InvalidConfig | A CLI argument or YAML config option is invalid, fatal (non-retryable) |
 | 8 | RedisUnavailable | Could not connect to the Redis instance for managing queues or deduplication |
 | 9 | Failed | Crawl failed unexpectedly, might be worth retrying |
 | 10 | BrowserCrashed | Browser used to fetch pages has crashed |

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -374,6 +374,9 @@ export class Crawler {
     if (!redisUrl.startsWith("redis://")) {
       await logger.fatal(
         "stateStoreUrl must start with redis:// -- Only redis-based store currently supported",
+        {},
+        "config",
+        ExitCodes.InvalidConfig,
       );
     }
 

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -23,6 +23,7 @@ import {
   RATE_LIMIT_TTL_SECS,
   RateLimitRule,
   DEFAULT_MAX_RATE_LIMIT_RETRIES,
+  ExitCodes,
 } from "./constants.js";
 import { interpolateFilename } from "./storage.js";
 import { screenshotTypes } from "./screenshots.js";
@@ -867,6 +868,9 @@ class ArgParser {
     if (argv.collection.search(/^[\w][\w-]*$/) === -1) {
       void logger.fatal(
         `\n${argv.collection} is an invalid collection name. Please supply a collection name only using alphanumeric characters and the following characters [_ - ]\n`,
+        {},
+        "config",
+        ExitCodes.InvalidConfig,
       );
     }
 
@@ -877,9 +881,14 @@ class ArgParser {
         try {
           parser(argv.clickSelector);
         } catch (e) {
-          void logger.fatal("Invalid Autoclick CSS Selector", {
-            selector: argv.clickSelector,
-          });
+          void logger.fatal(
+            "Invalid Autoclick CSS Selector",
+            {
+              selector: argv.clickSelector,
+            },
+            "config",
+            ExitCodes.InvalidConfig,
+          );
         }
       }
 
@@ -910,7 +919,12 @@ class ArgParser {
         argv.mobileDevice.replace("-", " ")
       ];
       if (!argv.emulateDevice) {
-        void logger.fatal("Unknown device: " + argv.mobileDevice);
+        void logger.fatal(
+          "Unknown device: " + argv.mobileDevice,
+          {},
+          "config",
+          ExitCodes.InvalidConfig,
+        );
       }
     } else {
       argv.emulateDevice = { viewport: null };
@@ -922,6 +936,9 @@ class ArgParser {
       if (!ISO6391.validate(argv.lang)) {
         void logger.fatal(
           "Invalid ISO-639-1 country code for --lang: " + argv.lang,
+          {},
+          "config",
+          ExitCodes.InvalidConfig,
         );
       }
     }
@@ -938,9 +955,14 @@ class ArgParser {
         try {
           parser(selector);
         } catch (e) {
-          void logger.fatal("Invalid Link Extraction CSS Selector", {
-            selector,
-          });
+          void logger.fatal(
+            "Invalid Link Extraction CSS Selector",
+            {
+              selector,
+            },
+            "config",
+            ExitCodes.InvalidConfig,
+          );
         }
         return { selector, extract, isAttribute };
       });
@@ -951,7 +973,12 @@ class ArgParser {
     argv.selectLinks = selectLinks;
 
     if (isQA && !argv.qaSource) {
-      void logger.fatal("--qaSource required for QA mode");
+      void logger.fatal(
+        "--qaSource required for QA mode",
+        {},
+        "config",
+        ExitCodes.InvalidConfig,
+      );
     }
 
     // Resolve statsFilename

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -82,6 +82,7 @@ export enum ExitCodes {
   Success = 0,
   GenericError = 1,
   OutOfSpace = 3,
+  InvalidConfig = 4,
   RedisUnavailable = 8,
   Failed = 9,
   BrowserCrashed = 10,

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -61,6 +61,7 @@ export const LOG_CONTEXT_TYPES = [
   "scope",
   "robots",
   "dedupe",
+  "config",
 ] as const;
 
 export type LogContext = (typeof LOG_CONTEXT_TYPES)[number];

--- a/tests/custom_selector.test.ts
+++ b/tests/custom_selector.test.ts
@@ -60,8 +60,8 @@ test("test invalid selector, crawl fails", async () => {
     status = (e as ErrorWithStatus).status;
   }
 
-  // logger fatal exit code
-  expect(status).toBe(17);
+  // logger invalid config exit code
+  expect(status).toBe(4);
 });
 
 test("test valid autoclick selector passes validation", async () => {
@@ -90,6 +90,6 @@ test("test invalid autoclick selector fails validation, crawl fails", async () =
     status = (e as ErrorWithStatus).status;
   }
 
-  // logger fatal exit code
-  expect(status).toBe(17);
+  // logger invalid config exit code
+  expect(status).toBe(4);
 });

--- a/tests/invalid-config.test.ts
+++ b/tests/invalid-config.test.ts
@@ -1,0 +1,38 @@
+import { execSync } from "node:child_process";
+
+const INVALID_CONFIG = 4;
+
+function runGetError(cmd: string) {
+  let error = 0;
+  try {
+    execSync(cmd);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    error = e.status || 999;
+  }
+  return error;
+}
+
+test("invalid css selector ", async () => {
+  expect(
+    runGetError(
+      "docker run --rm webrecorder/browsertrix-crawler crawl --url https://example.com/ --selectLinks 'div[2]->body'",
+    ),
+  ).toBe(INVALID_CONFIG);
+});
+
+test("click selector + restartsOnError not applicable here ", async () => {
+  expect(
+    runGetError(
+      "docker run --rm webrecorder/browsertrix-crawler crawl --url https://example.com/ --clickSelector 'div[3]' --restartsOnError",
+    ),
+  ).toBe(INVALID_CONFIG);
+});
+
+test("invalid redis URL ", async () => {
+  expect(
+    runGetError(
+      "docker run --rm webrecorder/browsertrix-crawler crawl --url https://example.com/ --redisStoreUrl https://redis",
+    ),
+  ).toBe(INVALID_CONFIG);
+});

--- a/tests/invalid-config.test.ts
+++ b/tests/invalid-config.test.ts
@@ -1,30 +1,32 @@
 import { execSync } from "node:child_process";
+import { ErrorWithStatus } from "./utils";
 
 const INVALID_CONFIG = 4;
+
+// Note other invalid config options are tested in lang-code.test.ts and custom_selector.test.ts
 
 function runGetError(cmd: string) {
   let error = 0;
   try {
     execSync(cmd);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (e: any) {
-    error = e.status || 999;
+  } catch (e) {
+    error = (e as ErrorWithStatus).status;
   }
   return error;
 }
 
-test("invalid css selector ", async () => {
+test("invalid collection name ", async () => {
   expect(
     runGetError(
-      "docker run --rm webrecorder/browsertrix-crawler crawl --url https://example.com/ --selectLinks 'div[2]->body'",
+      "docker run --rm webrecorder/browsertrix-crawler crawl --url https://example.com/ --collection %foo#",
     ),
   ).toBe(INVALID_CONFIG);
 });
 
-test("click selector + restartsOnError not applicable here ", async () => {
+test("invalid device + restartsOnError not applicable here ", async () => {
   expect(
     runGetError(
-      "docker run --rm webrecorder/browsertrix-crawler crawl --url https://example.com/ --clickSelector 'div[3]' --restartsOnError",
+      "docker run --rm webrecorder/browsertrix-crawler crawl --url https://example.com/ --mobileDevice blah --restartsOnError",
     ),
   ).toBe(INVALID_CONFIG);
 });

--- a/tests/lang-code.test.ts
+++ b/tests/lang-code.test.ts
@@ -10,7 +10,7 @@ test("run crawl with invalid lang", () => {
   } catch (e) {
     status = (e as ErrorWithStatus).status;
   }
-  expect(status).toBe(17);
+  expect(status).toBe(4);
 });
 
 test("run crawl with valid lang", () => {


### PR DESCRIPTION
to be used before Redis state is inited to ensure crawler can exit with distinct exit code that indicates invalid config, to complement webrecorder/browsertrix#3552
- add ExitCodes.InvalidConfig exit code (4) and 'config' log type
- to be tested for in app via webrecorder/browsertrix#3552