### PR TITLE
argParser: remove startEarly

### DIFF
--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -904,7 +904,6 @@ class ArgParser {
         }
       });
       behaviorOpts.log = BxFunctionBindings.BehaviorLogFunc;
-      behaviorOpts.startEarly = true;
       behaviorOpts.clickSelector = argv.clickSelector;
       argv.behaviorOpts = JSON.stringify(behaviorOpts);
     } else {


### PR DESCRIPTION
This is an alternative to #1140. We're instead planning on doing https://github.com/webrecorder/browsertrix-behaviors/pull/168, which removes the flag and switches the relevant behaviour to always-on or always-off as appropriate in the two behaviours that use it.

Closes #1140.