### PR TITLE
argParser: disable startEarly to behaviours

### DIFF
--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -904,7 +904,7 @@ class ArgParser {
         }
       });
       behaviorOpts.log = BxFunctionBindings.BehaviorLogFunc;
-      behaviorOpts.startEarly = true;
+      behaviorOpts.startEarly = false;
       behaviorOpts.clickSelector = argv.clickSelector;
       argv.behaviorOpts = JSON.stringify(behaviorOpts);
     } else {


### PR DESCRIPTION
Passing `startEarly` causes us to initialize autofetch's `MutationObserver` immediately on the behaviour class being constructed instead of at the time we call `start()`. This has performance implications and ends up causing us to wait around an extra few seconds at the start of page load, causing many more complex pages to take longer to load than they properly need to.

We originally added this in c247189474e2786ad381a67e49447b03f2f35f0f in response to certain sites where we weren't waiting long enough for them to initialize, in particular Instagram. Now that we have `awaitPageLoad` for behaviours, we don't always have to do this for every page; we can do targeted behaviours to specific sites to wait on exactly the things we need them to, but avoid doing this on other sites where it's not gaining us anything.

This should be paired with https://github.com/webrecorder/browsertrix-behaviors/pull/160 to make sure fetching YouTube videos still works.