### PR TITLE
Add WARC-IP-Address to captured network records

### DIFF
--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -10,6 +10,7 @@ import { logger } from "./logger.js";
 import { socksDispatcher } from "fetch-socks";
 import type { SocksProxyType } from "socks/typings/common/constants.js";
 import { ExitCodes, FETCH_HEADERS_TIMEOUT_SECS } from "./constants.js";
+import { trackRemoteIPAddress } from "./undici-ip.js";
 
 import http, { IncomingMessage, ServerResponse } from "http";
 
@@ -305,6 +306,7 @@ export function getProxyDispatcher(
   url: string,
   withRedirect = true,
   withDecompression = true,
+  onRemoteAddress?: (remoteAddress?: string) => void,
 ) {
   let proxyEntry: ProxyEntry | null = null;
 
@@ -315,8 +317,29 @@ export function getProxyDispatcher(
     }
   }
 
-  const { dispatcher, redirectDispatcher, decompressRedirectDispatcher } =
-    proxyEntry || defaultProxyEntry || globalDispatchers;
+  const selectedEntry = proxyEntry || defaultProxyEntry || globalDispatchers;
+  const {
+    dispatcher,
+    redirectDispatcher,
+    decompressRedirectDispatcher,
+    proxyUrl,
+  } = selectedEntry;
+
+  // A proxied socket's peer is generally the proxy, not the target host.
+  // Omit WARC-IP-Address rather than recording a misleading target address.
+  if (onRemoteAddress && !proxyUrl) {
+    let trackedDispatcher: Dispatcher = trackRemoteIPAddress(
+      dispatcher,
+      onRemoteAddress,
+    );
+    if (withRedirect) {
+      trackedDispatcher = addRedirectInterceptor(trackedDispatcher);
+    }
+    if (withDecompression) {
+      trackedDispatcher = addDecompressInterceptor(trackedDispatcher);
+    }
+    return trackedDispatcher;
+  }
 
   // if default proxy set, return dispatcher from default proxy, otherwise a default dispatcher
   if (withDecompression && withRedirect) {

--- a/src/util/recorder.ts
+++ b/src/util/recorder.ts
@@ -2179,7 +2179,12 @@ class AsyncFetcher {
 
     const headers = reqresp.getRequestHeadersDict();
 
-    let dispatcher = getProxyDispatcher(url, !this.manualRedirect, false);
+    let dispatcher = getProxyDispatcher(
+      url,
+      !this.manualRedirect,
+      false,
+      (remoteAddress) => reqresp.setRemoteIPAddress(remoteAddress),
+    );
 
     dispatcher = dispatcher.compose((dispatch) => {
       return (opts, handler) => {
@@ -2372,6 +2377,10 @@ function createResponse(
     "WARC-Page-ID": pageid,
   };
 
+  if (reqresp.remoteIPAddress) {
+    warcHeaders["WARC-IP-Address"] = reqresp.remoteIPAddress;
+  }
+
   if (reqresp.protocols.length) {
     warcHeaders["WARC-Protocol"] = multiValueHeader(
       "WARC-Protocol",
@@ -2412,6 +2421,7 @@ function createResponse(
 // =================================================================
 const REVISIT_COPY_HEADERS = [
   "WARC-Page-ID",
+  "WARC-IP-Address",
   "WARC-Protocol",
   "WARC-Resource-Type",
   "WARC-JSON-Metadata",
@@ -2491,6 +2501,10 @@ function createRequest(
     "WARC-Concurrent-To": responseRecord.warcHeader("WARC-Record-ID")!,
     "WARC-Page-ID": pageid,
   };
+
+  if (reqresp.remoteIPAddress) {
+    warcHeaders["WARC-IP-Address"] = reqresp.remoteIPAddress;
+  }
 
   if (reqresp.resourceType) {
     warcHeaders["WARC-Resource-Type"] = reqresp.resourceType;

--- a/src/util/reqresp.ts
+++ b/src/util/reqresp.ts
@@ -8,6 +8,7 @@ import { Protocol } from "puppeteer-core";
 import { postToGetUrl } from "warcio";
 import { HTML_TYPES } from "./constants.js";
 import { Dispatcher } from "undici";
+import { isIP } from "node:net";
 
 const CONTENT_LENGTH = "content-length";
 const CONTENT_RANGE = "content-range";
@@ -49,6 +50,10 @@ export class RequestResponseInfo {
   // response data
   status: number = 0;
   statusText?: string;
+
+  // Numeric address of the peer used for this retrieval. This is emitted as
+  // the standard WARC-IP-Address field when available.
+  remoteIPAddress?: string;
 
   errorText?: string;
 
@@ -101,6 +106,12 @@ export class RequestResponseInfo {
     this.statusText = statusText || getStatusText(this.status);
   }
 
+  setRemoteIPAddress(remoteIPAddress?: string) {
+    if (remoteIPAddress && isIP(remoteIPAddress)) {
+      this.remoteIPAddress = remoteIPAddress;
+    }
+  }
+
   fillFetchRequestPaused(params: Protocol.Fetch.RequestPausedEvent) {
     this.fillRequest(params.request, params.resourceType);
 
@@ -143,6 +154,8 @@ export class RequestResponseInfo {
     this.url = response.url.split("#")[0];
 
     this.setStatus(response.status, response.statusText);
+
+    this.setRemoteIPAddress(response.remoteIPAddress);
 
     if (response.protocol) {
       if (response.protocol === "http/1.0") {

--- a/src/util/undici-ip.ts
+++ b/src/util/undici-ip.ts
@@ -1,0 +1,67 @@
+import diagnosticsChannel from "node:diagnostics_channel";
+import { Dispatcher } from "undici";
+
+type RemoteAddressCallback = (remoteAddress?: string) => void;
+
+type RequestCreateMessage = {
+  request: object;
+};
+
+type SendHeadersMessage = {
+  request: object;
+  socket: {
+    remoteAddress?: string;
+  };
+};
+
+const requestTrackers = new WeakMap<object, RemoteAddressCallback>();
+const activeTrackers: RemoteAddressCallback[] = [];
+
+let initialized = false;
+
+function initDiagnostics() {
+  if (initialized) {
+    return;
+  }
+
+  initialized = true;
+
+  diagnosticsChannel.channel("undici:request:create").subscribe((message) => {
+    const { request } = message as RequestCreateMessage;
+    const tracker = activeTrackers[activeTrackers.length - 1];
+    if (tracker && request) {
+      requestTrackers.set(request, tracker);
+    }
+  });
+
+  diagnosticsChannel
+    .channel("undici:client:sendHeaders")
+    .subscribe((message) => {
+      const { request, socket } = message as SendHeadersMessage;
+      const tracker = requestTrackers.get(request);
+      if (tracker) {
+        tracker(socket.remoteAddress);
+      }
+    });
+}
+
+/**
+ * Associate each request dispatched through this wrapper with the exact
+ * socket on which Undici sends it. The request:create event is synchronous
+ * with dispatch; sendHeaders may occur later and supplies the actual socket.
+ */
+export function trackRemoteIPAddress(
+  dispatcher: Dispatcher,
+  onRemoteAddress: RemoteAddressCallback,
+) {
+  initDiagnostics();
+
+  return dispatcher.compose((dispatch) => (opts, handler) => {
+    activeTrackers.push(onRemoteAddress);
+    try {
+      return dispatch(opts, handler);
+    } finally {
+      activeTrackers.pop();
+    }
+  });
+}

--- a/tests/reqresp-ip.test.ts
+++ b/tests/reqresp-ip.test.ts
@@ -1,0 +1,32 @@
+import { Protocol } from "puppeteer-core";
+import { RequestResponseInfo } from "../src/util/reqresp.js";
+
+function response(remoteIPAddress?: string) {
+  return {
+    url: "https://example.com/",
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    mimeType: "text/html",
+    protocol: "h2",
+    remoteIPAddress,
+  } as Protocol.Network.Response;
+}
+
+test.each(["192.0.2.10", "2001:db8::10"])(
+  "stores a valid remote IP address: %s",
+  (remoteIPAddress) => {
+    const reqresp = new RequestResponseInfo("request-1");
+    reqresp.fillResponse(response(remoteIPAddress), "Document");
+    expect(reqresp.remoteIPAddress).toBe(remoteIPAddress);
+  },
+);
+
+test.each([undefined, "", "example.com", "192.0.2.999"])(
+  "does not store a missing or invalid remote IP address: %s",
+  (remoteIPAddress) => {
+    const reqresp = new RequestResponseInfo("request-1");
+    reqresp.fillResponse(response(remoteIPAddress), "Document");
+    expect(reqresp.remoteIPAddress).toBeUndefined();
+  },
+);

--- a/tests/undici-ip.test.ts
+++ b/tests/undici-ip.test.ts
@@ -1,0 +1,37 @@
+import { createServer } from "node:http";
+import { AddressInfo } from "node:net";
+import { Agent, request } from "undici";
+import { trackRemoteIPAddress } from "../src/util/undici-ip.js";
+
+test("associates an Undici request with its actual peer socket", async () => {
+  const server = createServer((_req, res) => {
+    res.end("ok");
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+
+  const { port } = server.address() as AddressInfo;
+  const agent = new Agent();
+  let remoteAddress: string | undefined;
+  const dispatcher = trackRemoteIPAddress(agent, (address) => {
+    remoteAddress = address;
+  });
+
+  try {
+    const resp = await request(`http://127.0.0.1:${port}/`, { dispatcher });
+    await resp.body.text();
+    expect(remoteAddress).toBe("127.0.0.1");
+  } finally {
+    await dispatcher.close();
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+});


### PR DESCRIPTION
## Summary

This PR adds the remote server IP address used during retrieval to applicable WARC network records using the standard `WARC-IP-Address` header.

The implementation records the IP address observed during the actual network connection. It does not perform a later DNS lookup, since a later lookup could return a different address and would therefore not reliably represent the connection used for the archived response.

## Motivation

For evidentiary and forensic web archiving, it is useful to retain not only the requested URL and HTTP exchange but also the numeric peer address contacted during the crawl.

This is especially relevant when:

- a hostname resolves to multiple IP addresses;
- DNS responses change over time;
- a CDN or load balancer is involved;
- the archived material must document the actual endpoint used during retrieval.

`WARC-IP-Address` is the appropriate WARC field for preserving this information.

## Implementation

The IP address is obtained from the retrieval path that performed the actual request:

- Browser requests use the `remoteIPAddress` value reported by the Chrome DevTools Protocol network response.
- Direct Node.js/Undici requests use the connected socket exposed through the documented `undici:client:sendHeaders` diagnostics event.

The captured address is associated with the corresponding WARC network records and written as:

```text
WARC-IP-Address: <numeric peer address>
```

The field is added to matching `response`, `request`, and `revisit` records
where the remote address can be determined reliably.

## Behaviour and limitations

- No additional or later DNS lookup is performed.
- Missing or invalid remote addresses are omitted.
- Cached and service-worker responses without a reliable network peer do not receive an invented value.
- Requests made through an HTTP or SOCKS proxy omit the field because the connected peer would normally be the proxy rather than the target server.
- Both IPv4 and IPv6 addresses are supported.
- Non-network WARC records are not modified.
- Existing crawl behaviour is unchanged when no reliable remote address is available.

## Tests

The automated tests included in this PR cover:

- storing valid IPv4 and IPv6 addresses reported by CDP;
- rejecting missing, malformed, or non-numeric addresses;
- associating an Undici request with the peer address of the socket that actually sends its headers.

The change was additionally exercised with a controlled local integration crawl covering browser requests, a direct fetch, and duplicate/revisit records. All expected network records contained the local peer address, while unrelated WARC records did not receive `WARC-IP-Address`.

Validation performed against the current `main` branch:

- `yarn tsc --noEmit`
- `yarn format`
- `yarn lint`
- `jest --runInBand tests/reqresp-ip.test.ts tests/undici-ip.test.ts`

## Compatibility

The change is additive. Existing WARC consumers that do not use `WARC-IP-Address` can ignore the header, while preservation and forensic workflows can use it to document the endpoint contacted during capture.

I'm not the best programmer and did the changes with help of Codex. But of course i would be happy to adjust the implementation or tests to match the project's preferred architecture and coding conventions.

Best regards form Bavaria!