### PR TITLE
browser: add configurable --browserStartTimeout

### DIFF
--- a/docs/docs/user-guide/cli-options.md
+++ b/docs/docs/user-guide/cli-options.md
@@ -174,6 +174,11 @@ Options:
       --profile, --loadProfile              Path or HTTP(S) URL to tar.gz file w
                                             hich contains the browser profile di
                                             rectory                     [string]
+      --browserStartTimeout                 Timeout (in seconds) for the browser
+                                             process to start and connect. Raise
+                                             this on hosts under high load where
+                                            browser startup is slow.
+                                                          [number] [default: 30]
       --saveProfile                         If set, save profile if crawl succee
                                             ded successfully. If no value provid
                                             ed, save back to save location as sp
@@ -419,6 +424,10 @@ Options:
                             e browser profile directory   [string] [default: ""]
   --windowSize              Browser window dimensions, specified as: width,heigh
                             t                    [string] [default: "1360,1020"]
+  --browserStartTimeout     Timeout (in seconds) for the browser process to star
+                            t and connect. Raise this on hosts under high load w
+                            here browser startup is slow.
+                                                          [number] [default: 30]
   --cookieDays              If >0, set all cookies, including session cookies, t
                             o have this duration in days before saving profile
                                                            [number] [default: 7]

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -2030,6 +2030,7 @@ self.__bx_behaviors.selectMainBehavior();
       headless: this.params.headless,
       emulateDevice: this.emulateDevice,
       swOpt: this.params.serviceWorker,
+      browserStartTimeout: this.params.browserStartTimeout,
       chromeOptions: {
         proxyServer: this.proxyServer,
         proxyPacUrl: this.proxyPacUrl,

--- a/src/create-login-profile.ts
+++ b/src/create-login-profile.ts
@@ -15,7 +15,11 @@ import { Browser } from "./util/browser.js";
 import { initStorage } from "./util/storage.js";
 import { CDPSession, Page, PuppeteerLifeCycleEvent } from "puppeteer-core";
 import { getInfoString } from "./util/file_reader.js";
-import { DISPLAY, ExitCodes } from "./util/constants.js";
+import {
+  DISPLAY,
+  ExitCodes,
+  BROWSER_STARTUP_TIMEOUT_SECS,
+} from "./util/constants.js";
 import { initProxy, loadProxyConfig } from "./util/proxy.js";
 import { sleep } from "./util/timing.js";
 
@@ -117,6 +121,13 @@ function initArgs() {
         default: getDefaultWindowSize(),
       },
 
+      browserStartTimeout: {
+        describe:
+          "Timeout (in seconds) for the browser process to start and connect. Raise this on hosts under high load where browser startup is slow.",
+        type: "number",
+        default: BROWSER_STARTUP_TIMEOUT_SECS,
+      },
+
       cookieDays: {
         describe:
           "If >0, set all cookies, including session cookies, to have this duration in days before saving profile",
@@ -208,6 +219,7 @@ async function main() {
     profileUrl: params.profile,
     headless: params.headless,
     signals: false,
+    browserStartTimeout: params.browserStartTimeout,
     chromeOptions: {
       proxyServer,
       proxyPacUrl,

--- a/src/util/argParser.ts
+++ b/src/util/argParser.ts
@@ -24,6 +24,7 @@ import {
   RateLimitRule,
   DEFAULT_MAX_RATE_LIMIT_RETRIES,
   ExitCodes,
+  BROWSER_STARTUP_TIMEOUT_SECS,
 } from "./constants.js";
 import { interpolateFilename } from "./storage.js";
 import { screenshotTypes } from "./screenshots.js";
@@ -422,6 +423,13 @@ class ArgParser {
           describe:
             "Path or HTTP(S) URL to tar.gz file which contains the browser profile directory",
           type: "string",
+        },
+
+        browserStartTimeout: {
+          describe:
+            "Timeout (in seconds) for the browser process to start and connect. Raise this on hosts under high load where browser startup is slow.",
+          default: BROWSER_STARTUP_TIMEOUT_SECS,
+          type: "number",
         },
 
         saveProfile: {
@@ -987,6 +995,18 @@ class ArgParser {
 
     if (argv.diskUtilization < 0 || argv.diskUtilization > 99) {
       argv.diskUtilization = 90;
+    }
+
+    if (!(argv.browserStartTimeout > 0)) {
+      logger.warn(
+        "Invalid --browserStartTimeout, using default",
+        {
+          value: argv.browserStartTimeout,
+          default: BROWSER_STARTUP_TIMEOUT_SECS,
+        },
+        "general",
+      );
+      argv.browserStartTimeout = BROWSER_STARTUP_TIMEOUT_SECS;
     }
 
     if (argv.saveStorage) {

--- a/src/util/browser.ts
+++ b/src/util/browser.ts
@@ -16,6 +16,7 @@ import { initStorage, S3StorageSync, UploadResult } from "./storage.js";
 import {
   DISPLAY,
   PAGE_OP_TIMEOUT_SECS,
+  BROWSER_STARTUP_TIMEOUT_SECS,
   type ServiceWorkerOpt,
 } from "./constants.js";
 
@@ -29,6 +30,7 @@ import puppeteer, {
   CDPSession,
   Target,
   Browser as PptrBrowser,
+  TimeoutError,
 } from "puppeteer-core";
 import { Recorder } from "./recorder.js";
 import { timedRun } from "./timing.js";
@@ -53,6 +55,9 @@ type LaunchOpts = {
   ondisconnect?: ((err: unknown) => NonNullable<unknown>) | null;
 
   swOpt?: ServiceWorkerOpt;
+
+  // timeout (in seconds) for browser process startup / devtools connection
+  browserStartTimeout?: number;
 
   recording: boolean;
 };
@@ -110,6 +115,7 @@ export class Browser {
     emulateDevice = {},
     swOpt = "disabled",
     ondisconnect = null,
+    browserStartTimeout,
     recording = true,
   }: LaunchOpts) {
     if (this.isLaunched()) {
@@ -140,6 +146,9 @@ export class Browser {
       height: this.screenHeight - (recording ? 0 : BROWSER_HEIGHT_OFFSET),
     };
 
+    const startTimeoutSecs =
+      browserStartTimeout ?? BROWSER_STARTUP_TIMEOUT_SECS;
+
     const launchOpts: LaunchOptions = {
       args,
       headless,
@@ -150,6 +159,9 @@ export class Browser {
       handleSIGINT: signals,
       handleSIGTERM: signals,
       protocolTimeout: 0,
+      // puppeteer's own default here is 30000ms, which is too short on hosts
+      // under high load where the browser process is slow to start
+      timeout: startTimeoutSecs * 1000,
 
       defaultViewport,
       waitForInitialPage: false,
@@ -158,7 +170,7 @@ export class Browser {
         ? undefined
         : (target) => this.targetFilter(target),
     };
-    await this._init(launchOpts, recording, ondisconnect);
+    await this._init(launchOpts, recording, ondisconnect, startTimeoutSecs);
   }
 
   targetFilter(target: Target) {
@@ -524,8 +536,21 @@ export class Browser {
     recording: boolean,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     ondisconnect: Function | null = null,
+    startTimeoutSecs = BROWSER_STARTUP_TIMEOUT_SECS,
   ) {
-    this.browser = await puppeteer.launch(launchOpts);
+    try {
+      this.browser = await puppeteer.launch(launchOpts);
+    } catch (e) {
+      if (e instanceof TimeoutError || (e as Error).name === "TimeoutError") {
+        await logger.fatal(
+          "Browser did not start within the configured startup timeout. " +
+            "On hosts under high load, raise --browserStartTimeout.",
+          { startTimeoutSecs, ...formatErr(e) },
+          "browser",
+        );
+      }
+      throw e;
+    }
 
     const target = this.browser.target();
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -48,6 +48,11 @@ export const FETCH_HEADERS_TIMEOUT_SECS = 30;
 export const PAGE_OP_TIMEOUT_SECS = 5;
 export const SITEMAP_INITIAL_FETCH_TIMEOUT_SECS = 30;
 
+// time to wait (in seconds) for the browser process to start and the
+// devtools connection to be established before puppeteer.launch() times out.
+// can be raised via --browserStartTimeout on hosts where browser startup is slow.
+export const BROWSER_STARTUP_TIMEOUT_SECS = 30;
+
 export const ROBOTS_CACHE_LIMIT = 100;
 
 // max JS dialogs (alert/prompt) to allow per page

--- a/tests/browser-start-timeout.test.ts
+++ b/tests/browser-start-timeout.test.ts
@@ -1,0 +1,38 @@
+import { execSync } from "child_process";
+import { ErrorWithStatus } from "./utils";
+
+// exit code used by logger.fatal() when not restarting on error
+const FATAL = 17;
+
+function runCrawl(extraArgs: string): { status: number; output: string } {
+  let status = 0;
+  let output = "";
+  try {
+    output = execSync(
+      `docker run --rm webrecorder/browsertrix-crawler crawl --url https://webrecorder.net/ --limit 1 ${extraArgs}`,
+      { encoding: "utf-8", stdio: "pipe" },
+    );
+  } catch (e) {
+    status = (e as ErrorWithStatus).status;
+    const err = e as ErrorWithStatus & { stdout?: Buffer; stderr?: Buffer };
+    output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+  }
+  return { status, output };
+}
+
+test("crawl succeeds with a raised --browserStartTimeout", () => {
+  const { status } = runCrawl("--browserStartTimeout 120");
+  expect(status).toBe(0);
+});
+
+test("invalid --browserStartTimeout falls back to the default, crawl still runs", () => {
+  const { status } = runCrawl("--browserStartTimeout 0");
+  expect(status).toBe(0);
+});
+
+test("crawl fails with an actionable message when browser startup times out", () => {
+  // 0.001s -> 1ms, browser cannot start that fast, must hit the timeout
+  const { status, output } = runCrawl("--browserStartTimeout 0.001");
+  expect(status).toBe(FATAL);
+  expect(output).toContain("--browserStartTimeout");
+});


### PR DESCRIPTION
puppeteer.launch() used its hardcoded 30s default for browser startup, too short on loaded VMs where
  the launch fails with a TimeoutError and aborts the crawl. Adds --browserStartTimeout (seconds, default
  30) for crawl and create-login-profile, plus an actionable fatal on launch timeout.