### PR TITLE
save the detected content-type:

### DIFF
--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -584,8 +584,11 @@ export class Recorder extends EventEmitter {
       return;
     }
 
-    if (this.shouldSaveStorage && url === this.finalPageUrl) {
-      await this.saveStorage(reqresp, cdp);
+    if (url === this.finalPageUrl) {
+      if (this.shouldSaveStorage) {
+        await this.saveStorage(reqresp, cdp);
+      }
+      await this.saveDetectedContentType(reqresp, cdp);
     }
 
     try {
@@ -596,6 +599,25 @@ export class Recorder extends EventEmitter {
         { url, ...formatErr(e) },
         "recorder",
       );
+    }
+  }
+
+  async saveDetectedContentType(reqresp: RequestResponseInfo, cdp: CDPSession) {
+    try {
+      const { result } = await cdp.send("Runtime.evaluate", {
+        expression:
+          '`${document.contentType}; charset="${document.characterSet}"`',
+        returnByValue: true,
+      });
+
+      const contentType = result.value;
+
+      // only save charset if its not the default UTF-8
+      if (contentType && contentType !== 'text/html; charset="UTF-8"') {
+        reqresp.detectedCT = contentType;
+      }
+    } catch (e) {
+      logger.warn("Error getting detected content-type", e, "recorder");
     }
   }
 
@@ -1970,6 +1992,13 @@ export class Recorder extends EventEmitter {
       modified = true;
     }
 
+    if (reqresp.detectedCT) {
+      responseRecord.warcHeaders.headers.set(
+        "WARC-Identified-Payload-Type",
+        reqresp.detectedCT,
+      );
+    }
+
     if (modified) {
       serializer.warcHeadersBuff = encoder.encode(
         responseRecord.warcHeaders.toString(),
@@ -2356,6 +2385,10 @@ function createResponse(
 
   if (Object.keys(reqresp.extraOpts).length) {
     warcHeaders["WARC-JSON-Metadata"] = JSON.stringify(reqresp.extraOpts);
+  }
+
+  if (reqresp.detectedCT) {
+    warcHeaders["WARC-Identified-Payload-Type"] = reqresp.detectedCT;
   }
 
   if (!contentIter) {

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -606,14 +606,14 @@ export class Recorder extends EventEmitter {
     try {
       const { result } = await cdp.send("Runtime.evaluate", {
         expression:
-          '`${document.contentType}; charset="${document.characterSet}"`',
+          "`${document.contentType}; charset=${document.characterSet}`",
         returnByValue: true,
       });
 
       const contentType = result.value;
 
       // only save charset if its not the default UTF-8
-      if (contentType && contentType !== 'text/html; charset="UTF-8"') {
+      if (contentType && contentType !== "text/html; charset=UTF-8") {
         reqresp.detectedCT = contentType;
       }
     } catch (e) {

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -34,6 +34,7 @@ export class RequestResponseInfo {
   protocols: string[] = [];
 
   mimeType?: string;
+  detectedCT?: string;
 
   // request data
   requestHeaders?: Record<string, string>;

--- a/tests/non-html-crawl.test.ts
+++ b/tests/non-html-crawl.test.ts
@@ -1,7 +1,7 @@
 import child_process from "child_process";
 import fs from "fs";
 import path from "path";
-import { WARCParser } from "warcio";
+import { WARCParser, WARCRecord } from "warcio";
 
 const PDF = "https://specs.webrecorder.net/wacz/1.1.1/wacz-2021.pdf";
 const PDF_HTTP = PDF.replace("https", "http");
@@ -169,4 +169,36 @@ test("XML: check that CDX contains one xml 200, one 301 and one 200, two pageinf
 
   expect(cdxj[5].url).toBe("urn:pageinfo:" + XML_REDIR);
   expect(cdxj[5].mime).toBe("application/json");
+});
+
+// the revisit record is after a redirect in browser, so is loaded in browser, and will have the
+// WARC-Identified-Payload-Type, while the original was loaded directly
+test("XML: check that revisit record has WARC-Identified-Payload-Type", async () => {
+  const archiveWarcLists = fs.readdirSync(
+    "test-crawls/collections/crawl-xml/archive",
+  );
+
+  const warcName = path.join(
+    "test-crawls/collections/crawl-xml/archive",
+    archiveWarcLists[0],
+  );
+
+  const nodeStream = fs.createReadStream(warcName);
+
+  const parser = new WARCParser(nodeStream);
+
+  let matchedRecord: WARCRecord | null = null;
+
+  for await (const record of parser) {
+    if (record.warcType === "revisit") {
+      matchedRecord = record;
+      break;
+    }
+  }
+
+  expect(matchedRecord).not.toBeNull();
+  expect(matchedRecord!.warcTargetURI).toBe(XML);
+  expect(matchedRecord!.warcHeader("WARC-Identified-Payload-Type")).toBe(
+    "application/rss+xml; charset=UTF-8",
+  );
 });


### PR DESCRIPTION
- set WARC-Identified-Payload-Type to `${document.contentType}; charset="${document.characterSet}"` from the page
- fixes capture part of webrecorder/replayweb.page#541
- depends on webrecorder/wabac.js#366