### PR TITLE
Show the current page URL as a clickable link in the screencast view

### DIFF
--- a/html/screencast.html
+++ b/html/screencast.html
@@ -35,8 +35,11 @@
           case "init":
             if (resp.width && resp.height) {
               try {
-                self.document.styleSheets[0].rules[1].style.width = resp.width + "px";
-                self.document.styleSheets[0].rules[1].style.height = resp.height + "px";
+                const contentImgRule = Array.from(self.document.styleSheets[0].cssRules).find((rule) => rule.selectorText === "#content img");
+                if (contentImgRule) {
+                  contentImgRule.style.width = resp.width + "px";
+                  contentImgRule.style.height = resp.height + "px";
+                }
               } catch (e) {
                 console.log("Error adjusting stylesheet: ", e);
               }

--- a/html/screencast.html
+++ b/html/screencast.html
@@ -7,6 +7,13 @@
         flex-direction: row;
         flex-wrap: wrap;
       }
+      #currentUrl {
+        margin: 1rem 2rem 0;
+        font: 14px sans-serif;
+      }
+      #currentUrl a {
+        word-break: break-all;
+      }
       #content img {
         width: 640px;
         height: 480px;
@@ -37,6 +44,7 @@
             break;
 
           case "screencast":
+            setCurrentUrl(resp.url);
             img = createImage(resp.id);
             if (resp.data) {
               setImageData(img, resp.data);
@@ -52,6 +60,23 @@
       function setImageData(img, data) {
         //img.style.display = "";
         img.src = "data:image/png;base64," + data;
+      }
+
+      function setCurrentUrl(url) {
+        const elem = document.getElementById("currentUrl");
+        if (!elem) {
+          return;
+        }
+        elem.replaceChildren();
+        if (!url) {
+          return;
+        }
+        const link = document.createElement("a");
+        link.href = url;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        link.textContent = url;
+        elem.appendChild(link);
       }
 
       function createImage(id) {
@@ -83,6 +108,7 @@
     </script>
     <head>
       <body>
+        <div id="currentUrl"></div>
         <div id="content"></div>
       </body>
     </head>

--- a/tests/screencast.test.ts
+++ b/tests/screencast.test.ts
@@ -34,6 +34,30 @@ function connectAndReadFirstMessage(url: string) {
   });
 }
 
+function connectAndReadFirstScreencast(url: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new Promise<any>((resolve, reject) => {
+    const sock = new WebSocket(url);
+    const timer = setTimeout(() => {
+      sock.terminate();
+      reject(new Error("timed out waiting for screencast frame"));
+    }, 10000);
+    sock.on("message", (data) => {
+      const parsed = JSON.parse(data.toString());
+      if (parsed.msg !== "screencast" || !parsed.url) {
+        return;
+      }
+      clearTimeout(timer);
+      sock.close();
+      resolve(parsed);
+    });
+    sock.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
 test("screencast server sends init message to websocket client during crawl", async () => {
   containerId = child_process
     .execSync(
@@ -66,4 +90,9 @@ test("screencast server sends init message to websocket client during crawl", as
   expect(firstMessage.browsers).toBe(1);
   expect(firstMessage.width).toBeGreaterThan(0);
   expect(firstMessage.height).toBeGreaterThan(0);
+
+  const screencastMessage = await connectAndReadFirstScreencast(
+    "ws://localhost:39037/ws",
+  );
+  expect(screencastMessage.url).toContain("example-com.webrecorder.net");
 }, 120000);


### PR DESCRIPTION
The screencast transport already sends the URL with each screencast image. This change only updates the static screencast HTML to render the URL as a link above the images, providing convenient additional information while watching a screencast session.